### PR TITLE
docs: merge Clash Smart legacy changelog into Clash Party/CHANGELOG.md

### DIFF
--- a/Clash Party/CHANGELOG.md
+++ b/Clash Party/CHANGELOG.md
@@ -52,7 +52,185 @@
 
 ---
 
-## v4.5.5 ~ v5.2.0
+## v5.1.9 及之前版本
 
-历史版本（v4.5.5 至 v5.2.0）的详细变更历史过于庞大，未随迁移迁入本文件。
-有追溯需要时，查询 git 历史：`git log --follow "Clash Party/Clash Smart内核覆写脚本.js"`。
+v5.1.9 变更摘要（1项清理 + 1项配置调整）：
+- ★ CLEAN#1-P1：清理防吞盾（FIX#14）产生的 ~16 条 dead rules
+  - 防吞盾区块已将 Google 子服务规则提升至 szkane-ai 之前
+  - 原位置的重复规则永远不会被匹配（first-match-wins），仅消耗 CPU 周期
+  - 已删除：gmail.com×2 / googlemail.com×2 / mail.google.com×2 / inbox.google.com×2
+    googlesearch×1 / googledrive×1 / googleearth×1 / google×1 / google-ip×1
+    googlevoice×1 / meet.google.com×1 / meet.googleapis.com×1
+    dl.google.com×1 / play.googleapis.com×1 / android.clients.google.com×1 / googlefcm×1
+  - 原位置保留注释标记「已提升至防吞盾」
+- ★ CFG#1-P2：移除覆写中的 geo-update-interval 和 geosite CDN URL
+  - 这两项由用户在 Clash Party UI 中手动管理，覆写不再覆盖
+  - geo-update-interval：移除（由 UI 控制，默认值取决于订阅/UI 设置）
+  - geosite CDN URL：移除（由 UI 控制 fastly/cdn 切换策略）
+  - geoip/mmdb/asn URL 保留不变（Loyalsoldier 加强版 MMDB 是脚本核心依赖）
+
+v5.1.8 变更摘要（4项修复 + 2项性能优化 + 1项标注）：
+- ★ FIX#11-P0：dns.google 被 szkane-ai 宽规则吞入「AI 服务」
+  - dns.google / dns.google.com 是 Google Public DNS DoH 入口，非 AI 服务
+  - 日志特征：[TCP] dial 🤖 AI 服务 (match RuleSet/szkane-ai) mihomo --> dns.google:443
+  - 修复：在 AI 规则区块之前前置 DOMAIN 精准拦截到 CLOUD_CDN
+- ★ FIX#14-P0：Google 全系子服务被 szkane-ai 宽规则吞入「AI 服务」（防吞盾）
+  - szkane AiDomain.list 含 Google 宽域名（因 Gemini AI），导致 Google 全系子服务误走 AI 代理
+  - 受影响服务：Google 搜索 / Gmail / Google Meet / Google Drive / YouTube / Google FCM / Google Voice 等
+  - 修复：在 RULE-SET,szkane-ai 之前插入「Google 子服务防吞盾」
+    - 邮件：gmail.com/googlemail.com/mail.google.com → EMAIL
+    - 即时通讯：RULE-SET,googlevoice → IM
+    - 会议协作：meet.google.com/meet.googleapis.com → WORK
+    - 下载更新：dl.google.com/play.googleapis.com/RULE-SET,googlefcm → DOWNLOAD
+    - 搜索引擎：RULE-SET,googlesearch/googledrive/googleearth/google/google-ip → SEARCH
+    - 流媒体：youtube.com/googlevideo.com/ytimg.com/ggpht.com → STREAM_US
+  - 已安全（在防吞盾之前已匹配）：Gemini(RULE-SET) / NotebookLM / Copilot / dns.google
+  - 原位置 dead rules 已在 v5.1.9 CLEAN#1 中清除
+- ★ PERF#2-P0：fastly.jsdelivr.net EOF 风暴缓解（03-05 单日 40+ provider 拉取失败）
+  - 根因：389 providers 以 10s 步长密集拉取同一 CDN 节点，瞬时并发触发断连
+  - 日志特征：[Provider] xxx pull error: ...fastly.jsdelivr.net/...xxx.yaml: EOF
+  - 优化措施三合一：
+    1) RP_STEP 10→15（冷启动窗口 ~65min→~97min，降低瞬时并发密度）
+    2) nextInterval() 加 0~59s 随机抖动（打破整齐步长的周期性并发浪峰）
+    3) bm7 provider CDN 混合策略（主力 fastly.jsdelivr.net + 备选 cdn.jsdelivr.net 轮替）
+- ★ FIX#12-P1：GSCService.exe→ip.cip.cc 每 2 小时 DNS 解析失败
+  - ip.cip.cc 是外部 IP 检测服务，技嘉 GCC 服务进程定时调用
+  - 日志特征：dial DIRECT (match ProcessName/GSCService.exe) --> ip.cip.cc:80 error: dns resolve failed
+  - 修复：新增 DOMAIN,ip.cip.cc,DIRECT（在 TUN 下允许直连 DNS 解析）
+- ★ NOTE#1-P1：bm7 上游规则解析噪声（已知问题，非本脚本 bug）
+  - USER-AGENT,BBCiPlayer* / USER-AGENT,TikTok*：mihomo 不支持 USER-AGENT 规则类型（Surge 语法残留）
+  - IP-CIDR[空格], 17.253.4.125：bm7 Apple 相关 provider 格式错误（多余空格）
+  - 来源：blackmatrix7/ios_rule_script 上游数据质量问题，每次 config reload 重复 3 条 warning
+  - 处理：标注为已知噪声，不影响功能，等待上游修复
+- ★ FIX#13-P2：acc-copilot 误匹配微软 Delivery Optimization 遥测域名
+  - geover.prod.do.dsp.mp.microsoft.com 是微软 DO 服务，非 Copilot AI
+  - 日志特征：match RuleSet/acc-copilot) --> geover.prod.do.dsp.mp.microsoft.com:443（4次/天）
+  - 修复：前置 DOMAIN-SUFFIX 拦截到 DOWNLOAD 组
+- ★ PERF#4-P2：geosite.dat 更新与 provider 争抢 CDN 带宽
+  - 日志特征：[GEO] Failed to update GEO database: ...geosite.dat: TLS handshake timeout
+  - 优化：geosite.dat 切换 cdn.jsdelivr.net（Cloudflare）与 provider 的 Fastly CDN 错开
+  - geo-update-interval 24h→72h（降低更新频率，geo 数据变化缓慢）
+
+v5.1.7 变更摘要（1项性能优化 + 1项修复）：
+- ★ PERF#1-P1：3 个 domain-behavior provider 升级为 .mrs 二进制格式（降低冷启动解析开销）
+  - anti-ad：yaml → DustinWin/ruleset_geodata ads.mrs（同源 privacy-protection-tools/anti-AD，每日3:00自动构建）
+  - loyalsoldier-gfw：text → MetaCubeX geosite:gfw.mrs（同源 gfwlist/gfwlist → v2fly/domain-list-community，~4000+ 域名）
+  - loyalsoldier-greatfire：text → MetaCubeX geosite:greatfire.mrs（同源 GreatFire Analyzer → v2fly/domain-list-community）
+  - 优化前：29/389 providers 使用 .mrs（7.4%）→ 优化后：32/389（8.2%）
+  - 剩余 domain-behavior 非 mrs（18个）：sukka-phishing(text,无.mrs源) + acc-geo-d-*(17,Accademia无.mrs)
+  - 剩余 classical-behavior（322个）：mrs 格式不支持 classical（mihomo 内核限制）
+  - 测试环境：确认 MetaCubeX geosite:gfw.mrs / geosite:greatfire.mrs CDN 可达
+- ★ FIX#10-P0：hagezi-tif URL 双修（v5.1.6遗漏）
+  - CDN：cdn.jsdelivr.net → fastly.jsdelivr.net（Cloudflare在国内/印尼频繁EOF）
+  - 文件名：HageziTIF.mrs → HageziUltimate.mrs（实际release分支文件名，原名404）
+
+v5.1.6 变更摘要（1项安全增强）：
+- ★ FEAT#2-P0：新增 Hagezi Threat Intelligence Feeds（威胁情报）
+  - 覆盖 malware(恶意软件)/cryptojacking(挖矿)/C2(命令控制)/scam(诈骗)/spam(垃圾邮件)
+  - 补齐 v5.1.5 安全覆盖缺口（原仅有 ads/privacy/hijacking/phishing/anti-fraud/anti-PCDN）
+  - 优先使用 MiHomoer/MiHomo-Hagezi .mrs 二进制格式（domain behavior，冷启动开销极小）
+  - 备选：Hagezi 原始文本域名列表（format:text, behavior:domain）
+  - 来源：hagezi/dns-blocklists ⭐20k+，每日自动构建，30+ 威胁情报源聚合
+  - 挂到「🛑 广告拦截」组，默认 REJECT
+
+v5.1.5 变更摘要（1项重构）：
+- ★ REFACTOR#1-P1：删除「🇮🇩 印尼本地」独立代理组（29→28 业务策略组）
+  - 印尼银行/证券（bca/bni/bri/mandiri等11家 + idx/ksei）→ 金融支付
+  - 印尼电商/出行/外卖/电信/ISP/政府/新闻（~36域名）→ 国外网站
+  - GEOIP,ID → 国外网站（与 GEOIP,CN→国内网站 对称，可在印尼时手动切DIRECT）
+  - 印尼支付网关（midtrans/gopay/ovo/dana等）保留在金融支付组不变
+  - 印尼流媒体（vidio/rctiplus等）保留在东南亚流媒体组不变
+  - 删除 ID_LOCAL_PROXIES 常量
+
+v5.1.4 变更摘要（1项新增）：
+- ★ FEAT#1-P1：新增「🚫 受限网站」GFW 代理组（4源覆盖，位于 INTL_SITE 之前）
+  - Loyalsoldier/clash-rules gfw.txt（GFWList 每日6:30自动构建，~4000+ 域名）
+  - Loyalsoldier/clash-rules greatfire.txt（GreatFire 独立封锁探测，与 GFWList 互补）
+  - GEOSITE,gfw（MetaCubeX geosite.dat 内置 GFW 标签，支持 keyword/regexp 规则类型）
+  - szkane ProxyGFWlist（从 INTL_SITE 移入，GFW 域名补充）
+  - 代理列表含 DIRECT（在国外时可直连被墙站点），与 INTL_SITE 语义分离
+  - 数据源层级：gfwlist/gfwlist + GreatFire Analyzer → v2fly/domain-list-community → Loyalsoldier/v2ray-rules-dat → clash-rules
+
+v5.1.3 变更摘要（3处修复）：
+- ★ FIX#7-P1：Zoho 宽域名 DOMAIN-SUFFIX 收窄为 mail.zoho.* 精确子域名（防止吞掉会议协作规则）
+- ★ FIX#8-P2：acc-kwai（Kwai国际版）从 CNMEDIA(DIRECT优先) 移到 STREAM_SEA（海外APP需代理）
+- ★ FIX#9-P2：ehgallery 从 STREAM_US 移到 INTL_SITE（非流媒体服务，全球节点更灵活）
+
+v5.1.2 变更摘要（6处修复）：
+- ★ FIX#1-P0：Asia_China GeoRouting 从 INTL_SITE 修正为 CN_SITE（.cn域名/中国IP段误走代理）
+- ★ FIX#2-P1：BilibiliHMT 从 CNMEDIA(DIRECT优先) 修正为 STREAM_HK（港澳台B站需代理解锁）
+- ★ FIX#3-P1：补充5个孤儿provider规则引用（googledrive/googleearth/scholar/yandex→搜索, naver→国外网站）
+- ★ FIX#4-P2：HomeIP US/JP 从 CN_SITE 修正为 INTL_SITE（美日住宅IP段不应走直连）
+- ★ FIX#5-P2：Aqara Global 从 CN_SITE 修正为 INTL_SITE（绿米国际服务需代理）
+- ★ FIX#6-P1：删除3个DNS provider（bm7-dns/acc-globaldns/acc-chinadns），DNS流量改为自然分流
+
+v5.1 变更摘要（4步集成）：
+- ★ Step1-P0：Ckrvxr AntiPCDN（阻止P2P CDN吸血）+ AntiAntiFraud（阻止反诈隐私上传）
+- ★ Step1-P0：SukkaW reject_phishing（13万钓鱼域名拦截）
+- ★ Step1-P2：szkane crypto-exchanges（Binance/OKX/Web3量化交易精准路由）
+- ★ Step2：Accademia 全量35规则目录（bm7补充：AI/Bank/Signal/FakeLocation等）
+- ★ Step3：szkane 全量规则（AI/CiciAI/Web3/Developer/Edu/UK等）
+- ★ Step4：geox-url 切换 Loyalsoldier 加强版 MMDB（含 cloudflare/telegram/netflix IP段）
+- ★ Step4：新增 GEOIP 精准标签路由（geoip:cloudflare/telegram/netflix）
+- ★ D6：所有外部规则 URL 统一 fastly.jsdelivr.net CDN（v5.1.6: raw.githubusercontent.com → CDN 消除 EOF）
+
+变更 v4.5.9→v5.0：
+- ★ P0 扩展：rule-providers 从 72 扩展到 326（+254 个 bm7 规则集）
+- ★ P0 扩展：实现 100% blackmatrix7 服务覆盖（排除已删除/国内兜底/聚合/重复/停服/测试规则）
+- ★ P1 优化：刷新步长从 25s 缩短到 10s（冷启动窗口 ≈ 54 分钟）
+- ★ P1 新增：13 个广告拦截/隐私保护 provider（Advertising/EasyPrivacy/Hijacking 等）
+- ★ P1 新增：42 个国内流媒体 provider（iQIYI/Youku/Douyin/WeTV 等完整覆盖）
+- ★ P1 新增：22 个美国流媒体 provider（CBS/NBC/PBS/Fox 等电视网络）
+- ★ P1 新增：30 个国外网站 provider（Wikipedia/Dropbox/Airbnb/Nike/Adobe 等）
+- ★ P1 新增：15 个下载更新 provider（含 D2 硬件品牌 Intel/Nvidia/Dell/HP 等）
+- ★ P1 新增：15 个云与CDN provider（含 D4 CA 证书 DigiCert/GlobalSign/LetsEncrypt 等）
+- ★ P1 新增：13 个苹果服务 provider（AppStore/AppleTV/Siri/TestFlight/FaceTime 等）
+- ★ P1 新增：13 个开发者 provider（Developer/Python/JetBrains/Oracle/WordPress 等）
+- ★ P1 新增：10 个社交媒体 provider（Pixiv/VK/Imgur/Disqus 等）
+- ★ P1 新增：10 个国外游戏 provider（Rockstar/Riot/GOG/Supercell/HoYoverse 等）
+- ★ P1 新增：8 个会议协作 provider（Atlassian/Notion/TeamViewer/Salesforce 等）
+- ★ P1 新增：7 个香港/台湾/东南亚/欧洲流媒体 provider 各类
+- ★ P1 新增：6 个搜索引擎 provider（GoogleDrive/GoogleEarth/DuckDuckGo/Yandex/Scholar 等）
+- ★ P1 新增：6 个即时通讯 provider（Telegram 地区IP段/GoogleVoice/Zalo 等）
+- ★ P2 新增：PrivateTracker（253 条 PT 站规则，P0 优先级）
+- ★ D0 决策：Blizzard 子游戏跳过（被 Blizzard 主规则覆盖）
+- ★ D1 决策：Google 子服务拆分（Drive→搜索, FCM→下载, Voice→IM）
+- ★ D2 决策：硬件/消费品牌统一归入下载更新/国外网站
+- ★ D3 决策：新闻媒体统一归入国外网站
+- ★ D4 决策：CA 证书服务归入云与CDN
+- ★ D5 决策：刷新步长 25s→10s
+
+沿用 v4.5.8→v4.5.9（全部修复保留）：
+
+变更 v4.5.7→v4.5.8：
+- ★ P0 修复：删除 announce.php 伪域名死规则（DOMAIN-SUFFIX 无法匹配 URL 路径）
+- ★ P0 修复：AWS 域名前置于 RULE-SET,amazon 之前，修复 AWS Console 被吞入「美国流媒体」
+  - amazonaws.com/awsstatic.com → 云与CDN
+  - aws.amazon.com/console.aws.amazon.com → 开发者服务
+  - 删除 ⑱ 中对应死规则
+- ★ P0 修复：Google 下载域名前置于 RULE-SET,google 之前，修复 dl.google.com 等被吞入「搜索引擎」
+  - dl.google.com/play.googleapis.com/android.clients.google.com → 下载更新
+  - 删除 ⑱½ 中对应死规则
+- ★ P0 修复：live.com 范围收窄，防止 login.live.com/xbox.live.com 被吞入「邮件服务」
+  - DOMAIN-SUFFIX,live.com → DOMAIN,mail.live.com（仅保留邮件入口）
+- ★ P1 修复：naver.com 拆分为流媒体子域名，修复 search.naver.com 死规则
+  - ⑪ 日韩流媒体：naver.com → tv.naver.com/now.naver.com 等具体子域名
+  - ⑮ 搜索引擎：search.naver.com 恢复生效
+  - naver.com 宽域名降级到 ㉑ 国外网站兜底
+- ★ P1 修复：清理 ~10 条同区块内冗余后缀死规则
+  - ⑮ 删除 search.yahoo.com（被 yahoo.com 覆盖）
+  - ⑮ 删除 search.brave.com（被 brave.com 覆盖）
+  - ⑦⅔ 删除 tv.sohu.com（被 sohu.com 覆盖）
+  - ⑲½ 删除 7 条被 go.id 覆盖的政府子域名
+- ★ P2 修复：TLS 指纹改用确定性哈希（按节点名），避免 WebSocket 长连接指纹漂移
+- ★ P2 修复：台湾节点 Emoji 从 🇨🇳 修正为 🇹🇼
+- ★ P2 新增：GEOIP,ID 印尼兜底（与 GEOIP,CN 对称，v5.1.5 移入国外网站组）
+
+沿用 v4.5.7：
+- ★ P1 变更：删除「🏠 中国智能」节点组（10→9 Smart 区域组）
+- ★ P1 变更：所有「XX智能」节点组重命名为「XX节点」
+
+沿用 v4.5.6：
+- ★ P2 优化：rule-provider 刷新间隔逐条递增（25s 步长，零并发）
+
+沿用 v4.5.5 及更早版本的所有修复。


### PR DESCRIPTION
### Motivation

- Preserve and surface the historical v5.1.9 and earlier changelog entries that were previously omitted from the `Clash Party/CHANGELOG.md` placeholder. 
- Ensure the `Clash Party` changelog is a self-contained historical record while keeping current `v5.2.x` notes intact.

### Description

- Added a new `## v5.1.9 及之前版本` section and merged the supplied legacy entries (v5.1.9 → v5.1 → v5.0 and relevant v4.5.x notes) into `Clash Party/CHANGELOG.md` replacing the prior placeholder block. 
- Kept existing `v5.2.x` entries unchanged and integrated the legacy history below them to provide a contiguous timeline. 
- This change is documentation-only and does not modify any runtime configuration, rule-provider, or other product files outside `Clash Party/CHANGELOG.md`.
- Commit created with message `docs: merge legacy v5.1.9-and-earlier changelog into Clash Party [agent: codex]`.

### Testing

- Confirmed the working tree was clean after staging and committing via `git status --short`. 
- Verified the updated file content by printing the affected region of `Clash Party/CHANGELOG.md` to ensure the legacy section was inserted in place of the placeholder. 
- No config/runtime self-checks were required because this is a documentation-only change and no rule/provider files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6bd1cf12083308235df504e9a9894)