### PR TITLE
feat: add SingBox profile and tutorial aligned with Clash Party v5.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Clash/
 │   ├── Clash Smart内核覆写脚本.js
 │   ├── 其他配置在UI里面填写
 │   └── 使用方法.md
+├── SingBox/
+│   ├── singbox-smart.json
+│   └── 使用教程.md
 ├── OpenClash/
 │   ├── openclash_custom_overwrite.sh
 │   ├── openclash_custom_overwrite_full.sh

--- a/SingBox/singbox-smart.json
+++ b/SingBox/singbox-smart.json
@@ -1,0 +1,379 @@
+{
+  "log": {
+    "level": "info",
+    "timestamp": true
+  },
+  "experimental": {
+    "cache_file": {
+      "enabled": true,
+      "path": "cache.db",
+      "store_fakeip": true,
+      "store_rdrc": true
+    }
+  },
+  "dns": {
+    "servers": [
+      {
+        "tag": "dns_direct",
+        "address": "https://223.5.5.5/dns-query",
+        "detour": "direct"
+      },
+      {
+        "tag": "dns_proxy",
+        "address": "https://1.1.1.1/dns-query",
+        "detour": "🌍 全球节点"
+      },
+      {
+        "tag": "dns_block",
+        "address": "rcode://success"
+      }
+    ],
+    "rules": [
+      {
+        "rule_set": [
+          "geosite-cn"
+        ],
+        "action": "route",
+        "server": "dns_direct"
+      },
+      {
+        "rule_set": [
+          "geosite-category-ads-all"
+        ],
+        "action": "route",
+        "server": "dns_block"
+      }
+    ],
+    "final": "dns_proxy",
+    "strategy": "prefer_ipv4"
+  },
+  "inbounds": [
+    {
+      "type": "tun",
+      "tag": "tun-in",
+      "address": [
+        "172.19.0.1/30"
+      ],
+      "mtu": 9000,
+      "auto_route": true,
+      "strict_route": true,
+      "sniff": true,
+      "sniff_override_destination": true,
+      "stack": "mixed"
+    }
+  ],
+  "outbounds": [
+    {
+      "type": "selector",
+      "tag": "🚀 节点选择",
+      "outbounds": [
+        "🌍 全球节点",
+        "DIRECT",
+        "🚫 拦截"
+      ],
+      "default": "🌍 全球节点"
+    },
+
+    {
+      "type": "urltest",
+      "tag": "🌍 全球节点",
+      "outbounds": [
+        "🇭🇰 香港节点",
+        "🇹🇼 台湾节点",
+        "🇯🇵 日韩节点",
+        "🌏 亚太节点",
+        "🇺🇸 美国节点",
+        "🇪🇺 欧洲节点",
+        "🌎 美洲节点",
+        "🌍 非洲节点"
+      ],
+      "interval": "3m",
+      "tolerance": 50
+    },
+    {
+      "type": "selector",
+      "tag": "🇭🇰 香港节点",
+      "outbounds": [
+        "proxy-hk-1",
+        "proxy-hk-2",
+        "DIRECT"
+      ],
+      "default": "proxy-hk-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇹🇼 台湾节点",
+      "outbounds": [
+        "proxy-tw-1",
+        "DIRECT"
+      ],
+      "default": "proxy-tw-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇯🇵 日韩节点",
+      "outbounds": [
+        "proxy-jp-1",
+        "proxy-kr-1",
+        "DIRECT"
+      ],
+      "default": "proxy-jp-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🌏 亚太节点",
+      "outbounds": [
+        "proxy-sg-1",
+        "proxy-id-1",
+        "DIRECT"
+      ],
+      "default": "proxy-sg-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇺🇸 美国节点",
+      "outbounds": [
+        "proxy-us-1",
+        "proxy-us-2",
+        "DIRECT"
+      ],
+      "default": "proxy-us-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇪🇺 欧洲节点",
+      "outbounds": [
+        "proxy-eu-1",
+        "DIRECT"
+      ],
+      "default": "proxy-eu-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🌎 美洲节点",
+      "outbounds": [
+        "proxy-ca-1",
+        "proxy-us-1",
+        "DIRECT"
+      ],
+      "default": "proxy-ca-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🌍 非洲节点",
+      "outbounds": [
+        "proxy-af-1",
+        "DIRECT"
+      ],
+      "default": "proxy-af-1"
+    },
+
+    { "type": "selector", "tag": "🤖 AI 服务", "outbounds": ["🇺🇸 美国节点", "🌍 全球节点", "🇯🇵 日韩节点", "DIRECT"] },
+    { "type": "selector", "tag": "💰 加密货币", "outbounds": ["🇭🇰 香港节点", "🌍 全球节点", "🇺🇸 美国节点", "DIRECT"] },
+    { "type": "selector", "tag": "🏦 金融支付", "outbounds": ["DIRECT", "🇭🇰 香港节点", "🇯🇵 日韩节点", "🌍 全球节点"] },
+    { "type": "selector", "tag": "📧 邮件服务", "outbounds": ["🇯🇵 日韩节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "💬 即时通讯", "outbounds": ["🇭🇰 香港节点", "🇯🇵 日韩节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "📱 社交媒体", "outbounds": ["🇯🇵 日韩节点", "🌍 全球节点", "🇺🇸 美国节点", "DIRECT"] },
+    { "type": "selector", "tag": "🧑‍💼 会议协作", "outbounds": ["🇯🇵 日韩节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "📺 国内流媒体", "outbounds": ["DIRECT", "🇭🇰 香港节点", "🌍 全球节点"] },
+    { "type": "selector", "tag": "📺 东南亚流媒体", "outbounds": ["🌏 亚太节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🇺🇸 美国流媒体", "outbounds": ["🇺🇸 美国节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🇭🇰 香港流媒体", "outbounds": ["🇭🇰 香港节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🇹🇼 台湾流媒体", "outbounds": ["🇹🇼 台湾节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🇯🇵 日韩流媒体", "outbounds": ["🇯🇵 日韩节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🇪🇺 欧洲流媒体", "outbounds": ["🇪🇺 欧洲节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🕹️ 国内游戏", "outbounds": ["DIRECT", "🇭🇰 香港节点", "🌍 全球节点"] },
+    { "type": "selector", "tag": "🎮 国外游戏", "outbounds": ["🇯🇵 日韩节点", "🇭🇰 香港节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🔍 搜索引擎", "outbounds": ["🌍 全球节点", "🇯🇵 日韩节点", "DIRECT"] },
+    { "type": "selector", "tag": "📟 开发者服务", "outbounds": ["🌍 全球节点", "🇺🇸 美国节点", "🇯🇵 日韩节点", "DIRECT"] },
+    { "type": "selector", "tag": "Ⓜ️ 微软服务", "outbounds": ["🌍 全球节点", "🇯🇵 日韩节点", "DIRECT"] },
+    { "type": "selector", "tag": "🍎 苹果服务", "outbounds": ["DIRECT", "🇭🇰 香港节点", "🌍 全球节点"] },
+    { "type": "selector", "tag": "📥 下载更新", "outbounds": ["DIRECT", "🌍 全球节点", "🇭🇰 香港节点"] },
+    { "type": "selector", "tag": "☁️ 云与CDN", "outbounds": ["🌍 全球节点", "DIRECT", "🇺🇸 美国节点"] },
+    { "type": "selector", "tag": "🛰️ BT/PT Tracker", "outbounds": ["🚫 拦截", "DIRECT", "🌍 全球节点", "🇭🇰 香港节点"] },
+    { "type": "selector", "tag": "🏠 国内网站", "outbounds": ["DIRECT", "🇭🇰 香港节点", "🌍 全球节点"] },
+    { "type": "selector", "tag": "🚫 受限网站", "outbounds": ["🌍 全球节点", "🇺🇸 美国节点", "DIRECT"] },
+    { "type": "selector", "tag": "🌐 国外网站", "outbounds": ["🌍 全球节点", "🇯🇵 日韩节点", "🇺🇸 美国节点", "DIRECT"] },
+    { "type": "selector", "tag": "🐟 漏网之鱼", "outbounds": ["🌍 全球节点", "DIRECT", "🇭🇰 香港节点"] },
+    { "type": "selector", "tag": "🛑 广告拦截", "outbounds": ["🚫 拦截", "DIRECT"] },
+
+    {
+      "type": "trojan",
+      "tag": "proxy-hk-1",
+      "server": "example-hk-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-hk-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-hk-2",
+      "server": "example-hk-2.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-hk-2.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-tw-1",
+      "server": "example-tw-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-tw-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-jp-1",
+      "server": "example-jp-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-jp-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-kr-1",
+      "server": "example-kr-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-kr-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-sg-1",
+      "server": "example-sg-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-sg-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-id-1",
+      "server": "example-id-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-id-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-us-1",
+      "server": "example-us-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-us-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-us-2",
+      "server": "example-us-2.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-us-2.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-eu-1",
+      "server": "example-eu-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-eu-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-ca-1",
+      "server": "example-ca-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-ca-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-af-1",
+      "server": "example-af-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-af-1.com" }
+    },
+
+    { "type": "direct", "tag": "DIRECT" },
+    { "type": "block", "tag": "🚫 拦截" }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "final": "🐟 漏网之鱼",
+    "rule_set": [
+      {
+        "type": "remote",
+        "tag": "geosite-cn",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/cn.srs",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geoip-cn",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo-lite/geoip/cn.srs",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geosite-geolocation-!cn",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/geolocation-!cn.srs",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geosite-category-ads-all",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/category-ads-all.srs",
+        "update_interval": "1d"
+      }
+    ],
+    "rules": [
+      { "protocol": "dns", "action": "hijack-dns" },
+      { "port": [7680], "action": "reject" },
+
+      { "domain_suffix": ["openai.com", "chat.openai.com", "oaistatic.com", "anthropic.com", "claude.ai", "gemini.google.com", "perplexity.ai", "huggingface.co", "cursor.com", "v0.dev", "character.ai", "mistral.ai", "cohere.ai", "cohere.com", "replicate.com", "together.ai", "runpod.io", "openrouter.ai", "suno.ai", "suno.com"], "action": "route", "outbound": "🤖 AI 服务" },
+      { "domain_suffix": ["inflection.ai", "pi.ai"], "action": "route", "outbound": "🚫 受限网站" },
+      { "domain_suffix": ["binance.com", "binance.info", "binance.me", "binance.org", "binancefuture.com", "tradingview.com", "coinglass.com", "coinmarketcap.com", "coingecko.com"], "action": "route", "outbound": "💰 加密货币" },
+      { "domain_suffix": ["paypal.com", "stripe.com", "stripe.network", "wise.com", "revolut.com", "visa.com", "mastercard.com", "amex.com"], "action": "route", "outbound": "🏦 金融支付" },
+      { "domain_suffix": ["gmail.com", "googlemail.com", "outlook.com", "hotmail.com", "proton.me", "protonmail.com", "fastmail.com", "tuta.com"], "action": "route", "outbound": "📧 邮件服务" },
+      { "domain_suffix": ["telegram.org", "t.me", "discord.com", "discord.gg", "whatsapp.com", "line.me", "kakao.com", "skype.com"], "action": "route", "outbound": "💬 即时通讯" },
+      { "domain_suffix": ["x.com", "twitter.com", "instagram.com", "facebook.com", "fbcdn.net", "reddit.com"], "action": "route", "outbound": "📱 社交媒体" },
+      { "domain_suffix": ["zoom.us", "teams.microsoft.com", "slack.com", "notion.so", "atlassian.com", "meet.google.com"], "action": "route", "outbound": "🧑‍💼 会议协作" },
+      { "domain_suffix": ["bilibili.com", "iqiyi.com", "youku.com", "mgtv.com", "qq.com", "youkucloud.com"], "action": "route", "outbound": "📺 国内流媒体" },
+      { "domain_suffix": ["youtube.com", "youtu.be", "googlevideo.com", "ytimg.com", "netflix.com", "nflxvideo.net", "disneyplus.com", "hulu.com", "hbo.com"], "action": "route", "outbound": "🇺🇸 美国流媒体" },
+      { "domain_suffix": ["viu.com", "iq.com", "wetv.vip"], "action": "route", "outbound": "📺 东南亚流媒体" },
+      { "domain_suffix": ["now.com", "mytvsuper.com", "viu.tv"], "action": "route", "outbound": "🇭🇰 香港流媒体" },
+      { "domain_suffix": ["bahamut.com.tw", "hinet.net", "line.me"], "action": "route", "outbound": "🇹🇼 台湾流媒体" },
+      { "domain_suffix": ["abema.tv", "dmm.com", "tv-tokyo.co.jp"], "action": "route", "outbound": "🇯🇵 日韩流媒体" },
+      { "domain_suffix": ["bbc.co.uk", "iplayer.bbc.co.uk", "zdf.de"], "action": "route", "outbound": "🇪🇺 欧洲流媒体" },
+      { "domain_suffix": ["steamcommunity.com", "steampowered.com", "epicgames.com", "riotgames.com", "playstation.com"], "action": "route", "outbound": "🎮 国外游戏" },
+      { "domain_suffix": ["qq.com", "163.com", "mihoyo.com", "battlenet.com.cn"], "action": "route", "outbound": "🕹️ 国内游戏" },
+      { "domain_suffix": ["google.com", "googleapis.com", "duckduckgo.com", "bing.com"], "action": "route", "outbound": "🔍 搜索引擎" },
+      { "domain_suffix": ["github.com", "githubusercontent.com", "gitlab.com", "docker.io", "npmjs.com", "pypi.org"], "action": "route", "outbound": "📟 开发者服务" },
+      { "domain_suffix": ["microsoft.com", "windowsupdate.com", "office.com", "live.com"], "action": "route", "outbound": "Ⓜ️ 微软服务" },
+      { "domain_suffix": ["apple.com", "icloud.com", "mzstatic.com", "apple-dns.net"], "action": "route", "outbound": "🍎 苹果服务" },
+      { "domain_suffix": ["dl.google.com", "msftconnecttest.com", "windowsupdate.com", "cdn-apple.com"], "action": "route", "outbound": "📥 下载更新" },
+      { "domain_suffix": ["cloudflare.com", "jsdelivr.net", "fastly.com", "akamaized.net"], "action": "route", "outbound": "☁️ 云与CDN" },
+      { "domain_suffix": ["tracker.opentrackr.org", "openbittorrent.com", "nyaa.si"], "action": "route", "outbound": "🛰️ BT/PT Tracker" },
+
+      {
+        "rule_set": ["geosite-category-ads-all"],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": ["geosite-cn", "geoip-cn"],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "rule_set": ["geosite-geolocation-!cn"],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      }
+    ]
+  }
+}

--- a/SingBox/使用教程.md
+++ b/SingBox/使用教程.md
@@ -1,0 +1,125 @@
+# SingBox 使用教程（对齐 Clash Party v5.2.2 语义）
+
+> 配置文件：`SingBox/singbox-smart.json`  
+> 目标：在 **sing-box** 上尽可能复刻 Clash Party 的「9 个区域组 + 28 个业务组」分流语义，并保持 sing-box 官方配置兼容。
+
+---
+
+## 1. 设计说明（和 Clash Party 的一致性）
+
+该 sing-box 版本与 Clash Party 主线保持以下一致：
+
+- **区域层一致**：
+  - `🌍 全球节点`
+  - `🇭🇰 香港节点`
+  - `🇹🇼 台湾节点`
+  - `🇯🇵 日韩节点`
+  - `🌏 亚太节点`
+  - `🇺🇸 美国节点`
+  - `🇪🇺 欧洲节点`
+  - `🌎 美洲节点`
+  - `🌍 非洲节点`
+
+- **业务层一致（28 组）**：
+  - `🤖 AI 服务`、`💰 加密货币`、`🏦 金融支付`、`📧 邮件服务`、`💬 即时通讯`、`📱 社交媒体`
+  - `🧑‍💼 会议协作`、`📺 国内流媒体`、`📺 东南亚流媒体`、`🇺🇸 美国流媒体`、`🇭🇰 香港流媒体`
+  - `🇹🇼 台湾流媒体`、`🇯🇵 日韩流媒体`、`🇪🇺 欧洲流媒体`、`🕹️ 国内游戏`、`🎮 国外游戏`
+  - `🔍 搜索引擎`、`📟 开发者服务`、`Ⓜ️ 微软服务`、`🍎 苹果服务`、`📥 下载更新`
+  - `☁️ 云与CDN`、`🛰️ BT/PT Tracker`、`🏠 国内网站`、`🚫 受限网站`、`🌐 国外网站`
+  - `🐟 漏网之鱼`、`🛑 广告拦截`
+
+- **规则层策略一致**：
+  - AI、支付、加密货币、流媒体、即时通讯、开发者服务等关键域名前置匹配。
+  - 国内/国外流量使用 `geosite-cn` + `geoip-cn` 与 `geosite-geolocation-!cn` 收口。
+  - 广告使用 `category-ads-all` 统一拦截。
+
+---
+
+## 2. 准备工作
+
+1. 安装 sing-box 或图形客户端（如 sing-box for Android / macOS 图形端等）。
+2. 将 `SingBox/singbox-smart.json` 导入客户端。
+3. 将文件内 `proxy-xxx` 示例节点替换成你自己的真实节点（trojan/vless/vmess/hysteria2 都可以）。
+
+> 说明：我在模板中提供了可运行结构和占位节点，便于你快速迁移 Clash Party 的组策略；实际连接能力由你替换后的节点决定。
+
+---
+
+## 3. 关键兼容性（按 sing-box 官方文档）
+
+为了兼容新版本 sing-box，配置做了以下处理：
+
+- 路由规则使用 `action` + `outbound` 形式（sing-box 1.11+ 变更后推荐）。
+- 使用 `rule_set`（remote/binary）而非老 GeoIP/Geosite 旧写法。
+- 启用 `experimental.cache_file.enabled`，让远程规则和 selector 选择结果可缓存。
+- `selector` / `urltest` 均使用官方结构字段（`outbounds`、`default`、`interval`、`tolerance`）。
+
+---
+
+## 4. 替换节点的推荐方式
+
+在 `outbounds` 中，优先按区域替换：
+
+- `proxy-hk-*` → 香港节点
+- `proxy-tw-*` → 台湾节点
+- `proxy-jp-*` / `proxy-kr-*` → 日韩节点
+- `proxy-sg-*` / `proxy-id-*` → 亚太节点
+- `proxy-us-*` → 美国节点
+- `proxy-eu-*` → 欧洲节点
+- `proxy-ca-*` → 美洲节点
+- `proxy-af-*` → 非洲节点
+
+这样业务组就不需要改动，能保留 Clash Party 的“业务语义 -> 区域出口”逻辑。
+
+---
+
+## 5. 首次启动检查清单
+
+启动后请按顺序确认：
+
+1. **出站组是否完整**：能看到 9 区域 + 28 业务组。  
+2. **DNS 是否生效**：国内域名走 `dns_direct`，国外域名走 `dns_proxy`。  
+3. **规则集下载是否成功**：`geosite-cn / geoip-cn / geolocation-!cn / category-ads-all`。  
+4. **典型业务是否命中**：
+   - ChatGPT 命中 `🤖 AI 服务`
+   - Binance 命中 `💰 加密货币`
+   - YouTube/Netflix 命中对应流媒体组
+   - 国内站点命中 `🏠 国内网站`
+
+---
+
+## 6. 常见问题
+
+### Q1：为什么不能像 Clash Party 一样“自动按节点名分类”？
+
+Clash Party 当前使用 JS 覆写引擎做节点名称分类；sing-box 原生 JSON 配置没有同等 JS 运行时。这个版本采用“**固定区域组 + 手工节点归位**”实现同语义替代，行为更稳定、可审计。
+
+### Q2：规则集下载失败怎么办？
+
+- 先测试 `fastly.jsdelivr.net` 连通性；
+- 若你所在网络对 CDN 有限制，可替换为你可访问的镜像地址；
+- 保持 `.srs` 二进制格式和 `format: binary` 一致。
+
+### Q3：想继续贴近 Clash Party 规则量（300+ provider）怎么办？
+
+可以继续扩展 `route.rule_set` 与 `route.rules`，将更多服务拆分成独立 rule-set。当前版本先保证“结构一致 + 主功能一致 + sing-box 官方格式兼容”。
+
+---
+
+## 7. 参考文档（官方）
+
+- sing-box Outbound（selector/urltest）  
+  https://sing-box.sagernet.org/configuration/outbound/
+- sing-box Selector  
+  https://sing-box.sagernet.org/configuration/outbound/selector/
+- sing-box URLTest  
+  https://sing-box.sagernet.org/configuration/outbound/urltest/
+- sing-box Route / Route Rule / Rule Action  
+  https://sing-box.sagernet.org/configuration/route/
+  https://sing-box.sagernet.org/configuration/route/rule/
+  https://sing-box.sagernet.org/configuration/route/rule_action/
+- sing-box Rule-set  
+  https://sing-box.sagernet.org/configuration/rule-set/
+- sing-box Cache File  
+  https://sing-box.sagernet.org/configuration/experimental/cache-file/
+


### PR DESCRIPTION
### Motivation
- Provide a sing-box native configuration that reproduces Clash Party v5.2.2 splitting semantics while staying compatible with sing-box official config model.  
- Replace Clash Party's JavaScript-based automatic node classification with explicit regional selectors because sing-box JSON has no JS runtime.  
- Ship a migration guide so users can map their existing proxies and rule-set sources to sing-box while keeping the same business/region semantics.

### Description
- Added `SingBox/singbox-smart.json` implementing DNS servers and rules, a `tun` inbound, `selector` + `urltest` outbounds for 9 regional groups and 28 business policy groups, `route.rule_set` remote `.srs` loaders, experimental `cache_file` settings, and placeholder proxy outbounds.  
- Added `SingBox/使用教程.md` (Chinese) documenting design decisions, migration steps, compatibility notes, node-replacement recommendations, first-run checks and troubleshooting.  
- Updated `README.md` to include the new `SingBox/` directory entry in the repository structure.

### Testing
- Validated the produced JSON with `python -m json.tool SingBox/singbox-smart.json`, which succeeded.  
- Attempted to probe remote `.srs` rule-set endpoints with `curl -I` to upstream raw URLs, which returned HTTP 403 from the current environment and is noted in the tutorial as a possible CDN/mirror accessibility issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b660b68c8330a9c58c830a66f00c)