### PR TITLE
feat(Passwall2): add degraded shunt-rule reference (promised in aed69…

### DIFF
--- a/Passwall2/CHANGELOG.md
+++ b/Passwall2/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Passwall2 — 变更日志
+
+> `Passwall2/README.md` 的变更日志。
+> 本目录提供 Passwall2 的**降级版** shunt rule 参考（28 条展平，功能约 OpenClash slim 的 70%）。
+> 主版本号跟随 Clash Party 主线；尾段 `-pw2.N` 独立递增。
+
+---
+
+## v5.2.5-pw2.1 (2026-04-20) — 初版
+
+- ★ 初版：从 Clash Party v5.2.5 基线手工展平为 Passwall2 shunt rule 格式
+- ★ 28 条 shunt rule 覆盖 28 业务分类，每条包含：
+  - 推荐节点区域（对应 Clash Party 9 区域组，用户在 Passwall2 里创建负载均衡组时参照）
+  - 域名列表（`geosite:xxx` 为主 + `domain-suffix:xxx` 补充）
+  - IP 列表（`geoip:xxx` 按需）
+- ★ 关键规则顺序约束：
+  - 广告拦截作为最高优先级（Passwall2 独立开关或 shunt rule 目标 = block）
+  - 国内网站（`geosite:cn` + `geoip:cn`）放倒数第 5
+  - 受限网站（`geosite:gfw`）放倒数第 4
+  - 国外网站（`geosite:geolocation-!cn`）放倒数第 3
+  - FINAL 兜底放倒数第 2
+- ★ 协议支持说明：跟随 Passwall2 用户选的核（xray / sing-box），**不是独立产物**——用户需自行下载 geosite.dat / geoip.dat
+
+### 与 Clash Party 主线的差异（Passwall 引擎限制）
+
+- ❌ **无 proxy-groups 嵌套**：Clash 的"业务组 → 区域组 → url-test 节点"两级结构在 Passwall 里手工展平为 28 条 shunt rule，每条直接指向一个节点或负载均衡组
+- ❌ **无 LightGBM 自动择优**：Passwall 的"负载均衡"组基于 xray/sing-box 的 `balancer`，只支持简单 `round-robin` / `random` / `leastLoad`，不含机器学习
+- ❌ **无机场换节点自动分类**：Passwall 的节点标签靠手工维护；机场换节点时需要重新把节点拖入各地区负载均衡组
+- ❌ **无 JS 覆写**：订阅更新时没有预处理机会
+- ❌ **无 Clash 原生 rule-provider 格式**：Passwall2 支持 sing-box 的 `rule_set` remote URL（可按需加），但和 Clash 的格式不同
+- ⚠️ **广告拦截降级**：只能用 1-2 个 list（如 `geosite:category-ads-all`），不像 OpenClash 可以并集 20+ 源（DustinWin + SukkaW + Hagezi + Accademia + bm7 各广告集）
+
+### 推荐使用场景
+
+- ✅ 已经装了 Passwall2 且不想换 OpenClash 的用户
+- ✅ 只要基础分流能力，不在乎 LightGBM / 自动归位
+- ✅ 路由器内存紧张但不愿装 OpenClash slim
+
+### 不推荐的场景（请换 OpenClash）
+
+- ❌ 想要 Smart + LightGBM 自动择优
+- ❌ 经常换机场、希望节点自动归位到区域组
+- ❌ 需要广告拦截深度防护（钓鱼 / 威胁情报 / DNS 劫持 / 隐私追踪等多源并集）
+- ❌ 追求和 Clash Party 桌面端的精确一致性
+
+### 维护同步策略
+
+当 Clash Party 主线有规则/组/业务调整（典型场景：新增/删除业务组、rule-provider 变动）时，本 `Passwall2/README.md` 的 28 条 shunt rule 需要**手工同步**：
+
+1. 新增业务组 → 在 README 里加一节 shunt rule，带推荐节点 + 域名/IP 列表
+2. 删除业务组 → 删除对应 shunt rule 节，并在本 CHANGELOG 标注
+3. 业务组内新增域名 → 更新对应 shunt rule 的"域名列表"字段
+
+**豁免**：Clash Party 的纯 region/LightGBM 调整（如 `uselightgbm` 参数微调、Smart 组 url-test interval 变化）**不需要**同步——这些 Passwall 架构无法表达，见 CLAUDE.md §1.4「允许的不同步例外」。

--- a/Passwall2/README.md
+++ b/Passwall2/README.md
@@ -1,0 +1,516 @@
+# Passwall2 使用教程（对齐 Clash Party v5.2.5 简化版）
+
+> 配置参考：`Passwall2/` 目录  
+> 版本：**v5.2.5-pw2.1**（Build 2026-04-20，初版）  
+> 目标：**Passwall2**（iceeeder / xiaorouter 等社区分支），兼顾 Passwall 旧版  
+> 架构：28 条 shunt rule（展平版）+ 每条支持 `geosite:xxx` / `geoip:xxx` / `domain-suffix:xxx` / `IP-CIDR,x/n` 混合匹配
+
+---
+
+## 🚀 零基础 5 分钟快速开始
+
+### 这是什么？
+一份面向 **Passwall2 / Passwall** 的 **shunt rule（分流规则）参考清单**。**不是** Clash Party 那种自动生成的 YAML——Passwall 没有 proxy-groups 嵌套层级，所以这里把基线的"28 业务组 → 9 区域组"两层结构**手工展平成 28 条 shunt rule**，每条对应一个业务类别，用户手动指定目标节点或负载均衡组。
+
+### 能和不能（诚实对比）
+| 能力 | Passwall2（用本参考） | OpenClash（本仓库完整支持） |
+|---|:-:|:-:|
+| 基础分流（AI / 流媒体 / 支付 / GFW） | ✅ | ✅ |
+| 28 业务分类 | ✅（手工配置）| ✅（自动）|
+| 9 区域组自动 url-test 选最低延迟 | ⚠️ 用负载均衡组近似 | ✅ 原生 |
+| 机场换节点自动归位到区域组 | ❌ **每次换机场要重新改 28 条规则的目标** | ✅ 自动 |
+| Smart + LightGBM 机器学习择优 | ❌ | ✅ 原生 |
+| JS 覆写 / 订阅预处理 | ❌ | ✅ |
+| 广告拦截（纵深多源）| ⚠️ 只能导 1-2 个 list | ✅ 20+ 源 |
+
+**功能约 OpenClash slim 的 70%**。想要完整体验，用本仓库 `OpenClash/`。
+
+### 我要准备什么？
+1. **OpenWrt / iStoreOS / ImmortalWrt** 路由器已刷好
+2. **已安装 Passwall 或 Passwall2 插件**（iceeeder / xiaorouter 社区分支都行）
+3. **一个机场订阅 URL**
+4. **本文档的 28 条 shunt rule 参考**（往下看）
+
+### 3 步走完
+1. **Passwall2 LuCI → 节点列表 → 添加订阅**：粘贴机场订阅 URL → 下载节点 → 分地区手动创建负载均衡组（如"🇺🇸 美国负载"把所有 US 节点加进来）
+2. **Passwall2 LuCI → 分流控制 → 添加分流规则**：照下方「28 条 shunt rule 参考」每条点一次「新增」，填入 规则名 + 域名列表 + IP 列表 + 选择目标节点
+3. **回首页启用 Passwall2**，流量就按 28 条规则分流了
+
+### 跑起来怎么验证？
+- 浏览器打开 `https://www.google.com` 能打开 = 代理通了
+- Passwall2 → 分流控制 → 每条规则后的"命中次数"应开始累加
+- 访问 `chat.openai.com` → 应命中你第 1 条（🤖 AI 服务）规则
+
+### 最常见踩坑
+- ❌ **规则多了顺序错乱**：Passwall2 按列表顺序匹配，**把"国内网站"/"广告拦截"放最前或最后**，业务规则放中间
+- ❌ **geosite 关键字不识别**：确认 Passwall2 的 xray/sing-box 核已下载 `geosite.dat`（LuCI → 全局设置 → 规则资源设置里有个"更新 geosite.dat / geoip.dat"按钮）
+- ❌ **节点换了规则都白写**：这是 Passwall 的固有限制，没办法。想避开就换 OpenClash
+- ❌ **Passwall 旧版语法稍不同**：Passwall 老版用 "分流节点" 字段；Passwall2 用 "分流规则" 面板。本文档的 `geosite:` / `geoip:` 语法两者都支持
+
+---
+
+## 🔌 协议支持（底层 xray / sing-box 核）
+
+Passwall2 根据你选的核提供不同协议，与 v2rayN 同理：
+
+| 协议 | xray 核（默认） | sing-box 核 |
+|---|:-:|:-:|
+| Shadowsocks (SS + 2022) | ✅ | ✅ |
+| ShadowsocksR (SSR) | ❌ | ❌ |
+| VMess | ✅ | ✅ |
+| VLESS + REALITY + XTLS-Vision | ✅ | ✅ |
+| Trojan | ✅ | ✅ |
+| Hysteria v1 / v2 | ❌ | ✅ |
+| TUIC v5 | ❌ | ✅ |
+| WireGuard | ⚠️ 实验 | ✅ |
+| AnyTLS / ShadowTLS | ❌ | ✅ |
+
+**一句话选核**：机场主推 VLESS+REALITY → xray 核；机场主推 Hysteria 2 / TUIC → sing-box 核；都有 → sing-box 覆盖更广。
+
+---
+
+## 📋 28 条 shunt rule 参考清单
+
+下面每一条 = Passwall2 「分流控制」面板里点一次「新增」。按顺序添加。**第 24-28 条（国内/受限/国外/FINAL/广告）顺序很关键**。
+
+> 使用语法：`geosite:xxx` = xray/sing-box geosite 分类；`domain-suffix:xxx` = 手工补充域名；`geoip:xxx` = geoip 分类；`IP-CIDR,x/n` = IP 段。
+>
+> **推荐节点区域** = Clash Party 基线推荐。你要在 Passwall2 的"节点列表"里创建对应地区的负载均衡组（比如"🇺🇸 美国-LB"），然后把这里的 shunt rule 指向这个组。
+
+---
+
+### 1️⃣ 🤖 AI 服务
+**推荐节点**：🇺🇸 美国（避开 HK/CN）
+
+**域名列表**：
+```
+geosite:openai
+geosite:anthropic
+geosite:gemini
+geosite:copilot
+geosite:bard
+geosite:perplexity
+geosite:huggingface
+domain-suffix:cursor.com
+domain-suffix:v0.dev
+domain-suffix:character.ai
+domain-suffix:mistral.ai
+domain-suffix:cohere.ai
+domain-suffix:cohere.com
+domain-suffix:replicate.com
+domain-suffix:together.ai
+domain-suffix:runpod.io
+domain-suffix:openrouter.ai
+domain-suffix:suno.ai
+domain-suffix:suno.com
+domain-suffix:midjourney.com
+domain-suffix:pi.ai
+domain-suffix:inflection.ai
+```
+
+### 2️⃣ 💰 加密货币
+**推荐节点**：🇭🇰 香港 / 🇯🇵 日韩（合规性）
+
+**域名列表**：
+```
+geosite:cryptocurrency
+geosite:binance
+domain-suffix:tradingview.com
+domain-suffix:coinglass.com
+domain-suffix:coinmarketcap.com
+domain-suffix:coingecko.com
+```
+
+### 3️⃣ 🏦 金融支付
+**推荐节点**：🌍 全球
+
+**域名列表**：
+```
+geosite:paypal
+geosite:stripe
+domain-suffix:wise.com
+domain-suffix:revolut.com
+domain-suffix:visa.com
+domain-suffix:mastercard.com
+domain-suffix:amex.com
+```
+
+### 4️⃣ 📧 邮件服务
+**推荐节点**：🇯🇵 日韩 / 🌍 全球
+
+**域名列表**：
+```
+geosite:gmail
+geosite:outlook
+geosite:protonmail
+domain-suffix:fastmail.com
+domain-suffix:tuta.com
+domain-suffix:mail.ru
+```
+
+### 5️⃣ 💬 即时通讯
+**推荐节点**：🇭🇰 香港 / 🇯🇵 日韩
+
+**域名列表**：
+```
+geosite:telegram
+geosite:discord
+geosite:whatsapp
+geosite:line
+geosite:signal
+geosite:kakaotalk
+```
+
+**IP 列表**：
+```
+geoip:telegram
+```
+
+### 6️⃣ 📱 社交媒体
+**推荐节点**：🇯🇵 日韩 / 🌍 全球
+
+**域名列表**：
+```
+geosite:twitter
+geosite:facebook
+geosite:instagram
+geosite:tiktok
+geosite:reddit
+geosite:pinterest
+geosite:linkedin
+geosite:snap
+```
+
+**IP 列表**：
+```
+geoip:twitter
+geoip:facebook
+```
+
+### 7️⃣ 🧑‍💼 会议协作
+**推荐节点**：🇯🇵 日韩 / 🌍 全球
+
+**域名列表**：
+```
+geosite:zoom
+geosite:teams
+geosite:slack
+geosite:notion
+geosite:atlassian
+domain-suffix:meet.google.com
+```
+
+### 8️⃣ 📺 国内流媒体
+**推荐**：**direct**（境内）或 🇭🇰 香港（境外）
+
+**域名列表**：
+```
+geosite:bilibili
+geosite:iqiyi
+geosite:youku
+geosite:tencentvideo
+geosite:mgtv
+geosite:douyin
+geosite:netease-music
+geosite:qqmusic
+```
+
+### 9️⃣ 📺 东南亚流媒体
+**推荐节点**：🌏 亚太（SG/ID）
+
+**域名列表**：
+```
+geosite:viu
+domain-suffix:iq.com
+domain-suffix:wetv.vip
+domain-suffix:vidio.com
+domain-suffix:iqiyiintl.com
+```
+
+### 🔟 🇺🇸 美国流媒体
+**推荐节点**：🇺🇸 美国
+
+**域名列表**：
+```
+geosite:youtube
+geosite:netflix
+geosite:disney
+geosite:hbo
+geosite:hulu
+geosite:spotify
+geosite:primevideo
+domain-suffix:paramountplus.com
+domain-suffix:peacocktv.com
+domain-suffix:twitch.tv
+```
+
+**IP 列表**：
+```
+geoip:netflix
+```
+
+### 1️⃣1️⃣ 🇭🇰 香港流媒体
+**推荐节点**：🇭🇰 香港
+
+**域名列表**：
+```
+geosite:mytvsuper
+domain-suffix:mytvsuper.com
+domain-suffix:now.com
+domain-suffix:viu.tv
+domain-suffix:encoretvb.com
+domain-suffix:rthk.hk
+```
+
+### 1️⃣2️⃣ 🇹🇼 台湾流媒体
+**推荐节点**：🇹🇼 台湾
+
+**域名列表**：
+```
+geosite:bahamut
+domain-suffix:bahamut.com.tw
+domain-suffix:hinet.net
+domain-suffix:kktv.me
+domain-suffix:litv.tv
+domain-suffix:hamivideo.hinet.net
+domain-suffix:friday.tw
+```
+
+### 1️⃣3️⃣ 🇯🇵 日韩流媒体
+**推荐节点**：🇯🇵 日韩
+
+**域名列表**：
+```
+geosite:abema
+geosite:niconico
+domain-suffix:dazn.com
+domain-suffix:dmm.com
+domain-suffix:tv-tokyo.co.jp
+domain-suffix:tver.jp
+domain-suffix:rakuten.tv
+```
+
+### 1️⃣4️⃣ 🇪🇺 欧洲流媒体
+**推荐节点**：🇪🇺 欧洲
+
+**域名列表**：
+```
+geosite:bbc
+domain-suffix:itv.com
+domain-suffix:channel4.com
+domain-suffix:my5.tv
+domain-suffix:sky.com
+domain-suffix:skygo.com
+domain-suffix:britbox.co.uk
+```
+
+### 1️⃣5️⃣ 🕹️ 国内游戏
+**推荐**：**direct**
+
+**域名列表**：
+```
+geosite:steamcn
+domain-suffix:wanmei.com
+domain-suffix:majsoul.com
+domain-suffix:battlenet.com.cn
+```
+
+### 1️⃣6️⃣ 🎮 国外游戏
+**推荐节点**：🇯🇵 日韩 / 🇭🇰 香港
+
+**域名列表**：
+```
+geosite:steam
+geosite:epicgames
+geosite:playstation
+geosite:xbox
+geosite:nintendo
+domain-suffix:riotgames.com
+domain-suffix:ea.com
+domain-suffix:blizzard.com
+domain-suffix:hoyoverse.com
+domain-suffix:mihoyo.com
+```
+
+### 1️⃣7️⃣ 🔍 搜索引擎
+**推荐节点**：🌍 全球
+
+**域名列表**：
+```
+geosite:google
+geosite:bing
+geosite:duckduckgo
+geosite:yandex
+domain-suffix:scholar.google.com
+```
+
+**IP 列表**：
+```
+geoip:google
+```
+
+### 1️⃣8️⃣ 📟 开发者服务
+**推荐节点**：🇺🇸 美国 / 🌍 全球
+
+**域名列表**：
+```
+geosite:github
+geosite:gitlab
+geosite:docker
+geosite:npmjs
+geosite:pypi
+geosite:python
+domain-suffix:jetbrains.com
+domain-suffix:stackoverflow.com
+domain-suffix:stackexchange.com
+```
+
+### 1️⃣9️⃣ Ⓜ️ 微软服务
+**推荐节点**：🌍 全球
+
+**域名列表**：
+```
+geosite:microsoft
+geosite:onedrive
+domain-suffix:office.com
+domain-suffix:live.com
+domain-suffix:microsoftedge.com
+```
+
+### 2️⃣0️⃣ 🍎 苹果服务
+**推荐**：**direct**（境内）或 🌍 全球（境外）
+
+**域名列表**：
+```
+geosite:apple
+geosite:icloud
+domain-suffix:appstore.com
+domain-suffix:mzstatic.com
+domain-suffix:itunes.com
+domain-suffix:applemusic.com
+domain-suffix:apple-dns.net
+```
+
+### 2️⃣1️⃣ 📥 下载更新
+**推荐**：**direct**
+
+**域名列表**：
+```
+domain-suffix:dl.google.com
+domain-suffix:play.googleapis.com
+domain-suffix:msftconnecttest.com
+domain-suffix:windowsupdate.com
+domain-suffix:cdn-apple.com
+domain-suffix:ubuntu.com
+domain-suffix:mozilla.org
+domain-suffix:apkpure.com
+```
+
+### 2️⃣2️⃣ ☁️ 云与CDN
+**推荐节点**：🌍 全球
+
+**域名列表**：
+```
+geosite:cloudflare
+geosite:fastly
+geosite:akamai
+domain-suffix:jsdelivr.net
+domain-suffix:cloudfront.net
+```
+
+**IP 列表**：
+```
+geoip:cloudflare
+geoip:fastly
+```
+
+### 2️⃣3️⃣ 🛰️ BT/PT Tracker
+**推荐**：**direct** 或 **block**
+
+**域名列表**：
+```
+geosite:private-tracker
+domain-suffix:opentrackr.org
+domain-suffix:openbittorrent.com
+domain-suffix:nyaa.si
+```
+
+### 2️⃣4️⃣ 🏠 国内网站（倒数第 5 条 — 位置重要）
+**推荐**：**direct**
+
+**域名列表**：
+```
+geosite:cn
+```
+
+**IP 列表**：
+```
+geoip:cn
+geoip:private
+```
+
+### 2️⃣5️⃣ 🚫 受限网站（倒数第 4 条）
+**推荐节点**：🌍 全球
+
+**域名列表**：
+```
+geosite:gfw
+geosite:greatfire
+```
+
+### 2️⃣6️⃣ 🌐 国外网站（倒数第 3 条）
+**推荐节点**：🌍 全球
+
+**域名列表**：
+```
+geosite:geolocation-!cn
+domain-suffix:cnn.com
+domain-suffix:nytimes.com
+domain-suffix:bloomberg.com
+domain-suffix:wikipedia.org
+```
+
+### 2️⃣7️⃣ 🐟 漏网之鱼 FINAL（倒数第 2 条）
+**推荐节点**：🌍 全球
+
+**域名列表**：留空（或 `domain-keyword:` 通配）
+**IP 列表**：留空
+**网络**：tcp,udp
+**匹配**：Passwall2 把这条设置为**兜底规则**（通常是「其余流量默认走代理主节点」开关）
+
+### 2️⃣8️⃣ 🛑 广告拦截（最后 1 条，但要**优先级最高**）
+**推荐**：**block（拒绝）**
+
+**域名列表**：
+```
+geosite:category-ads-all
+```
+
+Passwall2 有个单独的"黑名单"或"广告拦截"切换开关，直接开即可；或者本条规则的"目标节点"选 `reject` / `block`。
+
+---
+
+## 🔁 从 OpenClash 切过来？或反过来？
+
+这两个插件**不能同时启用**（会互相覆盖 iptables 规则）。切换方法：
+
+```sh
+# 停 OpenClash，换 Passwall2
+/etc/init.d/openclash stop
+/etc/init.d/openclash disable
+/etc/init.d/passwall2 enable
+/etc/init.d/passwall2 start
+```
+
+想换回 OpenClash 反过来就行。配置互相独立保留，切换无数据丢失。
+
+**我们强烈推荐 OpenClash**。Passwall2 版本是降级版，用于不愿意换插件的用户兜底。
+
+---
+
+## 📚 参考
+
+- Passwall2 项目：https://github.com/xiaorouji/openwrt-passwall2
+- Passwall（旧版）：https://github.com/xiaorouji/openwrt-passwall
+- MetaCubeX geosite.dat：https://github.com/MetaCubeX/meta-rules-dat（本参考使用的分类名称依据）
+- 本仓库完整体验：`OpenClash/README.md`（强烈推荐）


### PR DESCRIPTION
…59 but folder was empty)

Maintainer noticed the Passwall2/ directory referenced in CLAUDE.md §0, AGENTS.md §1, root README, and OpenClash/README.md was never actually created — the directory existed locally as empty (git doesn't track empty dirs), so it was missing from all prior pushes.

Backfilling now as v5.2.5-pw2.1 so the docs become consistent.

New files:

  Passwall2/README.md  (516 lines)
    - 零基础 5 分钟快速开始 block
    - Honest "能和不能" comparison vs OpenClash (~70% functionality)
    - Protocol support table (inherits from user's selected core: xray / sing-box, i.e. same as v2rayN non-mihomo modes)
    - **28 shunt-rule reference list** — each rule block contains:
        - 规则名 (matches Clash Party baseline category)
        - 推荐节点区域 (maps to the 9 region groups) - 域名列表 (geosite:xxx primary + domain-suffix:xxx fill-ins) - IP 列表 (geoip:xxx where relevant: telegram/netflix/twitter/ facebook/google/cloudflare/fastly/cn/private)
    - Ordering constraints explained (ads top-priority via Passwall2's dedicated blacklist toggle; CN/GFW/!cn/FINAL bottom-most positions)
    - OpenClash ↔ Passwall2 switchover commands (init.d stop/disable/enable/start sequence) + explicit "don't run both simultaneously or iptables will fight"

  Passwall2/CHANGELOG.md  (54 lines)
    - v5.2.5-pw2.1 initial release notes
    - Explicit "与 Clash Party 主线的差异" list (5 items covering proxy-groups, LightGBM, auto-classify, JS override, rule- provider format; plus ad-blocking downgrade to single list)
    - 推荐/不推荐使用场景 (sets expectations honestly)
    - Maintenance sync policy: business-category changes must sync to shunt rule list, but LightGBM/url-test interval tweaks are exempt (matches CLAUDE.md §1.4 exceptions)

Design choices:

  - Chose markdown reference format over a binary JSON/UCI config because Passwall2's LuCI UI doesn't have bulk import for shunt rules — users click "新增" 28 times and paste the domain_list. A single readable markdown is the most human-friendly deliverable.

  - Used geosite:xxx for categories MetaCubeX/v2fly definitely provides; domain-suffix:xxx for newer services (cursor.com, v0.dev, character.ai, pi.ai etc.) that geosite may not yet include.

  - Did NOT generate a full passwall2-smart-shunt.json or UCI config fragment — those formats vary per Passwall2 community fork (iceeeder / xiaorouter / immortalwrt) and would need per-fork maintenance. Markdown reference is fork-agnostic.

Doc consistency now satisfied:
  - CLAUDE.md §0 reference to "Passwall2/ 目录" → points to real content
  - AGENTS.md §1 同 → 同
  - Root README.md "迁移到 OpenClash 或用 Passwall2/ 目录里的 shunt rule 简化版" → the simplified version now exists
  - OpenClash/README.md 顶部迁移段 "想保留 Passwall/Passwall2 + 拿 到约 70% 的分流能力，用本仓库 Passwall2/ 目录" → same