### PR TITLE
Add SingBox support: generator, template, full config and usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Clash/
 │   ├── Clash Smart内核覆写脚本.js
 │   ├── 其他配置在UI里面填写
 │   └── 使用方法.md
+├── SingBox/
+│   ├── generate-singbox-full.js
+│   ├── singbox-smart.json
+│   ├── singbox-smart-full.json
+│   └── 使用教程.md
 ├── OpenClash/
 │   ├── openclash_custom_overwrite.sh
 │   ├── openclash_custom_overwrite_full.sh

--- a/SingBox/generate-singbox-full.js
+++ b/SingBox/generate-singbox-full.js
@@ -1,0 +1,116 @@
+const fs = require('fs');
+const vm = require('vm');
+
+const clashScript = fs.readFileSync('Clash Party/Clash Smart内核覆写脚本.js', 'utf8');
+const baseConfig = JSON.parse(fs.readFileSync('SingBox/singbox-smart.json', 'utf8'));
+
+const sandbox = { console };
+vm.createContext(sandbox);
+vm.runInContext(clashScript + '\nthis.__main = main;', sandbox);
+if (typeof sandbox.__main !== 'function') throw new Error('main() not found');
+
+function p(name) {
+  return { name, type: 'trojan', server: 'example.com', port: 443, password: 'x', tls: true };
+}
+
+const proxies = [
+  p('🇭🇰 HK-01'), p('🇭🇰 HK-02'),
+  p('🇹🇼 TW-01'),
+  p('🇯🇵 JP-01'), p('🇰🇷 KR-01'),
+  p('🇸🇬 SG-01'), p('印尼 Jakarta 01'),
+  p('🇺🇸 US-01'), p('🇺🇸 US-02'),
+  p('🇪🇺 DE-01'), p('🇨🇦 CA-01'),
+  p('🇿🇦 South Africa-01'),
+  p('🇨🇳 回国专线-01')
+];
+
+const clashConfig = { proxies, 'proxy-groups': [], rules: [] };
+const out = sandbox.__main(clashConfig);
+const providers = out['rule-providers'] || {};
+const rules = out.rules || [];
+
+function toSingRule(ruleText) {
+  if (typeof ruleText !== 'string') return null;
+  const parts = ruleText.split(',');
+  const type = parts[0];
+
+  if (type === 'RULE-SET') {
+    if (parts[2] === 'REJECT') return { rule_set: [parts[1]], action: 'reject' };
+    return { rule_set: [parts[1]], action: 'route', outbound: parts[2] };
+  }
+  if (type === 'DOMAIN-SUFFIX') {
+    return { domain_suffix: [parts[1]], action: 'route', outbound: parts[2] };
+  }
+  if (type === 'DOMAIN') {
+    return { domain: [parts[1]], action: 'route', outbound: parts[2] };
+  }
+  if (type === 'DOMAIN-KEYWORD') {
+    return { domain_keyword: [parts[1]], action: 'route', outbound: parts[2] };
+  }
+  if (type === 'IP-CIDR' || type === 'IP-CIDR6' || type === 'SRC-IP-CIDR') {
+    return { ip_cidr: [parts[1]], action: 'route', outbound: parts[2] };
+  }
+  if (type === 'GEOIP') {
+    if (parts[1] === 'private') return { ip_is_private: true, action: 'route', outbound: parts[2] };
+    return { geoip: [parts[1]], action: 'route', outbound: parts[2] };
+  }
+  if (type === 'PROCESS-NAME') {
+    return { process_name: [parts[1]], action: 'route', outbound: parts[2] };
+  }
+  if (type === 'DST-PORT') {
+    const port = Number(parts[1]);
+    if (parts[2] === 'REJECT') return { port: Number.isFinite(port) ? [port] : [parts[1]], action: 'reject' };
+    return { port: Number.isFinite(port) ? [port] : [parts[1]], action: 'route', outbound: parts[2] };
+  }
+  if (type === 'GEOSITE') {
+    const tag = `geosite-${parts[1]}`;
+    if (parts[2] === 'REJECT') return { rule_set: [tag], action: 'reject' };
+    return { rule_set: [tag], action: 'route', outbound: parts[2] };
+  }
+  if (type === 'NETWORK') {
+    return { network: parts[1], action: 'route', outbound: parts[2] };
+  }
+  if (type === 'MATCH') {
+    return { action: 'route', outbound: parts[1] };
+  }
+  return null;
+}
+
+function toSrsUrl(url) {
+  if (!url) return '';
+  if (url.endsWith('.srs')) return url;
+  return url.replace(/\.mrs$/i, '.srs').replace(/\.yaml$/i, '.srs').replace(/\.list$/i, '.srs').replace(/\.txt$/i, '.srs');
+}
+
+const ruleSet = Object.entries(providers).map(([tag, info]) => ({
+  type: 'remote',
+  tag,
+  format: 'binary',
+  url: toSrsUrl(info.url),
+  download_detour: '🌍 全球节点',
+  update_interval: '1d'
+}));
+
+const convertedRules = rules.map(toSingRule).filter(Boolean);
+
+const extraGeoSiteTags = Array.from(new Set(
+  rules
+    .map((r) => String(r).split(','))
+    .filter((p) => p[0] === 'GEOSITE' && p[1])
+    .map((p) => `geosite-${p[1]}`)
+)).map((tag) => ({
+  type: 'remote',
+  tag,
+  format: 'binary',
+  url: `https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/${tag.replace('geosite-', '')}.srs`,
+  download_detour: '🌍 全球节点',
+  update_interval: '1d'
+}));
+
+baseConfig.route.rule_set = [...ruleSet, ...extraGeoSiteTags];
+baseConfig.route.rules = convertedRules;
+baseConfig.route.final = '🐟 漏网之鱼';
+
+fs.writeFileSync('SingBox/singbox-smart-full.json', JSON.stringify(baseConfig, null, 2) + '\n');
+
+console.log(`providers=${ruleSet.length} rules=${convertedRules.length}`);

--- a/SingBox/singbox-smart-full.json
+++ b/SingBox/singbox-smart-full.json
@@ -1,0 +1,10555 @@
+{
+  "log": {
+    "level": "info",
+    "timestamp": true
+  },
+  "experimental": {
+    "cache_file": {
+      "enabled": true,
+      "path": "cache.db",
+      "store_fakeip": true,
+      "store_rdrc": true
+    }
+  },
+  "dns": {
+    "servers": [
+      {
+        "tag": "dns_direct",
+        "address": "https://223.5.5.5/dns-query",
+        "detour": "direct"
+      },
+      {
+        "tag": "dns_proxy",
+        "address": "https://1.1.1.1/dns-query",
+        "detour": "🌍 全球节点"
+      },
+      {
+        "tag": "dns_block",
+        "address": "rcode://success"
+      }
+    ],
+    "rules": [
+      {
+        "rule_set": [
+          "geosite-cn"
+        ],
+        "action": "route",
+        "server": "dns_direct"
+      },
+      {
+        "rule_set": [
+          "geosite-category-ads-all"
+        ],
+        "action": "route",
+        "server": "dns_block"
+      }
+    ],
+    "final": "dns_proxy",
+    "strategy": "prefer_ipv4"
+  },
+  "inbounds": [
+    {
+      "type": "tun",
+      "tag": "tun-in",
+      "address": [
+        "172.19.0.1/30"
+      ],
+      "mtu": 9000,
+      "auto_route": true,
+      "strict_route": true,
+      "sniff": true,
+      "sniff_override_destination": true,
+      "stack": "mixed"
+    }
+  ],
+  "outbounds": [
+    {
+      "type": "selector",
+      "tag": "🚀 节点选择",
+      "outbounds": [
+        "🌍 全球节点",
+        "DIRECT",
+        "🚫 拦截"
+      ],
+      "default": "🌍 全球节点"
+    },
+    {
+      "type": "urltest",
+      "tag": "🌍 全球节点",
+      "outbounds": [
+        "🇭🇰 香港节点",
+        "🇹🇼 台湾节点",
+        "🇯🇵 日韩节点",
+        "🌏 亚太节点",
+        "🇺🇸 美国节点",
+        "🇪🇺 欧洲节点",
+        "🌎 美洲节点",
+        "🌍 非洲节点"
+      ],
+      "interval": "3m",
+      "tolerance": 50
+    },
+    {
+      "type": "selector",
+      "tag": "🇭🇰 香港节点",
+      "outbounds": [
+        "proxy-hk-1",
+        "proxy-hk-2",
+        "DIRECT"
+      ],
+      "default": "proxy-hk-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇹🇼 台湾节点",
+      "outbounds": [
+        "proxy-tw-1",
+        "DIRECT"
+      ],
+      "default": "proxy-tw-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇯🇵 日韩节点",
+      "outbounds": [
+        "proxy-jp-1",
+        "proxy-kr-1",
+        "DIRECT"
+      ],
+      "default": "proxy-jp-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🌏 亚太节点",
+      "outbounds": [
+        "proxy-sg-1",
+        "proxy-id-1",
+        "DIRECT"
+      ],
+      "default": "proxy-sg-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇺🇸 美国节点",
+      "outbounds": [
+        "proxy-us-1",
+        "proxy-us-2",
+        "DIRECT"
+      ],
+      "default": "proxy-us-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇪🇺 欧洲节点",
+      "outbounds": [
+        "proxy-eu-1",
+        "DIRECT"
+      ],
+      "default": "proxy-eu-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🌎 美洲节点",
+      "outbounds": [
+        "proxy-ca-1",
+        "proxy-us-1",
+        "DIRECT"
+      ],
+      "default": "proxy-ca-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🌍 非洲节点",
+      "outbounds": [
+        "proxy-af-1",
+        "DIRECT"
+      ],
+      "default": "proxy-af-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🤖 AI 服务",
+      "outbounds": [
+        "🇺🇸 美国节点",
+        "🌍 全球节点",
+        "🇯🇵 日韩节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "💰 加密货币",
+      "outbounds": [
+        "🇭🇰 香港节点",
+        "🌍 全球节点",
+        "🇺🇸 美国节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🏦 金融支付",
+      "outbounds": [
+        "DIRECT",
+        "🇭🇰 香港节点",
+        "🇯🇵 日韩节点",
+        "🌍 全球节点"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "📧 邮件服务",
+      "outbounds": [
+        "🇯🇵 日韩节点",
+        "🌍 全球节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "💬 即时通讯",
+      "outbounds": [
+        "🇭🇰 香港节点",
+        "🇯🇵 日韩节点",
+        "🌍 全球节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "📱 社交媒体",
+      "outbounds": [
+        "🇯🇵 日韩节点",
+        "🌍 全球节点",
+        "🇺🇸 美国节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🧑‍💼 会议协作",
+      "outbounds": [
+        "🇯🇵 日韩节点",
+        "🌍 全球节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "📺 国内流媒体",
+      "outbounds": [
+        "DIRECT",
+        "🇭🇰 香港节点",
+        "🌍 全球节点"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "📺 东南亚流媒体",
+      "outbounds": [
+        "🌏 亚太节点",
+        "🌍 全球节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🇺🇸 美国流媒体",
+      "outbounds": [
+        "🇺🇸 美国节点",
+        "🌍 全球节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🇭🇰 香港流媒体",
+      "outbounds": [
+        "🇭🇰 香港节点",
+        "🌍 全球节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🇹🇼 台湾流媒体",
+      "outbounds": [
+        "🇹🇼 台湾节点",
+        "🌍 全球节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🇯🇵 日韩流媒体",
+      "outbounds": [
+        "🇯🇵 日韩节点",
+        "🌍 全球节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🇪🇺 欧洲流媒体",
+      "outbounds": [
+        "🇪🇺 欧洲节点",
+        "🌍 全球节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🕹️ 国内游戏",
+      "outbounds": [
+        "DIRECT",
+        "🇭🇰 香港节点",
+        "🌍 全球节点"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🎮 国外游戏",
+      "outbounds": [
+        "🇯🇵 日韩节点",
+        "🇭🇰 香港节点",
+        "🌍 全球节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🔍 搜索引擎",
+      "outbounds": [
+        "🌍 全球节点",
+        "🇯🇵 日韩节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "📟 开发者服务",
+      "outbounds": [
+        "🌍 全球节点",
+        "🇺🇸 美国节点",
+        "🇯🇵 日韩节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "Ⓜ️ 微软服务",
+      "outbounds": [
+        "🌍 全球节点",
+        "🇯🇵 日韩节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🍎 苹果服务",
+      "outbounds": [
+        "DIRECT",
+        "🇭🇰 香港节点",
+        "🌍 全球节点"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "📥 下载更新",
+      "outbounds": [
+        "DIRECT",
+        "🌍 全球节点",
+        "🇭🇰 香港节点"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "☁️ 云与CDN",
+      "outbounds": [
+        "🌍 全球节点",
+        "DIRECT",
+        "🇺🇸 美国节点"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🛰️ BT/PT Tracker",
+      "outbounds": [
+        "🚫 拦截",
+        "DIRECT",
+        "🌍 全球节点",
+        "🇭🇰 香港节点"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🏠 国内网站",
+      "outbounds": [
+        "DIRECT",
+        "🇭🇰 香港节点",
+        "🌍 全球节点"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🚫 受限网站",
+      "outbounds": [
+        "🌍 全球节点",
+        "🇺🇸 美国节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🌐 国外网站",
+      "outbounds": [
+        "🌍 全球节点",
+        "🇯🇵 日韩节点",
+        "🇺🇸 美国节点",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🐟 漏网之鱼",
+      "outbounds": [
+        "🌍 全球节点",
+        "DIRECT",
+        "🇭🇰 香港节点"
+      ]
+    },
+    {
+      "type": "selector",
+      "tag": "🛑 广告拦截",
+      "outbounds": [
+        "🚫 拦截",
+        "DIRECT"
+      ]
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-hk-1",
+      "server": "example-hk-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-hk-1.com"
+      }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-hk-2",
+      "server": "example-hk-2.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-hk-2.com"
+      }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-tw-1",
+      "server": "example-tw-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-tw-1.com"
+      }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-jp-1",
+      "server": "example-jp-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-jp-1.com"
+      }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-kr-1",
+      "server": "example-kr-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-kr-1.com"
+      }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-sg-1",
+      "server": "example-sg-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-sg-1.com"
+      }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-id-1",
+      "server": "example-id-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-id-1.com"
+      }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-us-1",
+      "server": "example-us-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-us-1.com"
+      }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-us-2",
+      "server": "example-us-2.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-us-2.com"
+      }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-eu-1",
+      "server": "example-eu-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-eu-1.com"
+      }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-ca-1",
+      "server": "example-ca-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-ca-1.com"
+      }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-af-1",
+      "server": "example-af-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": {
+        "enabled": true,
+        "server_name": "example-af-1.com"
+      }
+    },
+    {
+      "type": "direct",
+      "tag": "DIRECT"
+    },
+    {
+      "type": "block",
+      "tag": "🚫 拦截"
+    }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "final": "🐟 漏网之鱼",
+    "rule_set": [
+      {
+        "type": "remote",
+        "tag": "56",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/56/56.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "anti-ad",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/DustinWin/ruleset_geodata@mihomo-ruleset/ads.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "openai",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/openai.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "claude",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Claude/Claude.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "gemini",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Gemini/Gemini.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "copilot",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Copilot/Copilot.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cryptocurrency",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Cryptocurrency/Cryptocurrency.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "telegram",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/telegram.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "telegram-ip",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/telegram.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "discord",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Discord/Discord.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "line",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Line/Line.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "whatsapp",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Whatsapp/Whatsapp.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "kakaotalk",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/KakaoTalk/KakaoTalk.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "twitter",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/twitter.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "twitter-ip",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/twitter.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "tiktok",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/tiktok.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "reddit",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Reddit/Reddit.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "facebook",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Facebook/Facebook.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "instagram",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Instagram/Instagram.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "snapchat",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Snap/Snap.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "pinterest",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Pinterest/Pinterest.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "linkedin",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/LinkedIn/LinkedIn.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "facebook-ip",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/facebook.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "slack",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Slack/Slack.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "zoom",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/ACL4SSR/ACL4SSR@master/Clash/Providers/Ruleset/Zoom.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "teams",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Teams/Teams.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "google",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/google.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "google-ip",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/google.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "bing",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Bing/Bing.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "googlesearch",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GoogleSearch/GoogleSearch.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "youtube",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/youtube.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "netflix",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/netflix.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "netflix-ip",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/netflix.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "spotify",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/spotify.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "disney",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Disney/Disney.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "hbo",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/HBO/HBO.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "primevideo",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/PrimeVideo/PrimeVideo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "hulu",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Hulu/Hulu.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "paramount",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/ParamountPlus/ParamountPlus.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "amazon",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Amazon/Amazon.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "peacock",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Peacock/Peacock.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "twitch",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Twitch/Twitch.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "bahamut",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/bahamut.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "kktv",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/KKTV/KKTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "abema",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/abema.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "dazn",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/DAZN/DAZN.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "bbc",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/BBC/BBC.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "steam",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Steam/Steam.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "epic",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Epic/Epic.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "playstation",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/PlayStation/PlayStation.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "nintendo",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Nintendo/Nintendo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "xbox",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Xbox/Xbox.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "ea",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/EA/EA.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "blizzard",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Blizzard/Blizzard.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "microsoft",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/microsoft.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "onedrive",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/onedrive.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "apple",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/apple.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "icloud",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/icloud.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "applemusic",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AppleMusic/AppleMusic.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "github",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/github.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "docker",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Docker/Docker.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "gitlab",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GitLab/GitLab.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "paypal",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/PayPal/PayPal.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cloudflare-ip",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cloudflare.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cloudfront-ip",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cloudfront.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "fastly-ip",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/fastly.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "systemota",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/SystemOTA/SystemOTA.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "viu",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/ViuTV/ViuTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "bilibili",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/bilibili.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "biliintl",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/biliintl.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cn",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/cn.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cn-ip",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geoip/cn.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "proxy",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/geolocation-!cn.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "advertising",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Advertising/Advertising.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "advertisingmitv",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AdvertisingMiTV/AdvertisingMiTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "adobeactivation",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AdobeActivation/AdobeActivation.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "blockhttpdns",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/BlockHttpDNS/BlockHttpDNS.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "domob",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Domob/Domob.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "hijacking",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Hijacking/Hijacking.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "jiguangtuisong",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/JiGuangTuiSong/JiGuangTuiSong.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "marketing",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Marketing/Marketing.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "miuiprivacy",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/MIUIPrivacy/MIUIPrivacy.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "privacy",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Privacy/Privacy.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "youmengchuangxiang",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/YouMengChuangXiang/YouMengChuangXiang.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "civitai",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Civitai/Civitai.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "binance",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Binance/Binance.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "stripe",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Stripe/Stripe.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "visa",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/VISA/VISA.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "tigerfintech",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TigerFintech/TigerFintech.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "mail",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Mail/Mail.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "mailru",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Mailru/Mailru.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "protonmail",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Protonmail/Protonmail.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "spark",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Spark/Spark.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "telegramnl",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TelegramNL/TelegramNL.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "telegramsg",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TelegramSG/TelegramSG.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "telegramus",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TelegramUS/TelegramUS.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "zalo",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Zalo/Zalo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "googlevoice",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GoogleVoice/GoogleVoice.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "italkbb",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/iTalkBB/iTalkBB.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "tumblr",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Tumblr/Tumblr.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "clubhouse",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Clubhouse/Clubhouse.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "clubhouseip",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/ClubhouseIP/ClubhouseIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "pixiv",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Pixiv/Pixiv.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "truthsocial",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TruthSocial/TruthSocial.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "vk",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/VK/VK.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "blued",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Blued/Blued.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "disqus",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Disqus/Disqus.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "imgur",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Imgur/Imgur.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "pixnet",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Pixnet/Pixnet.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "atlassian",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Atlassian/Atlassian.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "notion",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Notion/Notion.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "teamviewer",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TeamViewer/TeamViewer.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "zoho",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Zoho/Zoho.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "salesforce",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Salesforce/Salesforce.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "zendesk",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Zendesk/Zendesk.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "intercom",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Intercom/Intercom.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "remotedesktop",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/RemoteDesktop/RemoteDesktop.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "iqiyi",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/iQIYI/iQIYI.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "youku",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Youku/Youku.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "tencentvideo",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TencentVideo/TencentVideo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "douyin",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/DouYin/DouYin.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "bytedance",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/ByteDance/ByteDance.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "kuaishou",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/KuaiShou/KuaiShou.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "weibo",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Weibo/Weibo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "xiaohongshu",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/XiaoHongShu/XiaoHongShu.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "neteasemusic",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/NetEaseMusic/NetEaseMusic.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "kugoukuwo",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/KugouKuwo/KugouKuwo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "sohu",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Sohu/Sohu.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acfun",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AcFun/AcFun.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "douyu",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Douyu/Douyu.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "huya",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/HuYa/HuYa.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "himalaya",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Himalaya/Himalaya.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cctv",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/CCTV/CCTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "hunantv",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/HunanTV/HunanTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "pptv",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/PPTV/PPTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "funshion",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Funshion/Funshion.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "letv",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/LeTV/LeTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "taihemusic",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TaiheMusic/TaiheMusic.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "kukemusic",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/KuKeMusic/KuKeMusic.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "hibymusic",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/HibyMusic/HibyMusic.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "miwu",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/MiWu/MiWu.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "migu",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Migu/Migu.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "iptvmainland",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/IPTVMainland/IPTVMainland.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "iptvother",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/IPTVOther/IPTVOther.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cibn",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/CIBN/CIBN.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "bestv",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/BesTV/BesTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "huashutv",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/HuaShuTV/HuaShuTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "smg",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/SMG/SMG.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "hwtv",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/HWTV/HWTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "nivodtv",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/NivodTV/NivodTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "olevod",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Olevod/Olevod.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "dandanzan",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/DanDanZan/DanDanZan.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "dandanplay",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Dandanplay/Dandanplay.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "tiantiankankan",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TianTianKanKan/TianTianKanKan.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "yizhibo",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/YiZhiBo/YiZhiBo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "ku6",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Ku6/Ku6.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cetv",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/CETV/CETV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "yyets",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/YYeTs/YYeTs.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "asianmedia",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AsianMedia/AsianMedia.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "iqiyiintl",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/iQIYIIntl/iQIYIIntl.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "joox",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/JOOX/JOOX.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "mewatch",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/MeWatch/MeWatch.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "viki",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Viki/Viki.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "wetv",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/WeTV/WeTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "zee",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Zee/Zee.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cbs",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/CBS/CBS.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "nbc",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/NBC/NBC.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "pbs",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/PBS/PBS.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "attwatchtv",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/ATTWatchTV/ATTWatchTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "fox",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Fox/Fox.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "fubotv",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/FuboTV/FuboTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "sling",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Sling/Sling.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "soundcloud",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/SoundCloud/SoundCloud.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "pandora",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Pandora/Pandora.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "pandoratv",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/PandoraTV/PandoraTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "tidal",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TIDAL/TIDAL.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "vimeo",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Vimeo/Vimeo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "dailymotion",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Dailymotion/Dailymotion.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "deezer",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Deezer/Deezer.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "discoveryplus",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/DiscoveryPlus/DiscoveryPlus.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "overcast",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Overcast/Overcast.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "americasvoice",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Americasvoice/Americasvoice.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cake",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Cake/Cake.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "dood",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Dood/Dood.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "ehgallery",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/EHGallery/EHGallery.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "lastfm",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/LastFM/LastFM.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "emby",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Emby/Emby.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "mytvsuper",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/myTVSUPER/myTVSUPER.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "tvb",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TVB/TVB.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "encoretvb",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/EncoreTVB/EncoreTVB.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "nowe",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/NowE/NowE.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "rthk",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/RTHK/RTHK.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cabletv",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/CableTV/CableTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "moov",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/MOOV/MOOV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "litv",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/LiTV/LiTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "friday",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/friDay/friDay.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "hamivideo",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/HamiVideo/HamiVideo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "linetv",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/LineTV/LineTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "vidoltv",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/VidolTV/VidolTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "taiwangood",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TaiWanGood/TaiWanGood.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cht",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/CHT/CHT.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "dmm",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/DMM/DMM.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "tver",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TVer/TVer.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "niconico",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Niconico/Niconico.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "rakuten",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Rakuten/Rakuten.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "japonx",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Japonx/Japonx.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "nikkei",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Nikkei/Nikkei.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "itv",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/ITV/ITV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "all4",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/All4/All4.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "my5",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/My5/My5.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "skygo",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/SkyGO/SkyGO.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "britboxuk",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/BritboxUK/BritboxUK.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "londonreal",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/LondonReal/LondonReal.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "qobuz",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Qobuz/Qobuz.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "steamcn",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/SteamCN/SteamCN.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "wanmeishijie",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/WanMeiShiJie/WanMeiShiJie.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "wankahuanju",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/WanKaHuanJu/WanKaHuanJu.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "majsoul",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Majsoul/Majsoul.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "rockstar",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Rockstar/Rockstar.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "riot",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Riot/Riot.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "gog",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Gog/Gog.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "supercell",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Supercell/Supercell.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "garena",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Garena/Garena.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "hoyoverse",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/HoYoverse/HoYoverse.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "ubi",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/UBI/UBI.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "wildrift",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/WildRift/WildRift.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "sony",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Sony/Sony.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "yandex",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Yandex/Yandex.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "googledrive",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GoogleDrive/GoogleDrive.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "googleearth",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GoogleEarth/GoogleEarth.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "naver",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Naver/Naver.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "scholar",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Scholar/Scholar.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "developer",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Developer/Developer.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "python",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Python/Python.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "gitbook",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GitBook/GitBook.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "jfrog",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Jfrog/Jfrog.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "sublimetext",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/SublimeText/SublimeText.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "wordpress",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Wordpress/Wordpress.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "wix",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/WIX/WIX.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cisco",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Cisco/Cisco.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "ibm",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/IBM/IBM.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "oracle",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Oracle/Oracle.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "unity",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Unity/Unity.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "microsoftedge",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/MicrosoftEdge/MicrosoftEdge.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "appstore",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AppStore/AppStore.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "appletv",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AppleTV/AppleTV.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "applenews",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AppleNews/AppleNews.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "appledev",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AppleDev/AppleDev.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "appleproxy",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AppleProxy/AppleProxy.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "siri",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Siri/Siri.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "testflight",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/TestFlight/TestFlight.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "applefirmware",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/AppleFirmware/AppleFirmware.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "findmy",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/FindMy/FindMy.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "download",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Download/Download.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "ubuntu",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Ubuntu/Ubuntu.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "mozilla",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Mozilla/Mozilla.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "apkpure",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Apkpure/Apkpure.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "android",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Android/Android.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "googlefcm",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GoogleFCM/GoogleFCM.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "intel",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Intel/Intel.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "nvidia",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Nvidia/Nvidia.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "dell",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Dell/Dell.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "hp",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/HP/HP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "canon",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Canon/Canon.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "lg",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/LG/LG.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cloudflare",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Cloudflare/Cloudflare.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "akamai",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Akamai/Akamai.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "digicert",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/DigiCert/DigiCert.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "globalsign",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/GlobalSign/GlobalSign.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "sectigo",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Sectigo/Sectigo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "brightcove",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/BrightCove/BrightCove.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "jwplayer",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Jwplayer/Jwplayer.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "privatetracker",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/PrivateTracker/PrivateTracker.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "cnn",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/CNN/CNN.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "nytimes",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/NYTimes/NYTimes.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "bloomberg",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Bloomberg/Bloomberg.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "ebay",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/eBay/eBay.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "nike",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Nike/Nike.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "adobe",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Adobe/Adobe.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "samsung",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Samsung/Samsung.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "tesla",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Tesla/Tesla.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "dropbox",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Dropbox/Dropbox.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "mega",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/MEGA/MEGA.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "wikipedia",
+        "format": "binary",
+        "url": "https://cdn.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Wikipedia/Wikipedia.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "duolingo",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Clash/Duolingo/Duolingo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "sukka-phishing",
+        "format": "binary",
+        "url": "https://ruleset.skk.moe/Clash/domainset/reject_phishing.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "hagezi-tif",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MiHomoer/MiHomo-Hagezi@release/HageziUltimate.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "szkane-ai",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/AiDomain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "szkane-ciciai",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/CiciAi.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "szkane-web3",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Web3.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "szkane-developer",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Developer.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "szkane-khan",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Khan.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "szkane-edutools",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Edutools.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "szkane-uk",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/UK.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "szkane-bilihmt",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/BilibiliHMT.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "szkane-netflixip",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/NetflixIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "szkane-proxygfw",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/ProxyGFWlist.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "loyalsoldier-gfw",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/gfw.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "loyalsoldier-greatfire",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@meta/geo/geosite/greatfire.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-appleai",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/AppleAI/AppleAI.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-grok",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Grok/Grok.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-gemini",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Gemini/Gemini.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-copilot",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Copilot/Copilot.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-bank-us",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankUS.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-bank-uk",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankUK.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-bank-hk",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankHK.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-bank-sg",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankSG.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-bank-jp",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankJP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-bank-au",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankAU.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-bank-ca",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankCA.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-bank-de",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankDE.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-bank-nl",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankNL.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-bank-fr",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankFR.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-vf-paypal",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Paypal.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-vf-wise",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Wise.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-vf-monzo",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Monzo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-vf-revolut",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Revolut.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-applenews",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/AppleNews/AppleNews.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-apple",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Apple/Apple.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-microsoftapps",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/MicrosoftAPPs/MicrosoftAPPs.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-signal",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Signal/Signal.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-rustdesk",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/RustDesk/RustDesk.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-parsec",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Parsec/Parsec.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-alipan",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Alipan/Alipan.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-baidunetdisk",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/BaiduNetDisk/BaiduNetDisk.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-weiyun",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/WeiYun/WeiYun.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-kwai",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Kwai/Kwai.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-fl-bilibili",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationBiliBili.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-fl-douyin",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationDouYin.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-fl-kuaishou",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationKuaiShou.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-fl-xiaohongshu",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationXiaoHongShu.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-fl-xigua",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationXiGua.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-fl-weibo",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationWeiBo.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-fl-zhihu",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationZhiHu.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-fl-tieba",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationTieBa.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-fl-douban",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationDouBan.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-fl-xianyu",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationXianYu.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-hijackingplus",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/HijackingPlus/HijackingPlus.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-blockhttpdnsplus",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/BlockHttpDNSPlus/BlockHttpDNSPlus.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-prerepaireasyprivacy",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/PreRepairEasyPrivacy/PreRepairEasyPrivacy.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-unsupportvpn",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/UnsupportVPN/UnsupportVPN.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-macappupgrade",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/MacAppUpgrade/MacAppUpgrade.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-fastly",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Fastly/Fastly.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geositecn",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeositeCN/GeositeCN.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-chinamax",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/ChinaMax/ChinaMax.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-china",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/China/China.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-homeip-us",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/HomeIP/HomeIPUS.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-homeip-jp",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/HomeIP/HomeIPJP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-waybackmachine",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/WaybackMachine/WaybackMachine.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-pornhub",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Pornhub/Pornhub.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-aqara-cn",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Aqara/AqaraCN.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-aqara-global",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Aqara/AqaraGlobal.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-emuleserver",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/eMuleServer/eMuleServer.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-asia-east",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_East_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-asia-eastsouth",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_EastSouth_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-asia-south",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_South_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-asia-central",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_Central_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-asia-west",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_West_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-asia-china",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_China_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-america-north",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_America_North_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-america-south",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_America_South_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-europe-west",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Europe_West_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-europe-east",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Europe_East_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-oceania",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Oceania_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-antarctica",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Antarctica_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-africa-north",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_North_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-africa-south",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_South_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-africa-west",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_West_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-africa-east",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_East_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-d-africa-central",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_Central_ccTLD_Domain.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-asia-east",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Asia_East_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-asia-eastsouth",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Asia_EastSouth_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-asia-south",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Asia_South_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-asia-central",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Asia_Central_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-asia-west",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Asia_West_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-asia-china",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Asia_China_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-america-north",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_America_North_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-america-south",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_America_South_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-europe-west",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Europe_West_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-europe-east",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Europe_East_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-oceania",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Oceania_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-antarctica",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Antarctica_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-africa-north",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Africa_North_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-africa-south",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Africa_South_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-africa-west",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Africa_West_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-africa-east",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Africa_East_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "acc-geo-ip-africa-central",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_IP/GeoRouting_Africa_Central_GeoIP.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geosite-category-ads-all",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/category-ads-all.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geosite-private",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/private.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geosite-category-games",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/category-games.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geosite-category-dev",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/category-dev.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geosite-tracker",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/tracker.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geosite-gfw",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/gfw.srs",
+        "download_detour": "🌍 全球节点",
+        "update_interval": "1d"
+      }
+    ],
+    "rules": [
+      {
+        "rule_set": [
+          "anti-ad"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "sukka-phishing"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "hagezi-tif"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "acc-hijackingplus"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "acc-blockhttpdnsplus"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "acc-prerepaireasyprivacy"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "acc-unsupportvpn"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "geosite-category-ads-all"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "advertising"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "advertisingmitv"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "adobeactivation"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "blockhttpdns"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "domob"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "hijacking"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "jiguangtuisong"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "marketing"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "miuiprivacy"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "privacy"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": [
+          "youmengchuangxiang"
+        ],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "port": [
+          7680
+        ],
+        "action": "reject"
+      },
+      {
+        "rule_set": [
+          "geosite-private"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "ip_is_private": true,
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "ip_cidr": [
+          "172.90.1.130/32"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "WorkPro.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "GCUService.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "GCUBridge.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "CCUWinUI.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "HipsDaemon.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "gdphost.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "gehsender.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "GSCService.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "domain": [
+          "ip.cip.cc"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "gsupservice.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "gchsvc.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "port": [
+          26880
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "port": [
+          6540
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "port": [
+          33068
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "port": [
+          123
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "port": [
+          3478
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "port": [
+          3479
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "QQ.exe"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "process_name": [
+          "Weixin.exe"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "process_name": [
+          "WeChat.exe"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "domain_suffix": [
+          "chiphell.com"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "domain_suffix": [
+          "iwipwedabay.com"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "domain_suffix": [
+          "binance.vision"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "binance.com"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "binance.info"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "binance.cloud"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "binance.me"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "binance.org"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "binancefuture.com"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain": [
+          "dns.google"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain": [
+          "dns.google.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "youtube.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "youtu.be"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "googlevideo.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "ytimg.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "ggpht.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "youtube-nocookie.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "youtubekids.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "openai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "rule_set": [
+          "claude"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "rule_set": [
+          "gemini"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "rule_set": [
+          "copilot"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "perplexity.ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "mistral.ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "x.ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "grok.com"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "deepseek.com"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "domain_suffix": [
+          "huggingface.co"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "replicate.com"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "together.ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "cohere.ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "cohere.com"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "midjourney.com"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "stability.ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "anthropic.com"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "cursor.com"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "cursor.sh"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "v0.dev"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "vercel.ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "notebooklm.google"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "poe.com"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "character.ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "inflection.ai"
+        ],
+        "action": "route",
+        "outbound": "🚫 受限网站"
+      },
+      {
+        "domain_suffix": [
+          "pi.ai"
+        ],
+        "action": "route",
+        "outbound": "🚫 受限网站"
+      },
+      {
+        "domain_suffix": [
+          "suno.ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "suno.com"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "runway.ml"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "runwayml.com"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "openrouter.ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "fireworks.ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "modal.com"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "modal.run"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "runpod.io"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "rule_set": [
+          "civitai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "gmail.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "googlemail.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "mail.google.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "inbox.google.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "rule_set": [
+          "googlevoice"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "meet.google.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain": [
+          "meet.googleapis.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "dl.google.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "play.googleapis.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "android.clients.google.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "googlefcm"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "googlesearch"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "rule_set": [
+          "googledrive"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "rule_set": [
+          "googleearth"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "rule_set": [
+          "google"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "rule_set": [
+          "google-ip"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "rule_set": [
+          "szkane-ai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "rule_set": [
+          "szkane-ciciai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "rule_set": [
+          "acc-appleai"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "rule_set": [
+          "acc-grok"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "rule_set": [
+          "acc-gemini"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "do.dsp.mp.microsoft.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "acc-copilot"
+        ],
+        "action": "route",
+        "outbound": "🤖 AI 服务"
+      },
+      {
+        "domain_suffix": [
+          "tradingview.com"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "tvcdn.com"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "coinglass.com"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "hyperliquid.xyz"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "hyperliquid-testnet.xyz"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "rule_set": [
+          "cryptocurrency"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "eth.limo"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "domain_suffix": [
+          "glitternode.ru"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "rule_set": [
+          "binance"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "rule_set": [
+          "szkane-web3"
+        ],
+        "action": "route",
+        "outbound": "💰 加密货币"
+      },
+      {
+        "rule_set": [
+          "paypal"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "stripe.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "stripe.network"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "stripecdn.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "stripe.dev"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "wise.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "transferwise.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "revolut.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "revolut.me"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "braintreegateway.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "braintree-api.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "venmo.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "cash.app"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "squareup.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "square.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "adyen.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "checkout.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "klarna.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "afterpay.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "plaid.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "midtrans.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "gopay.co.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "ovo.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "dana.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "shopeepay.co.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "xendit.co"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "doku.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "stripe"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "visa"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "tigerfintech"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-bank-us"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-bank-uk"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-bank-hk"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-bank-sg"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-bank-jp"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-bank-au"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-bank-ca"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-bank-de"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-bank-nl"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-bank-fr"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-vf-paypal"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-vf-wise"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-vf-monzo"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "rule_set": [
+          "acc-vf-revolut"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain": [
+          "login.live.com"
+        ],
+        "action": "route",
+        "outbound": "Ⓜ️ 微软服务"
+      },
+      {
+        "domain": [
+          "g.live.com"
+        ],
+        "action": "route",
+        "outbound": "Ⓜ️ 微软服务"
+      },
+      {
+        "domain_suffix": [
+          "officeapps.live.com"
+        ],
+        "action": "route",
+        "outbound": "Ⓜ️ 微软服务"
+      },
+      {
+        "domain_suffix": [
+          "outlook.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "outlook.live.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "hotmail.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "mail.live.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "outlook.office365.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "outlook.office.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "mail.yahoo.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "ymail.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "protonmail.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "proton.me"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "pm.me"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "tutanota.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "tuta.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "mail.zoho.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "mail.zoho.eu"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "mail.zoho.in"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "mail.zoho.com.au"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "mail.zoho.jp"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain": [
+          "mail.me.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "fastmail.com"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "fastmail.fm"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "rule_set": [
+          "mail"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "rule_set": [
+          "mailru"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "rule_set": [
+          "protonmail"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "rule_set": [
+          "spark"
+        ],
+        "action": "route",
+        "outbound": "📧 邮件服务"
+      },
+      {
+        "domain_suffix": [
+          "mail.qq.com"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "domain_suffix": [
+          "mail.163.com"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "domain_suffix": [
+          "mail.126.com"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "domain_suffix": [
+          "mail.sina.com.cn"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "domain_suffix": [
+          "mail.aliyun.com"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "rule_set": [
+          "telegram"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "telegram-ip"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "discord"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "whatsapp"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "line"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "kakaotalk"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "skype.com"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "skypeecs.net"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "skypeforbusiness.com"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "sfbassets.com"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "lync.com"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "signal.org"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "whispersystems.org"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "signal.art"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "viber.com"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "viber.io"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "element.io"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "matrix.org"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "zalo.me"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "zalopay.vn"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "wire.com"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "threema.ch"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "telegramnl"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "telegramsg"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "telegramus"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "zalo"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "italkbb"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "acc-signal"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "domain_suffix": [
+          "icq.com"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "rule_set": [
+          "twitter"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "twitter-ip"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "tiktok"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "reddit"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "facebook"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "facebook-ip"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "instagram"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "snapchat"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "pinterest"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "linkedin"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "domain_suffix": [
+          "mastodon.social"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "domain_suffix": [
+          "joinmastodon.org"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "domain_suffix": [
+          "threads.net"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "domain_suffix": [
+          "bsky.app"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "domain_suffix": [
+          "bsky.social"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "domain_suffix": [
+          "tumblr.com"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "domain_suffix": [
+          "quora.com"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "domain_suffix": [
+          "medium.com"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "domain_suffix": [
+          "flickr.com"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "domain_suffix": [
+          "clubhouse.com"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "domain_suffix": [
+          "lemon8-app.com"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "tumblr"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "clubhouse"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "clubhouseip"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "pixiv"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "truthsocial"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "vk"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "blued"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "rule_set": [
+          "disqus"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "imgur"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "pixnet"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "rule_set": [
+          "zoom"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "slack"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "teams"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "webex.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "wbx2.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "ciscospark.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "notion.so"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "notion.site"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "figma.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "linear.app"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "atlassian.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "jira.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "trello.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "bitbucket.org"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "asana.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "monday.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "clickup.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "basecamp.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "airtable.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "miro.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "canva.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "coda.io"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "loom.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "larksuite.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "larkoffice.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "gotomeeting.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "logmein.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "goto.com"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "atlassian"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "notion"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "teamviewer"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "zoho"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "salesforce"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "zendesk"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "intercom"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "remotedesktop"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "acc-rustdesk"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "rule_set": [
+          "acc-parsec"
+        ],
+        "action": "route",
+        "outbound": "🧑‍💼 会议协作"
+      },
+      {
+        "domain_suffix": [
+          "feishu.cn"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "domain_suffix": [
+          "dingtalk.com"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "domain_suffix": [
+          "welink.huaweicloud.com"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "rule_set": [
+          "bilibili"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "iqiyi.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "iqiyipic.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "71.am"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "youku.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "ykimg.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "soku.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "v.qq.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "video.qq.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_keyword": [
+          "tencentvideo"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "mgtv.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "hitv.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "hunantv.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "douyin.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "douyinpic.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "douyinvod.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "ixigua.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "pstatp.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "snssdk.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "sohu.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "music.163.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "ntes53.netease.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "y.qq.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "music.qq.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "kugou.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "kuwo.cn"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "xiaohongshu.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "xhscdn.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "kuaishou.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "gifshow.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "weibo.com"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "weibo.cn"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain_suffix": [
+          "sinaimg.cn"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "iqiyi"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "youku"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "tencentvideo"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "douyin"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "bytedance"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "kuaishou"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "weibo"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "xiaohongshu"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "neteasemusic"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "kugoukuwo"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "sohu"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acfun"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "douyu"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "huya"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "himalaya"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "cctv"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "hunantv"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "pptv"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "funshion"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "letv"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "taihemusic"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "kukemusic"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "hibymusic"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "miwu"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "migu"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "iptvmainland"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "iptvother"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "cibn"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "bestv"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "huashutv"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "smg"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "hwtv"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "nivodtv"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "olevod"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "dandanzan"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "dandanplay"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "tiantiankankan"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "yizhibo"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "ku6"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "56"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "cetv"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "yyets"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-alipan"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-baidunetdisk"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-weiyun"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-fl-bilibili"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-fl-douyin"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-fl-kuaishou"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-fl-xiaohongshu"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-fl-xigua"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-fl-weibo"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-fl-zhihu"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-fl-tieba"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-fl-douban"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-fl-xianyu"
+        ],
+        "action": "route",
+        "outbound": "📺 国内流媒体"
+      },
+      {
+        "rule_set": [
+          "szkane-bilihmt"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "rule_set": [
+          "viu"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "wetv.vip"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "wetvinfo.com"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "iq.com"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "vidio.com"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "vidio.static6.com"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "rctiplus.com"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "visionplus.id"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "genflix.co.id"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "goplay.co.id"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "maxstream.tv"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "rule_set": [
+          "biliintl"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "viki.com"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "viki.io"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "iflix.com"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "catchplay.com"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "mewatch.sg"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "trueid.net"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "domain_suffix": [
+          "dimsum.my"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "rule_set": [
+          "asianmedia"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "rule_set": [
+          "iqiyiintl"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "rule_set": [
+          "joox"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "rule_set": [
+          "mewatch"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "rule_set": [
+          "viki"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "rule_set": [
+          "wetv"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "rule_set": [
+          "zee"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "rule_set": [
+          "acc-kwai"
+        ],
+        "action": "route",
+        "outbound": "📺 东南亚流媒体"
+      },
+      {
+        "rule_set": [
+          "youtube"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "netflix"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "netflix-ip"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "spotify"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "disney"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "hbo"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "primevideo"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "hulu"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "paramount"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "peacock"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "twitch"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "amazonaws.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "awsstatic.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "aws.amazon.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "elasticbeanstalk.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "amazon"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "crunchyroll.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "vrv.co"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "soundcloud.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "sndcdn.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "pandora.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "pluto.tv"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "tubi.tv"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "fubo.tv"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "discoveryplus.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "max.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "appletv.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "deezer.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "tidal.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "vimeo.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "dailymotion.com"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "cbs"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "nbc"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "pbs"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "attwatchtv"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "fox"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "fubotv"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "sling"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "soundcloud"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "pandora"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "pandoratv"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "tidal"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "vimeo"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "dailymotion"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "deezer"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "discoveryplus"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "overcast"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "americasvoice"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "cake"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "dood"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "lastfm"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "emby"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "rule_set": [
+          "szkane-netflixip"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "domain_suffix": [
+          "mytvsuper.com"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "domain_suffix": [
+          "mytv.com.hk"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "domain_suffix": [
+          "viu.com"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "domain_suffix": [
+          "viu.tv"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "domain_suffix": [
+          "hktv.com.hk"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "domain_suffix": [
+          "hktvmall.com"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "domain_suffix": [
+          "nowtv.com"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "domain_suffix": [
+          "nowe.com"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "domain_suffix": [
+          "rthk.hk"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "domain_suffix": [
+          "icable.com"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "domain_suffix": [
+          "cabletv.com.hk"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "domain_suffix": [
+          "hmvod.com.hk"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "rule_set": [
+          "mytvsuper"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "rule_set": [
+          "tvb"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "rule_set": [
+          "encoretvb"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "rule_set": [
+          "nowe"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "rule_set": [
+          "rthk"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "rule_set": [
+          "cabletv"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "rule_set": [
+          "moov"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
+      },
+      {
+        "rule_set": [
+          "bahamut"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "rule_set": [
+          "kktv"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "domain_suffix": [
+          "litv.tv"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "domain_suffix": [
+          "video.friday.tw"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "domain_suffix": [
+          "friday.tw"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "domain_suffix": [
+          "linetv.tw"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "domain_suffix": [
+          "elta.tv"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "domain_suffix": [
+          "mod.cht.com.tw"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "domain_suffix": [
+          "hamivideo.hinet.net"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "domain_suffix": [
+          "ofiii.com"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "domain_suffix": [
+          "pts.org.tw"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "domain_suffix": [
+          "4gtv.tv"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "rule_set": [
+          "litv"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "rule_set": [
+          "friday"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "rule_set": [
+          "hamivideo"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "rule_set": [
+          "linetv"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "rule_set": [
+          "vidoltv"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "rule_set": [
+          "taiwangood"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "rule_set": [
+          "cht"
+        ],
+        "action": "route",
+        "outbound": "🇹🇼 台湾流媒体"
+      },
+      {
+        "rule_set": [
+          "abema"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "rule_set": [
+          "dazn"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "tver.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "unext.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "video.unext.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "nhk.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "nhk.or.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "dmm.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "dmm.co.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "dtv.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "paravi.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "videomarket.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "fod.fujitv.co.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "hulu.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "happyon.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "gyao.yahoo.co.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "music.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "nicovideo.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "nicovideo.me"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "dmc.nico"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "radiko.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "lemino.docomo.ne.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "wowow.co.jp"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "wavve.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "tving.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "watcha.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "coupangplay.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "sbs.co.kr"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "kbs.co.kr"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "mbc.co.kr"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "jtbc.co.kr"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "tvn.cjenm.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "afreecatv.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "tv.naver.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "now.naver.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "vod.naver.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "navertv.naver.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "kakaotv.daum.net"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "domain_suffix": [
+          "navercorp.com"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "rule_set": [
+          "dmm"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "rule_set": [
+          "tver"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "rule_set": [
+          "niconico"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "rule_set": [
+          "rakuten"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "rule_set": [
+          "japonx"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "rule_set": [
+          "nikkei"
+        ],
+        "action": "route",
+        "outbound": "🇯🇵 日韩流媒体"
+      },
+      {
+        "rule_set": [
+          "bbc"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "itv.com"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "itvstatic.com"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "channel4.com"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "channel5.com"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "sky.com"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "nowtv.com.uk"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "britbox.com"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "canalplus.com"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "mycanal.fr"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "france.tv"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "tf1.fr"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "molotov.tv"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "arte.tv"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "joyn.de"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "zdf.de"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "ard.de"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "ardmediathek.de"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "rtlplus.com"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "raiplay.it"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "rtve.es"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "videoland.com"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "ruutu.fi"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "tv2.dk"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "svtplay.se"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "nrk.no"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "ivi.ru"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "kinopoisk.ru"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "okko.tv"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "more.tv"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "rule_set": [
+          "itv"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "rule_set": [
+          "all4"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "rule_set": [
+          "my5"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "rule_set": [
+          "skygo"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "rule_set": [
+          "britboxuk"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "rule_set": [
+          "londonreal"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "rule_set": [
+          "qobuz"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "rule_set": [
+          "szkane-uk"
+        ],
+        "action": "route",
+        "outbound": "🇪🇺 欧洲流媒体"
+      },
+      {
+        "domain_suffix": [
+          "mihoyo.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "miyoushe.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "yuanshen.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "bhsr.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "zenlesszonezero.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain": [
+          "game.163.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "gm.163.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "ds.163.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "nie.163.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "nie.netease.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "update.netease.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "netease.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "wegame.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "wegame.com.cn"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "perfect-world.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "wanmei.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "xd.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "taptap.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "taptap.io"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "papegames.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "hypergryph.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "gryphline.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "domain_suffix": [
+          "lilith.com"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "rule_set": [
+          "steamcn"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "rule_set": [
+          "wanmeishijie"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "rule_set": [
+          "wankahuanju"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "rule_set": [
+          "majsoul"
+        ],
+        "action": "route",
+        "outbound": "🕹️ 国内游戏"
+      },
+      {
+        "rule_set": [
+          "steam"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "epic"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "playstation"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "nintendo"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "xbox"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "ea"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "blizzard"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "geosite-category-games"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "ubisoft.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "ubi.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "riotgames.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "leagueoflegends.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "valorant.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "rockstargames.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "gog.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "gogalaxy.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "bethesda.net"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "supercell.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "garena.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "hoyoverse.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "domain_suffix": [
+          "hoyolab.com"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "rockstar"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "riot"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "gog"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "supercell"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "garena"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "hoyoverse"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "ubi"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "wildrift"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "sony"
+        ],
+        "action": "route",
+        "outbound": "🎮 国外游戏"
+      },
+      {
+        "rule_set": [
+          "bing"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "domain_suffix": [
+          "yahoo.com"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "domain_suffix": [
+          "yahoo.co.jp"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "domain_suffix": [
+          "duckduckgo.com"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "domain_suffix": [
+          "ddg.co"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "domain_suffix": [
+          "brave.com"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "domain_suffix": [
+          "yandex.com"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "domain_suffix": [
+          "yandex.ru"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "domain_suffix": [
+          "ecosia.org"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "domain_suffix": [
+          "startpage.com"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "domain_suffix": [
+          "you.com"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "domain_suffix": [
+          "search.naver.com"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "rule_set": [
+          "scholar"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "rule_set": [
+          "yandex"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "rule_set": [
+          "github"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "onedrive"
+        ],
+        "action": "route",
+        "outbound": "Ⓜ️ 微软服务"
+      },
+      {
+        "rule_set": [
+          "microsoft"
+        ],
+        "action": "route",
+        "outbound": "Ⓜ️ 微软服务"
+      },
+      {
+        "rule_set": [
+          "microsoftedge"
+        ],
+        "action": "route",
+        "outbound": "Ⓜ️ 微软服务"
+      },
+      {
+        "rule_set": [
+          "acc-microsoftapps"
+        ],
+        "action": "route",
+        "outbound": "Ⓜ️ 微软服务"
+      },
+      {
+        "rule_set": [
+          "applemusic"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "icloud"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "apple"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "appstore"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "appletv"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "applenews"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "appledev"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "appleproxy"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "siri"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "testflight"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "applefirmware"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "findmy"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "acc-applenews"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "acc-apple"
+        ],
+        "action": "route",
+        "outbound": "🍎 苹果服务"
+      },
+      {
+        "rule_set": [
+          "docker"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "gitlab"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "geosite-category-dev"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "npmjs.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "npmjs.org"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "yarnpkg.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "pypi.org"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "pythonhosted.org"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "crates.io"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "rubygems.org"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "packagist.org"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "maven.org"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "nuget.org"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "cocoapods.org"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "stackoverflow.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "stackexchange.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "sstatic.net"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "vercel.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "vercel.app"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "netlify.app"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "netlify.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "pages.dev"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "workers.dev"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain": [
+          "dash.cloudflare.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain": [
+          "api.cloudflare.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain": [
+          "developers.cloudflare.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain": [
+          "www.cloudflare.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "heroku.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "herokuapp.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "fly.io"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "railway.app"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "render.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "supabase.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "supabase.co"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "planetscale.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "neon.tech"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "digitalocean.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "vultr.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "linode.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "sentry.io"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "datadog.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "grafana.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "postman.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "jetbrains.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "hashicorp.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "terraform.io"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "domain_suffix": [
+          "vagrantup.com"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "developer"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "python"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "gitbook"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "jfrog"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "sublimetext"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "wordpress"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "wix"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "cisco"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "ibm"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "oracle"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "unity"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "szkane-developer"
+        ],
+        "action": "route",
+        "outbound": "📟 开发者服务"
+      },
+      {
+        "rule_set": [
+          "systemota"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "windowsupdate.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "update.microsoft.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "download.microsoft.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "delivery.mp.microsoft.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "dl.delivery.mp.microsoft.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "officecdn.microsoft.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "officecdn.microsoft.com.edgesuite.net"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "download.mozilla.org"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "archive.mozilla.org"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "releases.ubuntu.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "archive.ubuntu.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "security.ubuntu.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "mirrors.kernel.org"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "dl.fedoraproject.org"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "repo.anaconda.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "conda.anaconda.org"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "repo.continuum.io"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "sourceforge.net"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "fosshub.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "filehippo.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "softonic.com"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "gcr.io"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "ghcr.io"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "quay.io"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "domain_suffix": [
+          "registry.k8s.io"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "download"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "ubuntu"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "mozilla"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "apkpure"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "android"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "intel"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "nvidia"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "dell"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "hp"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "canon"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "lg"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "acc-macappupgrade"
+        ],
+        "action": "route",
+        "outbound": "📥 下载更新"
+      },
+      {
+        "rule_set": [
+          "cloudflare-ip"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "rule_set": [
+          "cloudfront-ip"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "rule_set": [
+          "fastly-ip"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "akamai.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "akamaized.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "akamaihd.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "akamaiedge.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "akamaitechnologies.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "edgekey.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "edgesuite.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "cloudfront.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "fastly.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "fastlylb.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "kxcdn.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "stackpathdns.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "stackpathcdn.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "b-cdn.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "bunny.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "bunnycdn.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "cdn77.org"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "azureedge.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "azurefd.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "msecnd.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "jsdelivr.net"
+        ],
+        "action": "route",
+        "outbound": "🚫 受限网站"
+      },
+      {
+        "domain_suffix": [
+          "unpkg.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "cloudflare-dns.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "cloudflarestorage.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "r2.dev"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "ziffstatic.com"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "ucoz.ru"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "ucoz.net"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "rule_set": [
+          "cloudflare"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "rule_set": [
+          "akamai"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "rule_set": [
+          "digicert"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "rule_set": [
+          "globalsign"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "rule_set": [
+          "sectigo"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "rule_set": [
+          "brightcove"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "rule_set": [
+          "jwplayer"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "rule_set": [
+          "acc-fastly"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "letsencrypt.org"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "domain_suffix": [
+          "lencr.org"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "rule_set": [
+          "geosite-tracker"
+        ],
+        "action": "route",
+        "outbound": "🛰️ BT/PT Tracker"
+      },
+      {
+        "domain_suffix": [
+          "tracker.opentrackr.org"
+        ],
+        "action": "route",
+        "outbound": "🛰️ BT/PT Tracker"
+      },
+      {
+        "domain_suffix": [
+          "open.stealth.si"
+        ],
+        "action": "route",
+        "outbound": "🛰️ BT/PT Tracker"
+      },
+      {
+        "domain_suffix": [
+          "tracker.torrent.eu.org"
+        ],
+        "action": "route",
+        "outbound": "🛰️ BT/PT Tracker"
+      },
+      {
+        "domain_suffix": [
+          "exodus.desync.com"
+        ],
+        "action": "route",
+        "outbound": "🛰️ BT/PT Tracker"
+      },
+      {
+        "domain_suffix": [
+          "tracker.openbittorrent.com"
+        ],
+        "action": "route",
+        "outbound": "🛰️ BT/PT Tracker"
+      },
+      {
+        "domain_suffix": [
+          "tracker.publicbt.com"
+        ],
+        "action": "route",
+        "outbound": "🛰️ BT/PT Tracker"
+      },
+      {
+        "domain_suffix": [
+          "tracker.dler.org"
+        ],
+        "action": "route",
+        "outbound": "🛰️ BT/PT Tracker"
+      },
+      {
+        "rule_set": [
+          "privatetracker"
+        ],
+        "action": "route",
+        "outbound": "🛰️ BT/PT Tracker"
+      },
+      {
+        "rule_set": [
+          "acc-emuleserver"
+        ],
+        "action": "route",
+        "outbound": "🛰️ BT/PT Tracker"
+      },
+      {
+        "domain_suffix": [
+          "bca.co.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "klikbca.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "bni.co.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "bri.co.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "bankmandiri.co.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "danamon.co.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "permatabank.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "cimbniaga.co.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "btn.co.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "ocbcnisp.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "banksinarmas.com"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "idx.co.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "ksei.co.id"
+        ],
+        "action": "route",
+        "outbound": "🏦 金融支付"
+      },
+      {
+        "domain_suffix": [
+          "tokopedia.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "tokopedia.net"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "shopee.co.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "bukalapak.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "blibli.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "lazada.co.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "grab.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "gojek.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "gojek.co.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "traveloka.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "tiket.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "telkomsel.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "telkom.co.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "indosatooredoo.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "im3.co.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "xl.co.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "smartfren.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "tri.co.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "by.u.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "myrepublic.co.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "firstmedia.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "biznet.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "go.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "or.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "kompas.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "detik.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "tempo.co"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "cnnindonesia.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "cnbcindonesia.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "liputan6.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "tribunnews.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "kumparan.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "idntimes.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "gofood.co.id"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "grabfood.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "66tutup.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "geoip": [
+          "ID"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "163.com"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "domain_suffix": [
+          "126.com"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "domain_suffix": [
+          "126.net"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "domain_suffix": [
+          "jianguoyun.com"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "rule_set": [
+          "cn"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "rule_set": [
+          "cn-ip"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "domain_suffix": [
+          "alimama.com"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "domain_suffix": [
+          "zxtdjy.com"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "rule_set": [
+          "acc-geositecn"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "rule_set": [
+          "acc-chinamax"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "rule_set": [
+          "acc-china"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "rule_set": [
+          "acc-homeip-us"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-homeip-jp"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-aqara-cn"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "rule_set": [
+          "acc-aqara-global"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "geosite-gfw"
+        ],
+        "action": "route",
+        "outbound": "🚫 受限网站"
+      },
+      {
+        "rule_set": [
+          "loyalsoldier-gfw"
+        ],
+        "action": "route",
+        "outbound": "🚫 受限网站"
+      },
+      {
+        "rule_set": [
+          "loyalsoldier-greatfire"
+        ],
+        "action": "route",
+        "outbound": "🚫 受限网站"
+      },
+      {
+        "rule_set": [
+          "szkane-proxygfw"
+        ],
+        "action": "route",
+        "outbound": "🚫 受限网站"
+      },
+      {
+        "rule_set": [
+          "cnn"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "nytimes"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "bloomberg"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "ebay"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "nike"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "adobe"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "samsung"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "tesla"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "dropbox"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "mega"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "wikipedia"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "duolingo"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "proxy"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-waybackmachine"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-pornhub"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "szkane-khan"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "szkane-edutools"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "naver"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "ehgallery"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-asia-east"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-asia-eastsouth"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-asia-south"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-asia-central"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-asia-west"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-america-north"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-america-south"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-europe-west"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-europe-east"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-oceania"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-antarctica"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-africa-north"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-africa-south"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-africa-west"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-africa-east"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-africa-central"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-asia-east"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-asia-eastsouth"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-asia-south"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-asia-central"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-asia-west"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-america-north"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-america-south"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-europe-west"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-europe-east"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-oceania"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-antarctica"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-africa-north"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-africa-south"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-africa-west"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-africa-east"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-africa-central"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-d-asia-china"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "rule_set": [
+          "acc-geo-ip-asia-china"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "domain_suffix": [
+          "archive.org"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "udemy.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "udemycdn.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "grammarly.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "grammarly.io"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "jetbrains.net"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "theguardian.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "guardianapis.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "box.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "boxcdn.net"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "domain_suffix": [
+          "noip.com"
+        ],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      },
+      {
+        "geoip": [
+          "cloudflare"
+        ],
+        "action": "route",
+        "outbound": "☁️ 云与CDN"
+      },
+      {
+        "geoip": [
+          "telegram"
+        ],
+        "action": "route",
+        "outbound": "💬 即时通讯"
+      },
+      {
+        "geoip": [
+          "netflix"
+        ],
+        "action": "route",
+        "outbound": "🇺🇸 美国流媒体"
+      },
+      {
+        "geoip": [
+          "facebook"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "geoip": [
+          "twitter"
+        ],
+        "action": "route",
+        "outbound": "📱 社交媒体"
+      },
+      {
+        "geoip": [
+          "google"
+        ],
+        "action": "route",
+        "outbound": "🔍 搜索引擎"
+      },
+      {
+        "geoip": [
+          "CN"
+        ],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "action": "route",
+        "outbound": "🐟 漏网之鱼"
+      }
+    ]
+  }
+}

--- a/SingBox/singbox-smart.json
+++ b/SingBox/singbox-smart.json
@@ -1,0 +1,379 @@
+{
+  "log": {
+    "level": "info",
+    "timestamp": true
+  },
+  "experimental": {
+    "cache_file": {
+      "enabled": true,
+      "path": "cache.db",
+      "store_fakeip": true,
+      "store_rdrc": true
+    }
+  },
+  "dns": {
+    "servers": [
+      {
+        "tag": "dns_direct",
+        "address": "https://223.5.5.5/dns-query",
+        "detour": "direct"
+      },
+      {
+        "tag": "dns_proxy",
+        "address": "https://1.1.1.1/dns-query",
+        "detour": "🌍 全球节点"
+      },
+      {
+        "tag": "dns_block",
+        "address": "rcode://success"
+      }
+    ],
+    "rules": [
+      {
+        "rule_set": [
+          "geosite-cn"
+        ],
+        "action": "route",
+        "server": "dns_direct"
+      },
+      {
+        "rule_set": [
+          "geosite-category-ads-all"
+        ],
+        "action": "route",
+        "server": "dns_block"
+      }
+    ],
+    "final": "dns_proxy",
+    "strategy": "prefer_ipv4"
+  },
+  "inbounds": [
+    {
+      "type": "tun",
+      "tag": "tun-in",
+      "address": [
+        "172.19.0.1/30"
+      ],
+      "mtu": 9000,
+      "auto_route": true,
+      "strict_route": true,
+      "sniff": true,
+      "sniff_override_destination": true,
+      "stack": "mixed"
+    }
+  ],
+  "outbounds": [
+    {
+      "type": "selector",
+      "tag": "🚀 节点选择",
+      "outbounds": [
+        "🌍 全球节点",
+        "DIRECT",
+        "🚫 拦截"
+      ],
+      "default": "🌍 全球节点"
+    },
+
+    {
+      "type": "urltest",
+      "tag": "🌍 全球节点",
+      "outbounds": [
+        "🇭🇰 香港节点",
+        "🇹🇼 台湾节点",
+        "🇯🇵 日韩节点",
+        "🌏 亚太节点",
+        "🇺🇸 美国节点",
+        "🇪🇺 欧洲节点",
+        "🌎 美洲节点",
+        "🌍 非洲节点"
+      ],
+      "interval": "3m",
+      "tolerance": 50
+    },
+    {
+      "type": "selector",
+      "tag": "🇭🇰 香港节点",
+      "outbounds": [
+        "proxy-hk-1",
+        "proxy-hk-2",
+        "DIRECT"
+      ],
+      "default": "proxy-hk-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇹🇼 台湾节点",
+      "outbounds": [
+        "proxy-tw-1",
+        "DIRECT"
+      ],
+      "default": "proxy-tw-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇯🇵 日韩节点",
+      "outbounds": [
+        "proxy-jp-1",
+        "proxy-kr-1",
+        "DIRECT"
+      ],
+      "default": "proxy-jp-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🌏 亚太节点",
+      "outbounds": [
+        "proxy-sg-1",
+        "proxy-id-1",
+        "DIRECT"
+      ],
+      "default": "proxy-sg-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇺🇸 美国节点",
+      "outbounds": [
+        "proxy-us-1",
+        "proxy-us-2",
+        "DIRECT"
+      ],
+      "default": "proxy-us-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🇪🇺 欧洲节点",
+      "outbounds": [
+        "proxy-eu-1",
+        "DIRECT"
+      ],
+      "default": "proxy-eu-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🌎 美洲节点",
+      "outbounds": [
+        "proxy-ca-1",
+        "proxy-us-1",
+        "DIRECT"
+      ],
+      "default": "proxy-ca-1"
+    },
+    {
+      "type": "selector",
+      "tag": "🌍 非洲节点",
+      "outbounds": [
+        "proxy-af-1",
+        "DIRECT"
+      ],
+      "default": "proxy-af-1"
+    },
+
+    { "type": "selector", "tag": "🤖 AI 服务", "outbounds": ["🇺🇸 美国节点", "🌍 全球节点", "🇯🇵 日韩节点", "DIRECT"] },
+    { "type": "selector", "tag": "💰 加密货币", "outbounds": ["🇭🇰 香港节点", "🌍 全球节点", "🇺🇸 美国节点", "DIRECT"] },
+    { "type": "selector", "tag": "🏦 金融支付", "outbounds": ["DIRECT", "🇭🇰 香港节点", "🇯🇵 日韩节点", "🌍 全球节点"] },
+    { "type": "selector", "tag": "📧 邮件服务", "outbounds": ["🇯🇵 日韩节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "💬 即时通讯", "outbounds": ["🇭🇰 香港节点", "🇯🇵 日韩节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "📱 社交媒体", "outbounds": ["🇯🇵 日韩节点", "🌍 全球节点", "🇺🇸 美国节点", "DIRECT"] },
+    { "type": "selector", "tag": "🧑‍💼 会议协作", "outbounds": ["🇯🇵 日韩节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "📺 国内流媒体", "outbounds": ["DIRECT", "🇭🇰 香港节点", "🌍 全球节点"] },
+    { "type": "selector", "tag": "📺 东南亚流媒体", "outbounds": ["🌏 亚太节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🇺🇸 美国流媒体", "outbounds": ["🇺🇸 美国节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🇭🇰 香港流媒体", "outbounds": ["🇭🇰 香港节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🇹🇼 台湾流媒体", "outbounds": ["🇹🇼 台湾节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🇯🇵 日韩流媒体", "outbounds": ["🇯🇵 日韩节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🇪🇺 欧洲流媒体", "outbounds": ["🇪🇺 欧洲节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🕹️ 国内游戏", "outbounds": ["DIRECT", "🇭🇰 香港节点", "🌍 全球节点"] },
+    { "type": "selector", "tag": "🎮 国外游戏", "outbounds": ["🇯🇵 日韩节点", "🇭🇰 香港节点", "🌍 全球节点", "DIRECT"] },
+    { "type": "selector", "tag": "🔍 搜索引擎", "outbounds": ["🌍 全球节点", "🇯🇵 日韩节点", "DIRECT"] },
+    { "type": "selector", "tag": "📟 开发者服务", "outbounds": ["🌍 全球节点", "🇺🇸 美国节点", "🇯🇵 日韩节点", "DIRECT"] },
+    { "type": "selector", "tag": "Ⓜ️ 微软服务", "outbounds": ["🌍 全球节点", "🇯🇵 日韩节点", "DIRECT"] },
+    { "type": "selector", "tag": "🍎 苹果服务", "outbounds": ["DIRECT", "🇭🇰 香港节点", "🌍 全球节点"] },
+    { "type": "selector", "tag": "📥 下载更新", "outbounds": ["DIRECT", "🌍 全球节点", "🇭🇰 香港节点"] },
+    { "type": "selector", "tag": "☁️ 云与CDN", "outbounds": ["🌍 全球节点", "DIRECT", "🇺🇸 美国节点"] },
+    { "type": "selector", "tag": "🛰️ BT/PT Tracker", "outbounds": ["🚫 拦截", "DIRECT", "🌍 全球节点", "🇭🇰 香港节点"] },
+    { "type": "selector", "tag": "🏠 国内网站", "outbounds": ["DIRECT", "🇭🇰 香港节点", "🌍 全球节点"] },
+    { "type": "selector", "tag": "🚫 受限网站", "outbounds": ["🌍 全球节点", "🇺🇸 美国节点", "DIRECT"] },
+    { "type": "selector", "tag": "🌐 国外网站", "outbounds": ["🌍 全球节点", "🇯🇵 日韩节点", "🇺🇸 美国节点", "DIRECT"] },
+    { "type": "selector", "tag": "🐟 漏网之鱼", "outbounds": ["🌍 全球节点", "DIRECT", "🇭🇰 香港节点"] },
+    { "type": "selector", "tag": "🛑 广告拦截", "outbounds": ["🚫 拦截", "DIRECT"] },
+
+    {
+      "type": "trojan",
+      "tag": "proxy-hk-1",
+      "server": "example-hk-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-hk-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-hk-2",
+      "server": "example-hk-2.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-hk-2.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-tw-1",
+      "server": "example-tw-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-tw-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-jp-1",
+      "server": "example-jp-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-jp-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-kr-1",
+      "server": "example-kr-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-kr-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-sg-1",
+      "server": "example-sg-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-sg-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-id-1",
+      "server": "example-id-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-id-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-us-1",
+      "server": "example-us-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-us-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-us-2",
+      "server": "example-us-2.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-us-2.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-eu-1",
+      "server": "example-eu-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-eu-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-ca-1",
+      "server": "example-ca-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-ca-1.com" }
+    },
+    {
+      "type": "trojan",
+      "tag": "proxy-af-1",
+      "server": "example-af-1.com",
+      "server_port": 443,
+      "password": "REPLACE_ME",
+      "tls": { "enabled": true, "server_name": "example-af-1.com" }
+    },
+
+    { "type": "direct", "tag": "DIRECT" },
+    { "type": "block", "tag": "🚫 拦截" }
+  ],
+  "route": {
+    "auto_detect_interface": true,
+    "final": "🐟 漏网之鱼",
+    "rule_set": [
+      {
+        "type": "remote",
+        "tag": "geosite-cn",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/cn.srs",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geoip-cn",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo-lite/geoip/cn.srs",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geosite-geolocation-!cn",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/geolocation-!cn.srs",
+        "update_interval": "1d"
+      },
+      {
+        "type": "remote",
+        "tag": "geosite-category-ads-all",
+        "format": "binary",
+        "url": "https://fastly.jsdelivr.net/gh/MetaCubeX/meta-rules-dat@sing/geo/geosite/category-ads-all.srs",
+        "update_interval": "1d"
+      }
+    ],
+    "rules": [
+      { "protocol": "dns", "action": "hijack-dns" },
+      { "port": [7680], "action": "reject" },
+
+      { "domain_suffix": ["openai.com", "chat.openai.com", "oaistatic.com", "anthropic.com", "claude.ai", "gemini.google.com", "perplexity.ai", "huggingface.co", "cursor.com", "v0.dev", "character.ai", "mistral.ai", "cohere.ai", "cohere.com", "replicate.com", "together.ai", "runpod.io", "openrouter.ai", "suno.ai", "suno.com"], "action": "route", "outbound": "🤖 AI 服务" },
+      { "domain_suffix": ["inflection.ai", "pi.ai"], "action": "route", "outbound": "🚫 受限网站" },
+      { "domain_suffix": ["binance.com", "binance.info", "binance.me", "binance.org", "binancefuture.com", "tradingview.com", "coinglass.com", "coinmarketcap.com", "coingecko.com"], "action": "route", "outbound": "💰 加密货币" },
+      { "domain_suffix": ["paypal.com", "stripe.com", "stripe.network", "wise.com", "revolut.com", "visa.com", "mastercard.com", "amex.com"], "action": "route", "outbound": "🏦 金融支付" },
+      { "domain_suffix": ["gmail.com", "googlemail.com", "outlook.com", "hotmail.com", "proton.me", "protonmail.com", "fastmail.com", "tuta.com"], "action": "route", "outbound": "📧 邮件服务" },
+      { "domain_suffix": ["telegram.org", "t.me", "discord.com", "discord.gg", "whatsapp.com", "line.me", "kakao.com", "skype.com"], "action": "route", "outbound": "💬 即时通讯" },
+      { "domain_suffix": ["x.com", "twitter.com", "instagram.com", "facebook.com", "fbcdn.net", "reddit.com"], "action": "route", "outbound": "📱 社交媒体" },
+      { "domain_suffix": ["zoom.us", "teams.microsoft.com", "slack.com", "notion.so", "atlassian.com", "meet.google.com"], "action": "route", "outbound": "🧑‍💼 会议协作" },
+      { "domain_suffix": ["bilibili.com", "iqiyi.com", "youku.com", "mgtv.com", "qq.com", "youkucloud.com"], "action": "route", "outbound": "📺 国内流媒体" },
+      { "domain_suffix": ["youtube.com", "youtu.be", "googlevideo.com", "ytimg.com", "netflix.com", "nflxvideo.net", "disneyplus.com", "hulu.com", "hbo.com"], "action": "route", "outbound": "🇺🇸 美国流媒体" },
+      { "domain_suffix": ["viu.com", "iq.com", "wetv.vip"], "action": "route", "outbound": "📺 东南亚流媒体" },
+      { "domain_suffix": ["now.com", "mytvsuper.com", "viu.tv"], "action": "route", "outbound": "🇭🇰 香港流媒体" },
+      { "domain_suffix": ["bahamut.com.tw", "hinet.net", "line.me"], "action": "route", "outbound": "🇹🇼 台湾流媒体" },
+      { "domain_suffix": ["abema.tv", "dmm.com", "tv-tokyo.co.jp"], "action": "route", "outbound": "🇯🇵 日韩流媒体" },
+      { "domain_suffix": ["bbc.co.uk", "iplayer.bbc.co.uk", "zdf.de"], "action": "route", "outbound": "🇪🇺 欧洲流媒体" },
+      { "domain_suffix": ["steamcommunity.com", "steampowered.com", "epicgames.com", "riotgames.com", "playstation.com"], "action": "route", "outbound": "🎮 国外游戏" },
+      { "domain_suffix": ["qq.com", "163.com", "mihoyo.com", "battlenet.com.cn"], "action": "route", "outbound": "🕹️ 国内游戏" },
+      { "domain_suffix": ["google.com", "googleapis.com", "duckduckgo.com", "bing.com"], "action": "route", "outbound": "🔍 搜索引擎" },
+      { "domain_suffix": ["github.com", "githubusercontent.com", "gitlab.com", "docker.io", "npmjs.com", "pypi.org"], "action": "route", "outbound": "📟 开发者服务" },
+      { "domain_suffix": ["microsoft.com", "windowsupdate.com", "office.com", "live.com"], "action": "route", "outbound": "Ⓜ️ 微软服务" },
+      { "domain_suffix": ["apple.com", "icloud.com", "mzstatic.com", "apple-dns.net"], "action": "route", "outbound": "🍎 苹果服务" },
+      { "domain_suffix": ["dl.google.com", "msftconnecttest.com", "windowsupdate.com", "cdn-apple.com"], "action": "route", "outbound": "📥 下载更新" },
+      { "domain_suffix": ["cloudflare.com", "jsdelivr.net", "fastly.com", "akamaized.net"], "action": "route", "outbound": "☁️ 云与CDN" },
+      { "domain_suffix": ["tracker.opentrackr.org", "openbittorrent.com", "nyaa.si"], "action": "route", "outbound": "🛰️ BT/PT Tracker" },
+
+      {
+        "rule_set": ["geosite-category-ads-all"],
+        "action": "route",
+        "outbound": "🛑 广告拦截"
+      },
+      {
+        "rule_set": ["geosite-cn", "geoip-cn"],
+        "action": "route",
+        "outbound": "🏠 国内网站"
+      },
+      {
+        "rule_set": ["geosite-geolocation-!cn"],
+        "action": "route",
+        "outbound": "🌐 国外网站"
+      }
+    ]
+  }
+}

--- a/SingBox/使用教程.md
+++ b/SingBox/使用教程.md
@@ -1,0 +1,161 @@
+# SingBox 使用教程（对齐 Clash Party v5.2.2 Full 语义）
+
+> 配置文件（推荐）：`SingBox/singbox-smart-full.json`  
+> 基础模板：`SingBox/singbox-smart.json`  
+> 生成脚本：`SingBox/generate-singbox-full.js`  
+> 目标：在 **sing-box** 上复刻 Clash Party 的「9 个区域组 + 28 个业务组 + 387 rule-providers + 977 规则」语义，并保持 sing-box 官方配置兼容。
+
+---
+
+## 1. 设计说明（和 Clash Party 的一致性）
+
+该 sing-box 版本与 Clash Party 主线保持以下一致：
+
+- **区域层一致**：
+  - `🌍 全球节点`
+  - `🇭🇰 香港节点`
+  - `🇹🇼 台湾节点`
+  - `🇯🇵 日韩节点`
+  - `🌏 亚太节点`
+  - `🇺🇸 美国节点`
+  - `🇪🇺 欧洲节点`
+  - `🌎 美洲节点`
+  - `🌍 非洲节点`
+
+- **业务层一致（28 组）**：
+  - `🤖 AI 服务`、`💰 加密货币`、`🏦 金融支付`、`📧 邮件服务`、`💬 即时通讯`、`📱 社交媒体`
+  - `🧑‍💼 会议协作`、`📺 国内流媒体`、`📺 东南亚流媒体`、`🇺🇸 美国流媒体`、`🇭🇰 香港流媒体`
+  - `🇹🇼 台湾流媒体`、`🇯🇵 日韩流媒体`、`🇪🇺 欧洲流媒体`、`🕹️ 国内游戏`、`🎮 国外游戏`
+  - `🔍 搜索引擎`、`📟 开发者服务`、`Ⓜ️ 微软服务`、`🍎 苹果服务`、`📥 下载更新`
+  - `☁️ 云与CDN`、`🛰️ BT/PT Tracker`、`🏠 国内网站`、`🚫 受限网站`、`🌐 国外网站`
+  - `🐟 漏网之鱼`、`🛑 广告拦截`
+
+- **规则层策略一致**：
+  - AI、支付、加密货币、流媒体、即时通讯、开发者服务等关键域名前置匹配。
+  - 国内/国外流量使用 `geosite-cn` + `geoip-cn` 与 `geosite-geolocation-!cn` 收口。
+  - 广告使用 `category-ads-all` 统一拦截。
+  - 通过生成脚本从 `Clash Party/Clash Smart内核覆写脚本.js` 自动提取 rule-providers 与 rules，确保顺序和策略定义持续跟随 Clash Party 主线。
+
+---
+
+## 2. 准备工作
+
+1. 安装 sing-box 或图形客户端（如 sing-box for Android / macOS 图形端等）。
+2. 将 `SingBox/singbox-smart-full.json` 导入客户端。
+3. 将文件内 `proxy-xxx` 示例节点替换成你自己的真实节点（trojan/vless/vmess/hysteria2 都可以）。
+
+> 说明：`singbox-smart-full.json` 已内置 387 个 rule_set 入口与 977 条路由规则；你只需要替换节点出站即可。
+
+---
+
+## 2.1 重新生成 Full 规则（跟随 Clash Party 升级）
+
+当 `Clash Party/Clash Smart内核覆写脚本.js` 更新后，执行：
+
+```bash
+node SingBox/generate-singbox-full.js
+```
+
+脚本会自动：
+
+- 调用 Clash Party 的 `main(config)` 构建完整规则；
+- 同步导出 sing-box `route.rule_set`（387 项）；
+- 同步导出 sing-box `route.rules`（977 条）。
+
+---
+
+## 3. 关键兼容性（按 sing-box 官方文档）
+
+为了兼容新版本 sing-box，配置做了以下处理：
+
+- 路由规则使用 `action` + `outbound` 形式（sing-box 1.11+ 变更后推荐）。
+- 使用 `rule_set`（remote/binary）而非老 GeoIP/Geosite 旧写法。
+- 启用 `experimental.cache_file.enabled`，让远程规则和 selector 选择结果可缓存。
+- `selector` / `urltest` 均使用官方结构字段（`outbounds`、`default`、`interval`、`tolerance`）。
+
+---
+
+## 3.1 DNS / 嗅探 / GEO 增强版配置（已并入 Full 配置）
+
+为贴近 Clash Party 使用教程中的「DNS + Sniffer + GeoX URL」补充项，`singbox-smart-full.json` 已对应实现：
+
+- **DNS 增强**：
+  - `dns_direct`（223.5.5.5 DoH）用于国内规则集；
+  - `dns_proxy`（1.1.1.1 DoH）用于代理解析；
+  - `dns_block`（rcode://success）用于广告域名返回空响应。
+- **嗅探增强**：
+  - `inbounds.tun.sniff=true`
+  - `sniff_override_destination=true`
+  - 与 Clash Party 的 Sniffer 覆写语义对齐（提升 SNI/域名识别命中）。
+- **GEO 增强数据库**：
+  - `MetaCubeX/meta-rules-dat@sing` 的 geosite/geoip `.srs` 远程规则集；
+  - 按日更新（`update_interval: 1d`）。
+
+---
+
+## 4. 替换节点的推荐方式
+
+在 `outbounds` 中，优先按区域替换：
+
+- `proxy-hk-*` → 香港节点
+- `proxy-tw-*` → 台湾节点
+- `proxy-jp-*` / `proxy-kr-*` → 日韩节点
+- `proxy-sg-*` / `proxy-id-*` → 亚太节点
+- `proxy-us-*` → 美国节点
+- `proxy-eu-*` → 欧洲节点
+- `proxy-ca-*` → 美洲节点
+- `proxy-af-*` → 非洲节点
+
+这样业务组就不需要改动，能保留 Clash Party 的“业务语义 -> 区域出口”逻辑。
+
+---
+
+## 5. 首次启动检查清单
+
+启动后请按顺序确认：
+
+1. **出站组是否完整**：能看到 9 区域 + 28 业务组。  
+2. **DNS 是否生效**：国内域名走 `dns_direct`，国外域名走 `dns_proxy`。  
+3. **规则集下载是否成功**：应看到 `387+` 个 `rule_set` 被加载（与 Clash Party Provider 数量对齐）。  
+4. **典型业务是否命中**：
+   - ChatGPT 命中 `🤖 AI 服务`
+   - Binance 命中 `💰 加密货币`
+   - YouTube/Netflix 命中对应流媒体组
+   - 国内站点命中 `🏠 国内网站`
+
+---
+
+## 6. 常见问题
+
+### Q1：为什么不能像 Clash Party 一样“自动按节点名分类”？
+
+Clash Party 当前使用 JS 覆写引擎做节点名称分类；sing-box 原生 JSON 配置没有同等 JS 运行时。这个版本采用“**固定区域组 + 手工节点归位**”实现同语义替代，行为更稳定、可审计。
+
+### Q2：规则集下载失败怎么办？
+
+- 先测试 `fastly.jsdelivr.net` 连通性；
+- 若你所在网络对 CDN 有限制，可替换为你可访问的镜像地址；
+- 保持 `.srs` 二进制格式和 `format: binary` 一致。
+
+### Q3：如何保证和 Clash Party 规则保持完全一致？
+
+使用 `generate-singbox-full.js` 从 Clash Party 脚本自动提取是最稳妥方式。只要上游 `Clash Smart内核覆写脚本.js` 更新，你重新执行脚本即可同步。
+
+---
+
+## 7. 参考文档（官方）
+
+- sing-box Outbound（selector/urltest）  
+  https://sing-box.sagernet.org/configuration/outbound/
+- sing-box Selector  
+  https://sing-box.sagernet.org/configuration/outbound/selector/
+- sing-box URLTest  
+  https://sing-box.sagernet.org/configuration/outbound/urltest/
+- sing-box Route / Route Rule / Rule Action  
+  https://sing-box.sagernet.org/configuration/route/
+  https://sing-box.sagernet.org/configuration/route/rule/
+  https://sing-box.sagernet.org/configuration/route/rule_action/
+- sing-box Rule-set  
+  https://sing-box.sagernet.org/configuration/rule-set/
+- sing-box Cache File  
+  https://sing-box.sagernet.org/configuration/experimental/cache-file/


### PR DESCRIPTION
### Motivation

- Provide a sing-box compatible implementation that mirrors Clash Party semantics (regions, business groups and rule-providers) so users can run the same routing strategy on sing-box. 
- Enable automated regeneration of the large "full" sing-box config from the Clash Party core JS to keep rule-providers and rules synchronized.
- Ship a ready-to-use template and documentation to help users import and replace example nodes quickly.

### Description

- Added `SingBox/generate-singbox-full.js` which runs the `Clash Party/Clash Smart内核覆写脚本.js` in a sandbox and converts the resulting Clash-style `rule-providers` and `rules` into sing-box `route.rule_set` and `route.rules` entries. 
- Added `SingBox/singbox-smart.json` as the base sing-box template (selectors, urltest, DNS, example trojan outbounds and core route rule_set entries). 
- Added `SingBox/singbox-smart-full.json` — a generated, ready-to-import full configuration that includes the expanded `rule_set` and `rules` mapping (remote `.srs` providers, mapped actions/outbounds, and business-region selectors). 
- Added `SingBox/使用教程.md` with usage notes, regeneration instructions (`node SingBox/generate-singbox-full.js`), compatibility notes and configuration guidance. 
- Updated `README.md` to include the new `SingBox/` folder in the repository overview.

### Testing

- Ran `node SingBox/generate-singbox-full.js` to generate `SingBox/singbox-smart-full.json`, which completed and printed provider/rule counts indicating successful conversion. 
- Validated that `SingBox/singbox-smart-full.json` is valid JSON by parsing it with a JSON parser (`jq` / Node `JSON.parse`) after generation. 
- No unit tests were added; integration validation consisted of generation and JSON sanity checks which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b660b68c8330a9c58c830a66f00c)