### PR TITLE
docs: 完善 README 并为四个子目录新增详细使用说明

### DIFF
--- a/Clash Meta For Android/使用方法.md
+++ b/Clash Meta For Android/使用方法.md
@@ -1,0 +1,172 @@
+# Clash Meta For Android（CMFA）使用方法
+
+> 配置文件：`clash-smart-cmfa.yaml`
+> 适用客户端：**Clash Meta For Android（CMFA）** / **FlClash** / **mihomo-party-android**
+> 内核要求：**Mihomo Smart**（已内置 LightGBM 自学习模型）
+> 当前版本：**v5.2.0**（基于 `clash-smart-v5.2.0.js` 转换）
+
+---
+
+## 一、下载 CMFA 客户端
+
+1. 开源地址：https://github.com/MetaCubeX/ClashMetaForAndroid/releases
+2. 根据手机 CPU 选择合适的 APK：
+   - **arm64-v8a**：绝大多数 2017 年后的手机
+   - **armeabi-v7a**：少数老机型
+   - **universal**：不确定时的通用包
+3. 安装后授权「VPN 权限」与「文件读写权限」。
+
+---
+
+## 二、修改订阅链接
+
+打开 `clash-smart-cmfa.yaml`，找到 `proxy-providers` 段落（约第 137 行）：
+
+```yaml
+proxy-providers:
+  Subscribe:
+    type: http
+    url: 'https://my.example.com/your-subscription-url'   # ← 替换为你的机场订阅链接
+    interval: 86400
+    path: ./proxy_providers/subscribe.yaml
+    health-check:
+      enable: true
+      url: 'https://www.gstatic.com/generate_204'
+      interval: 300
+    exclude-filter: '(?i)(导航网址|距离下次重置|剩余流量|套餐到期|网址导航|官网|订阅|到期|剩余|重置|10x|20x|100x)'
+```
+
+**注意事项**：
+- 订阅链接建议选择 `?flag=meta` 或 `?flag=clash.meta` 风格，返回 **Mihomo 兼容格式**的节点。
+- `exclude-filter` 已内置过滤广告节点与高倍率节点，无需改动。
+- 若你使用 **Sub-Store** 做多机场融合，可直接粘贴 Sub-Store 生成的单一 URL。
+
+---
+
+## 三、导入配置到 CMFA
+
+### 方法 A：本地文件导入（推荐首次使用）
+
+1. 将修改后的 `clash-smart-cmfa.yaml` 复制到手机存储（例如 `Download/` 目录）。
+2. 打开 CMFA → **配置（Profiles）** → 右下角 ➕ → **从文件导入**。
+3. 选择刚才的 YAML → 命名为 `Clash Smart` → 确定。
+
+### 方法 B：URL 远程托管（推荐长期使用）
+
+1. 将 YAML 托管到 GitHub Raw / Gist / 自建 HTTP 服务。
+2. CMFA → **配置** → ➕ → **从 URL 导入** → 粘贴 URL → 确定。
+3. 后续自动轮询更新（默认每 24 小时，可在配置设置里调整）。
+
+---
+
+## 四、首次启动
+
+1. 在 CMFA 首页选择刚导入的配置，点击「**启动**」按钮。
+2. 首次启动 CMFA 会自动完成以下动作（需保持网络畅通）：
+   - 下载机场节点列表（`subscribe.yaml`）
+   - 下载 **375+ rule-providers**（`blackmatrix7 / MetaCubeX` 等规则集）
+   - 下载 **Loyalsoldier 增强版** `geoip.dat` / `Country.mmdb` / `GeoLite2-ASN.mmdb`
+   - 下载 **MetaCubeX** `geosite.dat`
+   - 下载 **LightGBM 模型** `Model.bin`（用于 Smart 组自动择优）
+3. 初始化时间：视网络情况约 **1–3 分钟**；完成后规则集会缓存到本地。
+
+> ⚠️ 首次启动建议在 **WiFi 环境**并开启 VPN 后进行，避免因某些 rule-provider 需代理下载而失败。
+
+---
+
+## 五、代理组说明
+
+本配置共 **9 个区域组 + 28 个业务组**，进入 CMFA「**代理（Proxies）**」页面可见：
+
+### 区域组（自动择优）
+
+以下 9 个 `url-test` 组会按节点名称自动聚合，**无需手动维护**：
+
+- 🌍 全球节点、🇭🇰 香港节点、🇹🇼 台湾节点、🇯🇵 日韩节点
+- 🌏 亚太节点、🇺🇸 美国节点、🇪🇺 欧洲节点、🌎 美洲节点、🌍 非洲节点
+
+### 业务组（手动选择）
+
+28 个 `select` 业务组，每组默认候选包含所有区域组 + `DIRECT`，首次使用需为每个业务组**手动指定一个首选区域**：
+
+| 业务组 | 推荐区域 |
+|--------|----------|
+| 🤖 AI 服务（ChatGPT/Claude/Gemini） | 🇺🇸 美国节点（避开 HK/CN 地区） |
+| 💰 加密货币 | 🇭🇰 香港节点 |
+| 📺 国内流媒体（B 站/爱奇艺/腾讯） | DIRECT（境内）或 🇭🇰 香港节点（境外） |
+| 🇺🇸 美国流媒体（Netflix US / HBO） | 🇺🇸 美国节点 |
+| 🇭🇰 香港流媒体（Now E / MyTV） | 🇭🇰 香港节点 |
+| 🇹🇼 台湾流媒体（LiTV / 巴哈姆特） | 🇹🇼 台湾节点 |
+| 📺 东南亚流媒体（爱奇艺 SEA / WeTV） | 🌏 亚太节点 |
+| 💬 即时通讯（Telegram/Discord） | 🇭🇰 香港节点 或 🇯🇵 日韩节点 |
+| 📱 社交媒体（X/Twitter/Instagram） | 🇯🇵 日韩节点 |
+| 🧑‍💼 会议协作（Zoom/Teams） | 🇯🇵 日韩节点（低延迟） |
+| 🚫 受限网站（GFW） | 境内选代理，境外选 DIRECT |
+| … | … |
+
+---
+
+## 六、常用高级设置
+
+### 1. 启用 TUN 模式（系统级代理）
+
+- CMFA → **设置** → **网络** → 打开 **TUN 模式**。
+- 配合配置中的 `stack: mixed` 可兼容绝大多数 App（包括 UDP / QUIC）。
+
+### 2. 启用 Meta SideBar（仪表盘）
+
+- CMFA → **设置** → **界面** → 开启「**显示流量图表 / 仪表盘**」，可实时查看 LightGBM 模型择优效果。
+
+### 3. 应用分应用代理（可选）
+
+- CMFA → **设置** → **应用过滤** → 选择模式：
+  - **黑名单**：列表内 App 不走代理（推荐国内银行/支付 App 加入）
+  - **白名单**：仅列表内 App 走代理
+
+### 4. 开启后台保活
+
+- 系统「**电池优化**」中将 CMFA 设为「**不优化**」。
+- MIUI / ColorOS / HarmonyOS 需额外在「自启动」与「后台弹出」权限中允许 CMFA。
+
+---
+
+## 七、常见问题
+
+### Q1：导入后提示 `list geosite not found` 或规则解析错误？
+A：本配置已将所有 `GEOSITE` 高级标签替换为等效 `RULE-SET`，理论上不会出现该错误。若仍出现，请检查：
+- 是否使用的是 **Mihomo Smart 内核**（而非旧版 ClashX / Clash Premium）。
+- CMFA 版本是否 ≥ **2.11.x**。
+
+### Q2：节点名称没有被正确分到区域组？
+A：脚本按「中文关键字 + 城市 + IATA 机场代码 + ISO 国家代码」综合匹配，覆盖率 > 95%。若仍漏判，请将节点名贴到 Issue 中反馈。
+
+### Q3：LightGBM 自动择优未生效？
+A：确认：
+- `proxy-groups` 中 `uselightgbm: true` 存在；
+- 已下载 `Model.bin`（首次启动日志会显示下载进度）；
+- CMFA 使用的是 **Smart 内核**而非普通 Meta 内核。
+
+### Q4：fake-ip 模式下银行/支付 App 异常？
+A：已通过 `sniffer.skip-domain` 排除主要支付域名（支付宝/微信/币安等）。若你使用的银行域名未在名单中，可在 `fake-ip-filter` 追加对应域名。
+
+---
+
+## 八、配置关键字段速查
+
+| 字段 | 位置 | 说明 |
+|------|------|------|
+| `mixed-port: 7890` | 顶部 | HTTP / SOCKS 混合端口 |
+| `mode: rule` | 顶部 | 规则模式（勿改 global/direct） |
+| `find-process-mode: strict` | 顶部 | Android 14+ 可识别进程 |
+| `dns.enhanced-mode: fake-ip` | `dns` | fake-ip 模式（性能最佳） |
+| `sniffer.enable: true` | `sniffer` | 启用 SNI 嗅探 |
+| `geodata-mode: false` | 顶部 | 使用 `.mrs` 二进制格式（体积更小） |
+
+---
+
+## 九、参考与致谢
+
+- 上游内核：[MetaCubeX/mihomo](https://github.com/MetaCubeX/mihomo)
+- LightGBM 模型：[vernesong/mihomo](https://github.com/vernesong/mihomo)
+- 规则集：[blackmatrix7/ios_rule_script](https://github.com/blackmatrix7/ios_rule_script) · [MetaCubeX/meta-rules-dat](https://github.com/MetaCubeX/meta-rules-dat)
+- GeoIP：[Loyalsoldier/geoip](https://github.com/Loyalsoldier/geoip)

--- a/Clash Party/使用方法.md
+++ b/Clash Party/使用方法.md
@@ -1,0 +1,211 @@
+# Clash Party / Clash Verge / Mihomo Party 使用方法
+
+> 覆写脚本：`Clash Smart内核覆写脚本.js`（**v5.2.2**，2026-04-13）
+> UI 补充配置：`其他配置在UI里面填写`
+> 架构：**SUB-STORE 多机场融合** + 9 Smart 区域组 + 28 业务策略组 + **373+ rule-providers**
+> 适用客户端：
+> - **Mihomo Party**（桌面端，推荐，原生支持 JS 覆写）
+> - **Clash Verge Rev**（桌面端，支持 JS/YAML 双覆写）
+> - **Clash Nyanpasu**（桌面端）
+> - 任何支持 Mihomo **JavaScript 覆写引擎**的客户端
+
+---
+
+## 一、安装客户端
+
+### Mihomo Party（推荐）
+- 开源地址：https://github.com/mihomo-party-org/mihomo-party/releases
+- 支持 Windows / macOS (Intel + Apple Silicon) / Linux (deb/rpm/AppImage)
+- 特性：**内置 Smart 内核**，默认开启 TUN，UI 中直接支持 JS 覆写。
+
+### Clash Verge Rev
+- 开源地址：https://github.com/clash-verge-rev/clash-verge-rev/releases
+- 需要在「设置 → Clash 内核」中切换到 **Mihomo Alpha**（Smart 内核当前仍在 Alpha 分支）。
+
+---
+
+## 二、准备订阅
+
+### 场景 A：单机场订阅
+直接在客户端「订阅（Subscriptions / Profiles）」中添加机场链接即可，脚本会自动识别并分类节点。
+
+### 场景 B：多机场融合（推荐，脚本原生针对此优化）
+本脚本**针对 Sub-Store 环境做了大量优化**，强烈建议搭配使用：
+
+1. 自建或使用公共 **Sub-Store**（https://github.com/sub-store-org/Sub-Store）。
+2. 在 Sub-Store 中添加 2–N 个机场作为「单条订阅」。
+3. 新建一个「**组合订阅**」或「**远程订阅**」，聚合所有机场。
+4. 生成一个 **Clash (Mihomo)** 格式的订阅 URL。
+5. 将该 URL 粘贴到客户端的订阅中。
+
+脚本会自动为所有节点：
+- 剔除信息类节点（导航/流量/到期/官网…）
+- 剔除高倍率节点（10x/20x/100x）
+- 按地区/城市/IATA 代码/ISO 代码**多维度分类**到 9 个区域组
+
+---
+
+## 三、导入覆写脚本（核心步骤）
+
+### Mihomo Party
+
+1. 左侧菜单 → **覆写（Override）** → 右上角 ➕。
+2. 类型选择 **JavaScript（.js）**。
+3. 名称：`Clash Smart v5.2.2`。
+4. 内容：复制 `Clash Party/Clash Smart内核覆写脚本.js` 的**全部 2246 行**粘贴进去。
+5. 保存。
+6. 返回「订阅」页面，右键你的订阅 → **编辑** → **启用覆写** → 勾选刚才的脚本 → 保存。
+7. 切换到该订阅，点击「**连接**」。
+
+### Clash Verge Rev
+
+1. 左侧 → **脚本（Scripts）** → ➕ **新建脚本** → **本地脚本**。
+2. 粘贴 `.js` 全部内容，保存。
+3. **订阅（Profiles）** → 右上角 ⋯ → **扩展管理（Extensions）** → 勾选刚才的脚本。
+4. 重启内核（Ctrl/Cmd + R）。
+
+---
+
+## 四、粘贴 UI 补充配置
+
+脚本主要处理 **proxies / proxy-groups / rules** 三大块，但不覆盖 **DNS / Sniffer / GeoX URL**（这些字段若写入 JS 会被机场订阅覆盖）。因此需要把 `其他配置在UI里面填写` 中的内容粘贴到客户端的 **Mixin / 覆盖字段**：
+
+### Mihomo Party
+- **设置 → 覆写配置（Mixin）** → 粘贴 `其他配置在UI里面填写` 全部内容 → 保存。
+
+### Clash Verge Rev
+- **设置 → Clash 设置 → 内核 Mixin** 或「**Merge 文件**」中粘贴。
+
+### 补充内容包括：
+```yaml
+geox-url:                                         # 四份增强数据库
+  geoip:   https://.../geoip.dat
+  mmdb:    https://.../Country.mmdb
+  asn:     https://.../GeoLite2-ASN.mmdb
+  geosite: https://.../geosite.dat
+geo-auto-update: true
+
+dns:                                              # 三层 DNS 架构
+  default-nameserver:  [223.5.5.5, 119.29.29.29, 1.1.1.1, 8.8.8.8]
+  nameserver:          [https://223.5.5.5/dns-query, ...]
+  proxy-server-nameserver: [...]
+  direct-nameserver:   [...]
+  fallback:            [...]
+  fallback-filter: { geoip: true, geoip-code: CN, ... }
+
+sniffer:                                          # HTTP / TLS / QUIC 嗅探
+  enable: true
+  parse-pure-ip: true
+  force-dns-mapping: true
+  override-destination: true
+  sniff: { HTTP: {...}, TLS: {...}, QUIC: {...} }
+```
+
+---
+
+## 五、验证配置生效
+
+连接成功后按以下步骤验证：
+
+1. **代理组（Proxies）页面**
+   - 应看到 **9 个区域 Smart 组**（全球/香港/台湾/日韩/亚太/美国/欧洲/美洲/非洲）；
+   - 每个区域组下方有对应地区的所有节点；
+   - **28 个业务策略组**（AI 服务、加密货币、Netflix、Disney+、YouTube、Telegram 等）可正常选择。
+
+2. **连接（Connections）页面**
+   - 访问 `https://chat.openai.com`：Rule 应命中「🤖 AI 服务 → 🇺🇸 美国节点 → 某个 US 节点」；
+   - 访问 `https://www.netflix.com`：Rule 应命中「Netflix → 🇺🇸 美国流媒体」；
+   - 访问 `https://www.bilibili.com`：应命中「📺 国内流媒体 / DIRECT」。
+
+3. **规则（Rules）页面**
+   - 总规则数应 ≥ **963 条**；
+   - `rule-providers` 数量 ≥ **373**。
+
+4. **日志（Logs）页面**
+   - 无 `parse error` / `list not found`；
+   - 无大量 `DNS resolve failed`（若出现请检查 DNS 段粘贴）。
+
+---
+
+## 六、版本亮点（v5.2.2，2026-04-13）
+
+- **FIX#17-P0**：`jsdelivr CDN` 永久直连
+  - `RP_PROXY` 从「云与CDN」改为「受限网站（GFW）」组
+  - 解决 04-06 单日 **4,931 条** jsdelivr 失败的 DNS 循环依赖问题
+  - 在印尼选 `DIRECT`，在中国选代理，灵活切换
+- **FIX#18-P1**：删除已死的 `ckrvxr` 规则源
+  - 移除 AntiPCDN / AntiAntiFraud（累计 221 次 404）
+- **FIX#19-P1**：`DST-PORT,7680,REJECT` 顺序修复
+  - 提前到 `GEOIP,private` 之前，确保 Windows Delivery Optimization 流量被正确拦截
+- **FIX#20-P2**：PI.ai 移入「🚫 受限网站（GFW）」组
+- **FIX#20-P2**：`GSCService.exe` 加入 TUN `exclude-process`（避免 fake-ip 下 `ip.cip.cc` DNS 解析失败）
+- **NOTE#2**：`BBC.yaml / Snap.yaml` 的 `USER-AGENT` warning 为无害提示，已由 `metaDomain('tiktok')` 独立覆盖
+
+---
+
+## 七、业务组推荐配置
+
+建议首次导入后，按以下方式为每个业务组「指定首选」：
+
+| 业务组 | 推荐上游 |
+|--------|----------|
+| 🤖 AI 服务 | 🇺🇸 美国节点（必须避开 HK / CN） |
+| 💰 加密货币 | 🇭🇰 香港节点（币安合规） |
+| 🏦 金融支付 | DIRECT |
+| 📧 邮件服务 | 🇯🇵 日韩节点（Gmail 响应更快） |
+| 💬 即时通讯 | 🇭🇰 香港 / 🇯🇵 日韩 |
+| 📱 社交媒体 | 🇯🇵 日韩节点 |
+| 🧑‍💼 会议协作 | 🇯🇵 日韩节点（延迟低） |
+| 📺 国内流媒体 | DIRECT（境内）/ 🇭🇰 香港（境外） |
+| 🇺🇸 美国流媒体 | 🇺🇸 美国节点 |
+| 🇭🇰 香港流媒体 | 🇭🇰 香港节点 |
+| 🇹🇼 台湾流媒体 | 🇹🇼 台湾节点 |
+| 🎮 游戏平台 | 🇯🇵 日韩节点（Steam/PSN） |
+| ☁️ 云与 CDN | 🌍 全球节点 |
+| 🚫 受限网站（GFW） | 中国选代理 / 海外选 DIRECT |
+
+---
+
+## 八、常见问题
+
+### Q1：启用脚本后节点为空 / 区域组为空？
+- 确认订阅返回的是 **Mihomo / Clash.Meta** 格式（不是 Surge / Quantumult）。
+- 确认机场节点名带有地区关键字（香港/HK/🇭🇰/hkg 至少其一）。
+- 打开日志，查看是否有 `No node classified` 提示。
+
+### Q2：首次连接特别慢？
+- 首次需下载 **373+ rule-providers**，约 15–30 MB；
+- 建议在 WiFi 环境下完成首次下载。
+
+### Q3：如何升级到新版本？
+- 将仓库里的 `.js` 文件更新，客户端会在下次刷新订阅时重新执行；
+- 无需删除旧订阅或重新导入。
+
+### Q4：能否同时启用多个覆写脚本？
+- **不建议**。本脚本会完整重写 `proxy-groups` 与 `rules`，与其他脚本叠加可能导致冲突。
+
+### Q5：LightGBM 模型未下载？
+- 检查 `lgbm-custom-url` 字段是否被篡改；
+- 确认客户端可访问 GitHub Release（可能需要代理）：
+  ```
+  https://github.com/vernesong/mihomo/releases/download/LightGBM-Model/Model.bin
+  ```
+
+---
+
+## 九、目录一览
+
+| 文件 | 用途 |
+|------|------|
+| `Clash Smart内核覆写脚本.js` | 主覆写脚本，粘贴到客户端 JS 覆写区 |
+| `其他配置在UI里面填写` | DNS / Sniffer / GeoX URL，粘贴到客户端 Mixin 区 |
+
+---
+
+## 十、致谢
+
+- [MetaCubeX/mihomo](https://github.com/MetaCubeX/mihomo) - Smart 内核
+- [mihomo-party-org/mihomo-party](https://github.com/mihomo-party-org/mihomo-party) - 桌面客户端
+- [clash-verge-rev](https://github.com/clash-verge-rev/clash-verge-rev) - 桌面客户端
+- [sub-store-org/Sub-Store](https://github.com/sub-store-org/Sub-Store) - 多机场融合工具
+- 所有上游规则集维护者（bm7 / MetaCubeX / Loyalsoldier / blackmatrix7 等）

--- a/OpenClash/使用方法.md
+++ b/OpenClash/使用方法.md
@@ -1,3 +1,249 @@
+# OpenClash 使用方法
+
+> 覆写脚本：`openclash_custom_overwrite.sh`（**v5.3.2-dns-rescue-no-rules**）
+> 界面配置：`clash-smart-openclash.conf`
+> 架构：基于 v5.2.4-oc，针对 **NanoPi R4S 4GB** 等中端路由器做了 OOM 内存优化
+> 目标内存占用：启动 RSS 从 ~3.5 GB 降至 **~1.8–2.3 GB**（省出 1.2–1.7 GB）
+
+---
+
+## 一、前置准备
+
+### 1. 硬件要求
+
+| 设备 | 内存 | 推荐等级 |
+|------|------|----------|
+| NanoPi R4S 4GB | 4 GB | ✅ 官方优化目标 |
+| NanoPi R5S / R6S | 4–8 GB | ✅ 推荐 |
+| 小米 AX 系列（刷 OpenWrt） | 256 MB–1 GB | ⚠️ 需进一步精简 `rule-providers` |
+| x86 软路由 | ≥ 2 GB | ✅ 推荐 |
+
+### 2. 软件要求
+
+- **OpenWrt** 21.02+ / **iStoreOS** / **ImmortalWrt**
+- **OpenClash** 版本 **≥ 0.46.068**（低版本缺少 Smart 内核支持）
+- **Mihomo Smart 内核**（在 OpenClash「版本更新」页切换）
+- **LuCI Web UI** 可访问
+
+---
+
+## 二、安装 OpenClash 与 Smart 内核
+
+### 1. 安装 OpenClash
+
+参考官方 Wiki：https://github.com/vernesong/OpenClash/wiki
+
+常用一键脚本（以 ARMv8 / iStoreOS 为例）：
+```sh
+opkg update
+opkg install luci-app-openclash
+/etc/init.d/openclash enable
+/etc/init.d/openclash start
+```
+
+### 2. 切换到 Smart 内核
+
+- LuCI → **服务 → OpenClash → 版本更新**
+- 「Meta 内核版本」下拉选择 **Smart**（若无该选项，先升级 OpenClash 到最新）
+- 点击「**一键下载**」→ 等待下载完成
+- 重启 OpenClash
+
+### 3. 下载 LightGBM 模型
+
+Smart 内核依赖 LightGBM 做自动择优：
+```sh
+# 手动下载（OpenClash 会自动管理，通常无需手动操作）
+wget -O /etc/openclash/Model.bin \
+  https://github.com/vernesong/mihomo/releases/download/LightGBM-Model/Model.bin
+```
+本脚本已在 `clash-smart-openclash.conf` 中启用 `SMART_ENABLE_LGBM=1` + `LGBM_AUTO_UPDATE=1`，72 小时自动更新。
+
+---
+
+## 三、部署覆写脚本
+
+### 1. 上传 `openclash_custom_overwrite.sh` 到路由器
+
+SSH 登录路由器：
+```sh
+scp openclash_custom_overwrite.sh root@192.168.1.1:/etc/openclash/
+ssh root@192.168.1.1
+chmod +x /etc/openclash/openclash_custom_overwrite.sh
+```
+
+或直接使用 LuCI → **系统 → 文件传输** 上传到 `/etc/openclash/`。
+
+### 2. 在 OpenClash 中启用覆写
+
+LuCI → **服务 → OpenClash → 覆写设置（Overwrite Settings）**：
+
+1. 找到 **「自定义 OpenClash 脚本（Custom Overwrite Script）」**
+2. 选择：`/etc/openclash/openclash_custom_overwrite.sh`
+3. 勾选「**启用自定义覆写**」
+4. 保存并应用。
+
+---
+
+## 四、导入界面配置（`clash-smart-openclash.conf`）
+
+此文件的每一项都对应 LuCI **插件设置（Plugin Settings）**页的一个选项。
+
+### 方式 A：手动对照填写（推荐首次）
+
+打开 `clash-smart-openclash.conf`，按字段对照填入 OpenClash LuCI 对应位置。关键项：
+
+| 字段 | 值 | 位置 |
+|------|------|------|
+| `CORE_TYPE` | `Smart` | 版本更新 → 选择 Smart |
+| `EN_MODE` | `fake-ip` | 插件设置 → DNS 模式 |
+| `ENABLE_RESPECT_RULES` | `1` | 插件设置 → 开启 Respect Rules |
+| `CHINA_IP_ROUTE` | `0`（★ 关键） | 插件设置 → 绕过中国大陆 IP |
+| `ENABLE_META_SNIFFER` | `1` | 插件设置 → 启用 Meta 嗅探 |
+| `ENABLE_TCP_CONCURRENT` | `1` | 插件设置 → TCP 并发 |
+| `FIND_PROCESS_MODE` | `off`（★ 关键） | 插件设置 → 进程匹配 → 关闭 |
+| `AUTO_SMART_SWITCH` | `1` | 插件设置 → Smart 自动切换 |
+| `SMART_ENABLE_LGBM` | `1` | 插件设置 → 启用 LightGBM |
+| `GEODATA_LOADER` | `standard`（4GB） / `memconservative`（2GB） | 插件设置 → GeoData 加载器 |
+| `GEOIP_CUSTOM_URL` | `https://fastly.jsdelivr.net/gh/Loyalsoldier/geoip@release/geoip.dat` | 同上 |
+| `GEOSITE_CUSTOM_URL` | `https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat` | 同上 |
+| `GEOASN_CUSTOM_URL` | `https://fastly.jsdelivr.net/gh/Loyalsoldier/geoip@release/GeoLite2-ASN.mmdb` | 同上 |
+
+### 方式 B：直接写入 UCI 配置（高级）
+
+```sh
+# 示例：一次性写入关键字段
+uci set openclash.config.core_type='Smart'
+uci set openclash.config.en_mode='fake-ip'
+uci set openclash.config.china_ip_route='0'
+uci set openclash.config.find_process_mode='off'
+uci set openclash.config.enable_respect_rules='1'
+uci set openclash.config.geodata_loader='standard'
+uci set openclash.config.geosite_custom_url='https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat'
+uci commit openclash
+/etc/init.d/openclash restart
+```
+
+---
+
+## 五、截图参考
+
 <img width="1280" height="678" alt="image" src="https://github.com/user-attachments/assets/3f7f16a8-f01c-4f7d-ad17-338140088a9a" />
 <img width="1280" height="678" alt="image" src="https://github.com/user-attachments/assets/e03460ea-606c-4e1b-b45b-a76bc8158abf" />
 <img width="1280" height="678" alt="image" src="https://github.com/user-attachments/assets/3a204b9e-ccc8-4b1f-8ed9-3dd1c1e66e7b" />
+
+---
+
+## 六、添加订阅并启动
+
+1. LuCI → **服务 → OpenClash → 配置订阅** → 添加机场订阅链接。
+2. 点击「**下载**」拉取配置。
+3. 「**全局设置 → 选择配置文件**」选择刚下载的订阅。
+4. 点击**启动 OpenClash**。
+5. 查看日志：**运行日志（Run Log）** 页应能看到：
+   ```
+   [Clash-Smart] v5.3.2-dns-rescue-no-rules overwrite starting...
+   [Clash-Smart] Processing: /etc/openclash/config/xxx.yaml
+   [Clash-Smart] Memory-optimized build for NanoPi R4S 4GB
+   ```
+
+---
+
+## 七、内存优化要点
+
+**v5.3.x 对比 v5.2.4-oc** 做了以下精简：
+
+| 优化项 | 节省 | 代价 |
+|--------|------|------|
+| `geodata-loader: standard → memconservative` | ~400–600 MB | 首次规则命中延迟 +几 ms（路由器无感） |
+| `rule-providers` 387 → 136（砍 65%） | ~800–1,100 MB | 少数冷门域名回退到 `GEOIP,CN` 兜底 |
+
+### 精简策略
+- **Google 家族合并**：GoogleSearch/Drive/Earth/FCM/Voice → 统一 `google`
+- **Apple 家族合并**：AppleTV/News/Dev/Proxy/Siri/TestFlight/Firmware/FindMy → `apple` + `icloud`
+- **删除区域化通讯分片**：TelegramNL/SG/US、KakaoTalk、Zalo、GoogleVoice、iTalkBB
+- **删除低频冷门**：国内小众流媒体、欧洲/日本分区、非洲/南美 GeoRouting
+- **删除冗余广告拦截**：10+ 个功能重叠的 blackmatrix7 广告集
+
+### 保留不变
+- ✅ 9 个 Smart 区域组（全部 `uselightgbm: true + include-all-proxies: true`）
+- ✅ 动态节点分类（HK/TW/JP/KR/SG/US/EU/AM/AF/APAC_OTHER）
+- ✅ DNS 多层架构（`respect-rules` + DoH 冗余 + `default-nameserver` bootstrap）
+- ✅ Sniffer 配置（HTTP/TLS/QUIC + binance/apple skip）
+- ✅ TLS 指纹注入逻辑（vless/vmess/trojan 自动哈希分配）
+- ✅ 节点过滤（移除信息节点 + 倍率节点）
+- ✅ TCP 并发 / keep-alive / unified-delay
+
+---
+
+## 八、常见问题
+
+### Q1：日志出现 `list geosite not found` / parse error？
+**原因**：`CHINA_IP_ROUTE=1` 时 OpenClash Step3 会自动注入裸 `geosite` 引用，在 `geodata-mode: true` + `geodata-loader: standard` 下可能解析失败。
+**解决**：必须设置 `CHINA_IP_ROUTE=0`（已在 `clash-smart-openclash.conf` 中硬编码）。覆写脚本已有完整的中国分流规则：
+`GEOIP,CN` + `RULE-SET,cn` + `cn-ip` + `acc-chinamax` + `acc-china` + `acc-geositecn` + `acc-geo-d/ip-asia-china`。
+
+### Q2：`geosite.dat` 来源不对 / 更新失败？
+**解决**：已显式配置 `GEOSITE_CUSTOM_URL=https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@release/geosite.dat`，确保与覆写脚本一致。
+
+### Q3：进程匹配导致性能下降？
+**解决**：OpenWrt 路由器上不需要进程匹配（Linux 侧无法准确识别移动/桌面端应用进程），强制 `FIND_PROCESS_MODE=off`。
+
+### Q4：路由器内存不够触发 OOM / Docker 被 kill？
+按激进程度依次尝试：
+1. 将 `GEODATA_LOADER` 改为 `memconservative`
+2. 继续精简 `rule-providers`（砍东南亚 / 香港 / 台湾流媒体板块）
+3. 关闭单个不常用区域的 Smart 组（如非洲 / 美洲）
+4. 最后才动 `uselightgbm: false`（会牺牲自动择优）
+
+### Q5：DNS 冷启动失败 / jsdelivr 大量 DNS resolve failed？
+本版本已内置「DNS 救援模式」：
+- `hosts` 段直接写入 1.1.1.1 / 8.8.8.8 / 9.9.9.9 的 IP，确保 bootstrap DNS 不走规则环。
+- `nameserver-policy` 把 `jsdelivr / github / githubusercontent / githubassets / fastly.net` 强制走 Cloudflare/Google DoH。
+- `default-nameserver` 使用多家公共 DoT/DoH 冗余，避免单点故障。
+
+### Q6：国内银行/支付异常？
+`sniffer.skip-domain` 已包含 `+.binance.com / +.binancefuture.com / Mijia Cloud` 等；如仍有问题，可在 UCI 中追加对应域名到 skip 列表。
+
+---
+
+## 九、调试命令
+
+```sh
+# 查看运行中的 Clash 进程内存
+ps | grep -i clash
+cat /proc/$(pidof clash)/status | grep -E 'VmRSS|VmSize'
+
+# 查看 OpenClash 实时日志
+tail -f /tmp/openclash.log
+
+# 验证覆写脚本是否执行
+grep -E '\[Clash-Smart\]' /tmp/openclash.log
+
+# 查看最终生效的配置
+cat /etc/openclash/config/$(uci get openclash.config.config_path | xargs basename)
+
+# 手动触发覆写（仅调试用）
+bash /etc/openclash/openclash_custom_overwrite.sh /etc/openclash/config/your-config.yaml
+```
+
+---
+
+## 十、版本回滚
+
+若新版本出现问题，可回退到旧版本：
+
+```sh
+cd /etc/openclash/
+cp openclash_custom_overwrite.sh openclash_custom_overwrite.sh.bak
+# 用仓库 git log 回滚到上一个 tag
+```
+
+建议每次更新覆写脚本前先备份 `/etc/openclash/` 整个目录。
+
+---
+
+## 十一、致谢
+
+- [vernesong/OpenClash](https://github.com/vernesong/OpenClash) - OpenWrt OpenClash 插件
+- [MetaCubeX/mihomo](https://github.com/MetaCubeX/mihomo) - Smart 内核
+- [NanoPi R4S](https://www.friendlyelec.com/) - 参考硬件平台

--- a/README.md
+++ b/README.md
@@ -1,2 +1,175 @@
-# Clash
-自用CLASH覆写脚本分享
+# Clash 自用覆写脚本 / 配置集合
+
+一套面向 **Mihomo Smart 内核** 的多平台 Clash 覆写脚本与配置文件，统一「9 区域 × 28 业务组」架构，跨 Android / iOS / OpenWrt / 桌面端保持同一套分流逻辑。
+
+> 仓库目标：让同一份机场订阅在不同设备上获得**一致的分流体验**、**精细的业务归组**和**尽可能低的误判率**。
+
+---
+
+## 目录结构
+
+```
+Clash/
+├── Clash Meta For Android/     # CMFA (Android) 独立 YAML 配置
+│   └── clash-smart-cmfa.yaml
+├── Clash Party/                # Clash Verge / Mihomo Party 等桌面端 JS 覆写
+│   ├── Clash Smart内核覆写脚本.js
+│   └── 其他配置在UI里面填写      # DNS / Sniffer / GeoX 等 UI 粘贴片段
+├── OpenClash/                  # OpenWrt 路由器端
+│   ├── openclash_custom_overwrite.sh   # Bash 覆写脚本（主）
+│   ├── clash-smart-openclash.conf      # OpenClash 界面开关配置
+│   └── 使用方法.md                      # 图文使用说明
+└── Shadowrocket/               # iOS / macOS 小火箭
+    └── shadowrocket-smart.conf
+```
+
+---
+
+## 核心架构
+
+所有平台遵循同一套拓扑，确保从手机到路由器的行为一致：
+
+### 1. 9 个区域 Smart 组（节点自动聚合）
+
+按节点名称关键字与 ISO 国家代码自动分类，无需手动维护：
+
+| 区域 ID | 覆盖范围 |
+|---------|----------|
+| **HK** | 香港 |
+| **TW** | 台湾 |
+| **CN** | 回国节点 / 国内中转 / 电信联通移动 |
+| **JP** | 日本（东京/大阪/横滨/名古屋…） |
+| **KR** | 韩国（首尔/釜山/仁川…） |
+| **SG** | 新加坡 |
+| **US** | 美国（LAX/SJC/SFO/SEA/JFK 等 30+ 城市） |
+| **EU** | 欧洲（英法德荷瑞士瑞典等 40+ 国家） |
+| **AM** | 美洲（加拿大/墨西哥/巴西/阿根廷等） |
+| **AF** | 非洲（埃及/南非/尼日利亚等） |
+| **APAC_OTHER** | 亚太其他（马来/印尼/泰国/越南/菲律宾/印度/中东/澳新等） |
+
+每个区域组均启用：
+- `url-test` 自动择优
+- `uselightgbm: true`（Mihomo Smart LightGBM 模型）
+- `include-all-proxies: true`（全订阅候选池）
+
+### 2. 28 个业务策略组（精细分流）
+
+覆盖主流 SaaS 与本地化场景，部分代表性分组：
+
+- **AI 服务**：OpenAI / ChatGPT / Claude / Gemini / Copilot / Perplexity / Grok …
+- **流媒体**：Netflix / Disney+ / HBO Max / YouTube / Prime Video / Spotify / Apple TV / Bilibili / 爱奇艺 / 腾讯视频 …
+- **社交通讯**：Telegram / Twitter/X / Discord / WhatsApp / LINE / Signal …
+- **开发工具**：GitHub / GitLab / Docker / NPM / PyPI / jsdelivr …
+- **云与 CDN**、**游戏加速**、**受限网站 (GFW)**、**广告拦截**、**隐私追踪**、**支付/银行**、**Apple / Microsoft / Google 服务** 等。
+
+### 3. 规则源
+
+- 基于 **blackmatrix7 / MetaCubeX / Loyalsoldier / bm7** 等上游规则集
+- `rule-providers` 数量根据平台不同：
+  - Clash Party / CMFA：**375+**
+  - OpenClash（R4S 4GB 内存优化版）：**136**（由 387 精简，降低 OOM 风险）
+- 自动回退 `GEOIP,CN` / `GEOSITE,cn` / `GEOIP,private` 多层兜底
+
+### 4. DNS 与 Sniffer
+
+- **DNS 三层架构**：`default-nameserver`（bootstrap）→ `nameserver`（国内 DoH）→ `proxy-server-nameserver` / `direct-nameserver` / `fallback`（国外 DoH + geoip CN 过滤）
+- `respect-rules: true`：DNS 查询遵循路由规则（防 DNS 泄漏 + 精准分流）
+- **Sniffer**：同时开启 HTTP / TLS / QUIC 嗅探，`force-dns-mapping + override-destination`，解决 fake-ip 下 SNI 识别问题
+- 默认 **fake-ip** 模式，过滤常见 STUN / NTP / 内网 / 支付域名
+
+### 5. 节点过滤
+
+覆写脚本会自动剔除：
+- 信息类假节点：`导航网址` / `剩余流量` / `到期` / `重置` / `官网`
+- 倍率警示节点：`10x` / `20x` / `100x` 等高倍率扣费节点
+
+---
+
+## 各平台使用说明
+
+### Clash Party（Clash Verge Rev / Mihomo Party / 桌面端）
+
+1. 在客户端「订阅」中添加机场订阅（建议配合 **Sub-Store** 多订阅融合，脚本已针对 Sub-Store 的节点命名优化）。
+2. 进入「覆写脚本 / Override」→ 新建 **JavaScript** 类型脚本。
+3. 粘贴 `Clash Party/Clash Smart内核覆写脚本.js` 的全部内容。
+4. 在客户端设置界面将 `Clash Party/其他配置在UI里面填写` 中的 **GeoX URL / DNS / Sniffer** 段粘贴到「Mixin 配置」或对应设置栏。
+5. 应用覆写，重启内核。
+
+> 脚本版本：**v5.2.2**（2026-04-13），支持 SUB-STORE 多机场融合、jsdelivr 永久直连（避免 rule-provider 刷新 DNS 循环依赖）等修复。
+
+### Clash Meta For Android (CMFA)
+
+1. 打开 `Clash Meta For Android/clash-smart-cmfa.yaml`，将文件顶部 `proxy-providers` → `Subscribe` → `url` 字段替换为你的机场订阅链接。
+2. 在 CMFA 中「配置」→ 导入本地文件，选择上面保存的 YAML。
+3. 首次导入后 CMFA 会自动拉取 Loyalsoldier 增强版 `geoip.dat / Country.mmdb / GeoLite2-ASN.mmdb / geosite.dat`。
+4. 所有 GEOSITE/GEOIP 高级标签已用等效 RULE-SET 替代，无需等待 dat 下载即可生效。
+
+### OpenClash（OpenWrt 路由器）
+
+目标设备参考：**NanoPi R4S 4GB** 等中端路由器。
+
+1. 登录 OpenWrt LuCI → **Services / 服务** → **OpenClash**。
+2. 「**覆写设置 / Overwrite Settings**」页：
+   - 上传并启用 `OpenClash/openclash_custom_overwrite.sh`
+   - 勾选「启用自定义覆写 (Enable Custom Overwrite)」
+3. 「**插件设置 / Plugin Settings**」页：
+   - 参考 `OpenClash/clash-smart-openclash.conf` 中的每一项按字段填入（或直接写入 `/etc/config/openclash`）。
+   - 关键项：`CORE_TYPE=Smart`、`GEODATA_LOADER=standard`（4GB 内存可用；2GB 设备建议改 `memconservative`）、`CHINA_IP_ROUTE=0`（避免 Step3 注入 geosite 解析错误）。
+4. 「**规则设置**」→ 选择你的 Smart 内核，保存并应用。
+5. 详细图文步骤：见 `OpenClash/使用方法.md`。
+
+内存优化要点（由 v5.3.x 内置）：
+- `geodata-loader: memconservative` 可再节省 400–600 MB；
+- `rule-providers` 从 387 精简到 136（Google/Apple 家族合并、删除区域化冗余、合并广告拦截集），节省 800–1,100 MB；
+- 保留完整 9 Smart 组、动态节点分类、DNS 多层架构、TLS 指纹注入。
+
+### Shadowrocket（iOS / macOS）
+
+1. 将 `Shadowrocket/shadowrocket-smart.conf` 托管至可访问 URL（GitHub Raw / jsDelivr / 自有服务器均可）。
+2. Shadowrocket → **配置** → 右上角 ➕ → 粘贴 URL → 下载。
+3. 点击该配置 → **使用配置**（触发 rule-set 下载，首次约 250+ 个规则集，需要保持代理开启）。
+4. 代理分组页面手动为 28 个业务组选择初始节点/子组。
+5. 首页 → **连通性测试**，确认 9 个区域组已正确聚合节点。
+
+与 Clash Party 原版的差异（受 iOS 平台 / SR 引擎限制）：
+- 不支持 `PROCESS-NAME` 规则、TUN `exclude-process`、Smart fingerprint 注入；
+- `GEOSITE` 全部替换为 `RULE-SET`；
+- Meta `.mrs` 二进制格式替换为 blackmatrix7 Shadowrocket `.list`；
+- `rule-provider` 周期刷新由 SR「自动更新配置」统一管理。
+
+---
+
+## 版本 / 更新日志
+
+- **v5.2.2**（2026-04-13）— Clash Party：PI.ai 移入 GFW 组；jsdelivr CDN 永久直连；删除已死的 ckrvxr 规则源；`DST-PORT,7680,REJECT` 顺序修复；`GSCService.exe` 加入 TUN exclude-process。
+- **v5.2.2-SR.1**（2026-04-16）— Shadowrocket：DNS 段重构，映射 Clash 原版 `proxy-server-nameserver` / `fallback`。
+- **v5.3.x-oc-slim** — OpenClash：R4S 4GB 内存优化版，DNS 冷启动修复。
+
+完整历史请参阅各脚本文件顶部的 `CHANGELOG` 注释块。
+
+---
+
+## 依赖上游
+
+本仓库仅做**编排与覆写**，规则集与数据库均来自以下优秀开源项目：
+
+- [MetaCubeX/mihomo](https://github.com/MetaCubeX/mihomo) — Smart 内核
+- [vernesong/mihomo](https://github.com/vernesong/mihomo/releases/download/LightGBM-Model/Model.bin) — LightGBM 模型
+- [Loyalsoldier/geoip](https://github.com/Loyalsoldier/geoip) — 增强版 geoip.dat / Country.mmdb / GeoLite2-ASN.mmdb
+- [MetaCubeX/meta-rules-dat](https://github.com/MetaCubeX/meta-rules-dat) — geosite.dat
+- [blackmatrix7/ios_rule_script](https://github.com/blackmatrix7/ios_rule_script) — 业务分流规则集
+- [bm7 / sub-store](https://github.com/sub-store-org/Sub-Store) — 多机场融合订阅
+
+---
+
+## 免责声明
+
+- 本仓库**仅供个人学习与研究网络技术使用**，不提供任何机场订阅。
+- 请遵守所在地区的法律法规，合理合法地使用本项目。
+- 所有脚本/配置均为「自用分享」，作者不对因使用本项目造成的任何直接或间接后果负责。
+
+---
+
+## License
+
+如无特别说明，本仓库内容以 **MIT License** 开放。上游规则集与数据库各自遵循原项目许可。

--- a/Shadowrocket/使用方法.md
+++ b/Shadowrocket/使用方法.md
@@ -1,0 +1,211 @@
+# Shadowrocket（小火箭）使用方法
+
+> 配置文件：`shadowrocket-smart.conf`
+> 版本：**v5.2.2-SR.1**（Build 2026-04-16，从 Clash Party v5.2.2 迁移重构）
+> 目标：**Shadowrocket iOS（App Store 正版）** / macOS 通用
+> 架构：9 Smart 区域组（`url-test` + `policy-regex-filter`）+ 28 业务策略组 + 250+ rule-set
+
+---
+
+## 一、下载 Shadowrocket
+
+- **iOS**：App Store 搜索「Shadowrocket」（需非中国大陆 Apple ID，美区 $2.99）。
+- **macOS**：同一 Apple ID 登录 App Store 后可在 Mac 直接安装 iOS 版本。
+- 安装后首次启动需授权 VPN 配置权限（系统会弹出添加 VPN 配置的提示）。
+
+---
+
+## 二、配置托管
+
+Shadowrocket 不像桌面端那样支持本地脚本覆写；必须把配置文件放到可访问的 URL 上：
+
+### 推荐托管方式
+
+**A. GitHub Raw**
+1. 将 `shadowrocket-smart.conf` 上传到你的 GitHub 仓库（public 或 private 均可，private 需生成 token URL）。
+2. 获取 Raw URL：`https://raw.githubusercontent.com/<user>/<repo>/main/shadowrocket-smart.conf`
+
+**B. jsDelivr CDN（国内访问更稳定）**
+`https://cdn.jsdelivr.net/gh/<user>/<repo>@main/shadowrocket-smart.conf`
+
+**C. 自建 HTTP 服务器**
+任意可通过 HTTPS 访问的 URL 均可。
+
+---
+
+## 三、导入配置
+
+1. 打开 Shadowrocket → 底部导航 **配置（Config）**。
+2. 右上角 ➕。
+3. 粘贴配置 URL，点击**下载**。
+4. 下载完成后，点击该配置行 → 选择「**使用配置（Use Config）**」。
+
+此时 Shadowrocket 会开始下载约 **250+ 个 rule-set**（blackmatrix7 Shadowrocket 专用 `.list` 格式），首次需要 **3–5 分钟**，期间请保持代理开启（否则 GitHub 访问不稳定会导致部分 rule-set 下载失败）。
+
+---
+
+## 四、修改机场订阅
+
+Shadowrocket 的节点来源与 Clash 不同，需要在 **首页 → 子网**（Subscribe）单独添加：
+
+1. 首页 → **子网（Subscribe）** → ➕。
+2. 粘贴机场订阅链接 → 下载。
+3. 下载后的节点会自动出现在**首页节点列表**和**代理组候选池**中。
+
+本配置内的 `policy-regex-filter` 会**自动按地区聚合节点**到 9 个 Smart 区域组，无需手动拖拽。
+
+---
+
+## 五、9 区域组 × 28 业务组说明
+
+Shadowrocket 不支持 JavaScript，改用 `policy-regex-filter` 在导入/编译时一次性匹配节点名：
+
+### 区域组（url-test 自动择优）
+- 🌍 全球节点 / 🇭🇰 香港节点 / 🇹🇼 台湾节点 / 🇯🇵 日韩节点
+- 🌏 亚太节点 / 🇺🇸 美国节点 / 🇪🇺 欧洲节点 / 🌎 美洲节点 / 🌍 非洲节点
+
+### 业务组（select 手动选择）
+- 🤖 AI 服务、💰 加密货币、🏦 金融支付、📧 邮件、💬 即时通讯、📱 社交媒体
+- 🧑‍💼 会议协作、📺 国内流媒体、📺 东南亚流媒体、🇺🇸 美国流媒体、🇭🇰 香港流媒体、🇹🇼 台湾流媒体
+- 🎮 游戏、☁️ 云与 CDN、🚫 受限网站（GFW）、🛡️ 广告拦截、🔒 隐私追踪
+- 🍎 Apple、🪟 Microsoft、🔍 Google、📦 GitHub / 开发工具 等
+
+首次导入后，建议在「**首页 → 代理组**」为 **28 个业务组**逐一选择一个默认上游节点或区域组。
+
+---
+
+## 六、DNS 配置说明（v5.2.2-SR.1 重构）
+
+本版本 DNS 段已重构以**尽量贴合 Clash 原版行为**，但受 SR 引擎限制有部分功能无法迁移：
+
+| 字段 | 对应 Clash 字段 | 内容 |
+|------|----------------|------|
+| `dns-server` | `nameserver` + `direct-nameserver` | 国内 DoH（AliDNS / DNSPod） |
+| `proxy-dns-server` | `proxy-server-nameserver` | 代理服务器域名解析（国外 DoH） |
+| `fallback-dns-server` | `fallback` | 国外 DoH（Cloudflare / Google） |
+
+### 无法迁移的功能（已在配置内标注）
+- Clash 的 `default-nameserver` **bootstrap**（SR 使用 iOS 系统 DNS 作为 bootstrap）
+- `respect-rules: true`（SR 无等价字段）
+- `fallback-filter.geoip-code: CN`（SR fallback 始终无条件启用）
+- GeoX `.dat` 格式（SR 只支持内置 `GEOIP`，不支持 `GEOSITE`）
+
+---
+
+## 七、与 Clash Party 原版的差异
+
+由于 iOS 平台与 SR 引擎限制，本配置相对桌面原版有以下调整：
+
+| 差异 | 原因 |
+|------|------|
+| ❌ 删除 `PROCESS-NAME` 规则 | iOS 无进程识别 API |
+| ❌ 删除 TUN `exclude-process` | SR 无该机制 |
+| ❌ 删除 Smart fingerprint 注入 | SR 不暴露 TLS 指纹控制 |
+| ⚙️ `GEOSITE` 全部替换为 `RULE-SET` | SR 不原生支持 GEOSITE |
+| ⚙️ Meta `.mrs` 二进制格式 → blackmatrix7 Shadowrocket `.list` | 格式兼容性 |
+| ⚙️ 部分 YAML classical 保留 | SR 按内容识别可解析 |
+| ⚙️ `rule-provider` 周期刷新 → SR 自动更新配置 | 统一由 SR 管理 |
+
+---
+
+## 八、启动与验证
+
+1. 首页顶部 → 点击 **启动（Not Connected → Connected）**。
+2. 首次连接系统会弹出「允许添加 VPN 配置」→ 允许 + 输入 Touch ID / 密码。
+3. 打开浏览器访问 `https://whoer.net` 或 `https://ipleak.net`：
+   - IP 应显示为所选节点的出口 IP
+   - DNS 泄漏检测应显示代理侧 DNS
+
+### 验证分流是否正确
+
+- 访问 `chat.openai.com` → 应通过「🤖 AI 服务」组出口；
+- 访问 `www.netflix.com` → 应通过「🇺🇸 美国流媒体」组；
+- 访问 `www.bilibili.com` → 应走 DIRECT 或国内流媒体；
+- 访问 `raw.githubusercontent.com` → 应走「📦 开发工具」或「🚫 受限网站」组；
+
+首页底部「**连接信息（Connections）**」可查看每条实时请求命中的规则与上游节点。
+
+---
+
+## 九、iOS 系统设置建议
+
+### 1. 开启后台刷新（**必做**）
+- **iOS 设置** → **通用** → **后台 App 刷新** → 确保 Shadowrocket 开启。
+- 否则 **rule-set 不会自动更新**。
+
+### 2. 允许常驻 VPN
+- **设置** → **VPN 与设备管理** → **Shadowrocket** → 开启「**按需连接**」。
+- 建议搭配「**域名/IP 地址**」触发规则，避免误杀国内直连流量。
+
+### 3. 跳过某些 App / 域名
+- 配置内已预置 `skip-proxy` 列表：
+  - 国内银行：建行 / 农行 / 邮储 / 工行 / 交行
+  - 支付：支付宝 / 微信支付 / 财付通
+  - iOS 系统：`captive.apple.com`（防 WiFi 检测异常）
+  - 私有网段：`192.168.0.0/16`、`10.0.0.0/8`、`172.16.0.0/12`、`100.64.0.0/10`（CGNAT）
+
+### 4. TUN 旁路路由（已预置）
+保留组播 + 私有 + 链路本地 + 文档网段 + 广播地址，避免 TUN 过度劫持：
+```
+tun-excluded-routes = 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, ...
+```
+
+---
+
+## 十、跨境场景（中国 ⇄ 境外）
+
+配置针对**常年跨境出差**用户做了优化：
+
+| 组 | 在中国 | 在印尼/其他境外 |
+|------|--------|----------------|
+| 🚫 受限网站（GFW） | 选代理节点翻墙 | 选 DIRECT 直连 |
+| ☁️ 云与 CDN（jsDelivr） | 选代理 | 选 DIRECT |
+| 📺 国内流媒体 | DIRECT | 选 🇭🇰 香港回国节点 |
+
+切换方式：**首页 → 代理组 → 手动切换** 即可，无需改配置。
+
+---
+
+## 十一、规则更新与维护
+
+### 手动刷新所有 rule-set
+- **配置页** → 长按配置 → **更新**。
+
+### 自动更新
+- 在配置页右上角齿轮 ⚙️ 中开启「**自动更新配置**」，默认每 24 小时一次。
+
+### 检查规则失效
+- 首页 → **规则（Rules）** → 滑动查看所有 rule-provider 状态；
+- 若某条显示红色叉号，通常是源 URL 暂时 404，可尝试手动刷新。
+
+---
+
+## 十二、常见问题
+
+### Q1：配置下载失败 / 部分 rule-set 空白？
+- 首次下载需要开启代理（否则 GitHub 不稳定）。
+- 可先使用一个简易直连代理下载配置后，再切回本配置。
+
+### Q2：iOS 支付/银行 App 异常？
+- 检查「**Skip Proxy**」是否包含你遇到问题的域名；
+- 必要时添加到 `skip-proxy` 列表后重新导入配置。
+
+### Q3：TikTok 海外版无法播放？
+- TikTok 已由 `metaDomain('tiktok')` 独立覆盖；
+- 手动在「📺 东南亚流媒体」或「🇺🇸 美国流媒体」中切换合适区域即可。
+
+### Q4：Netflix 显示「You seem to be using a proxy」？
+- 切换到「🇺🇸 美国流媒体」组中的其他节点；
+- Shadowrocket 无法自动检测 Netflix 解锁状态，需手动尝试。
+
+### Q5：修改配置后如何同步到 SR？
+- 修改 → 推送到托管 URL → Shadowrocket 配置页 → 长按 → **更新**。
+
+---
+
+## 十三、致谢
+
+- [Shadowrocket](https://apps.apple.com/app/shadowrocket/id932747118)
+- [blackmatrix7/ios_rule_script](https://github.com/blackmatrix7/ios_rule_script) - Shadowrocket `.list` 规则源
+- [szkane](https://github.com/szkane) - 补充规则
+- 原版 Clash Party v5.2.2 所有参考作者


### PR DESCRIPTION
## Summary

- **README.md**：由原先两行扩写为完整仓库介绍，覆盖「9 区域 × 28 业务组」架构、4 个平台的使用流程、依赖上游与免责声明。
- **Clash Meta For Android / 使用方法.md**（新增）：CMFA 客户端下载、YAML 订阅替换、本地/URL 两种导入方式、9+28 代理组说明、TUN / 保活 / 常见问题。
- **Clash Party / 使用方法.md**（新增）：Mihomo Party / Clash Verge Rev 的 JS 覆写导入、Mixin DNS 粘贴、v5.2.2 变更亮点（jsdelivr 直连、PI.ai 归组、GSCService TUN exclude）。
- **Shadowrocket / 使用方法.md**（新增）：iOS/macOS 导入托管配置、v5.2.2-SR.1 DNS 重构对照、跨境场景切换、iOS 后台刷新/VPN 设置、与 Clash Party 原版差异。
- **OpenClash / 使用方法.md**（改写）：保留原截图，新增硬件/内核要求、脚本部署、`clash-smart-openclash.conf` UCI 字段对照、R4S 4GB 内存优化（387→136 rule-providers、memconservative）、DNS 冷启动救援。

## Test plan

- [ ] 在 GitHub 上预览 README 与各子目录的 `使用方法.md` 渲染无乱码、表格正确
- [ ] 核对四个平台的脚本版本号是否与文档一致（v5.2.2 / v5.2.2-SR.1 / v5.2.0 / v5.3.2）
- [ ] 核对 GitHub 链接 / jsDelivr URL 可访问
- [ ] 如有需要，将 OpenClash 截图链接替换为仓库托管版本

https://claude.ai/code/session_013xFN611SMJi65LF1WpPCZa