### PR TITLE
docs: move 🧩 28 代理组速览 before 🎯 差异化价值 + rename + drop redundant 仓库对照

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,60 @@ DNS/嗅探层（Resolver + Sniffer Layer）
 使用 GEOIP / GEOSITE / Private 等规则做最后防线，保证“未知流量不裸奔、已知流量有归属”。
 
 ---
+## 🧩 Smart 分流规则：28 代理组速览
+
+为了让结构更清晰，下面用“**分层卡片 + 关系图**”展示 28 个代理组，而不是单一大表。
+
+```mermaid
+flowchart LR
+    A(入口总控 2组) --> B(核心业务 10组)
+    B --> C(区域选路 8组)
+    C --> D(基础能力 5组)
+    D --> E(兜底直连 3组)
+
+    style A fill:#EAF4FF,stroke:#4A90E2,stroke-width:1px
+    style B fill:#EEF9F1,stroke:#27AE60,stroke-width:1px
+    style C fill:#FFF6E9,stroke:#F39C12,stroke-width:1px
+    style D fill:#F3F0FF,stroke:#8E44AD,stroke-width:1px
+    style E fill:#FFEFF0,stroke:#E74C3C,stroke-width:1px
+```
+
+### 🗂️ 代理组与主要 Rule-Providers 对照（Clash Party 实际 28 业务组）
+
+> 只列“主要/高频命中”项，并标明规则来源仓库；不再混入节点组（HK/US/全球节点等）。
+
+| 代理组（与脚本一致） | 主要 rule-providers（示例） | 主要来源仓库 |
+|---|---|---|
+| 🤖 AI 服务 | `openai` `claude` `gemini` `copilot` `szkane-ai` `acc-copilot` | MetaCubeX / blackmatrix7 / szkane / Accademia |
+| 💰 加密货币 | `cryptocurrency` `binance` `szkane-web3` | blackmatrix7 / szkane |
+| 🏦 金融支付 | `paypal` `stripe` `visa` `tigerfintech` `acc-bank-*` `acc-vf-*` | blackmatrix7 / Accademia |
+| 📧 邮件服务 | `mail` `mailru` `protonmail` `spark` | blackmatrix7 |
+| 💬 即时通讯 | `telegram` `telegram-ip` `discord` `whatsapp` `line` `kakaotalk` `acc-signal` | MetaCubeX / blackmatrix7 / Accademia |
+| 📱 社交媒体 | `twitter` `twitter-ip` `tiktok` `facebook` `instagram` `snapchat` `reddit` | MetaCubeX / blackmatrix7 |
+| 🧑‍💼 会议协作 | `zoom` `slack` `teams` `atlassian` `notion` `remotedesktop` `acc-rustdesk` | ACL4SSR / blackmatrix7 / Accademia |
+| 📺 国内流媒体 | `bilibili` `iqiyi` `youku` `tencentvideo` `douyin` `neteasemusic` | blackmatrix7 |
+| 📺 东南亚流媒体 | `viu` `biliintl` `iqiyiintl` `wetv` `viki` `acc-kwai` | blackmatrix7 / Accademia |
+| 🇺🇸 美国流媒体 | `youtube` `netflix` `netflix-ip` `spotify` `disney` `hulu` `primevideo` | MetaCubeX / blackmatrix7 / szkane |
+| 🇭🇰 香港流媒体 | `mytvsuper` `tvb` `encoretvb` `nowe` `rthk` `szkane-bilihmt` | blackmatrix7 / szkane |
+| 🇹🇼 台湾流媒体 | `bahamut` `kktv` `litv` `hamivideo` `linetv` `friday` | blackmatrix7 |
+| 🇯🇵 日韩流媒体 | `abema` `dazn` `dmm` `tver` `niconico` `rakuten` | blackmatrix7 |
+| 🇪🇺 欧洲流媒体 | `bbc` `itv` `all4` `my5` `skygo` `britboxuk` `szkane-uk` | MetaCubeX / blackmatrix7 / szkane |
+| 🕹️ 国内游戏 | `steamcn` `wanmeishijie` `wankahuanju` `majsoul` | blackmatrix7 |
+| 🎮 国外游戏 | `steam` `epic` `playstation` `xbox` `riot` `ea` `hoyoverse` | blackmatrix7 |
+| 🔍 搜索引擎 | `google` `google-ip` `googlesearch` `bing` `scholar` `yandex` | MetaCubeX / blackmatrix7 |
+| 📟 开发者服务 | `github` `docker` `gitlab` `python` `developer` `szkane-developer` | blackmatrix7 / szkane |
+| Ⓜ️ 微软服务 | `onedrive` `microsoft` `microsoftedge` `acc-microsoftapps` | blackmatrix7 / Accademia |
+| 🍎 苹果服务 | `apple` `icloud` `appstore` `appletv` `applemusic` `acc-apple` `acc-applenews` | blackmatrix7 / Accademia |
+| 📥 下载更新 | `googlefcm` `systemota` `download` `ubuntu` `mozilla` `android` `acc-macappupgrade` | blackmatrix7 / Accademia |
+| ☁️ 云与CDN | `cloudflare` `cloudflare-ip` `cloudfront-ip` `fastly-ip` `akamai` `acc-fastly` | MetaCubeX / blackmatrix7 / Accademia |
+| 🛰️ BT/PT Tracker | `privatetracker` `acc-emuleserver` | blackmatrix7 / Accademia |
+| 🏠 国内网站 | `cn` `cn-ip` `acc-geositecn` `acc-chinamax` `acc-china` `acc-geo-d-asia-china` | MetaCubeX / blackmatrix7 / Accademia |
+| 🚫 受限网站 | `loyalsoldier-gfw` `loyalsoldier-greatfire` `szkane-proxygfw` | Loyalsoldier / szkane |
+| 🌐 国外网站 | `proxy` `cnn` `nytimes` `bloomberg` `ebay` `wikipedia` `acc-waybackmachine` | blackmatrix7 / Accademia / szkane |
+| 🐟 漏网之鱼 | 以 GEOSITE/GEOIP/FINAL 兜底为主（非单一固定 provider） | MetaCubeX（geo 规则） |
+| 🛑 广告拦截 | `anti-ad` `sukka-phishing` `hagezi-tif` `advertising` `privacy` `acc-unsupportvpn` | DustinWin / SukkaW / Hagezi / blackmatrix7 / Accademia |
+
+---
 
 ## 🎯 差异化价值：补充 rule-provider 相对原生 `geosite.dat` + `geoip.dat` 的差异
 
@@ -305,73 +359,6 @@ rules:
 > 本仓库在匹配层的增量 = **geosite 未收录的新兴服务** + **geosite 总类的子类拆分** + **多源纵深广告拦截** + **地区长尾 ASN**。**原生 geosite / geoip 能覆盖的部分一律不重复造轮子**。300 个补充 rule-provider 的每一条，都对应上述 4 类空白之一。
 >
 > 代理组嵌套 / Smart / LightGBM / JS 自动归类这些架构能力是另一维度（Axis 2），和匹配源用什么数据库**无关**，本节不涉及。
-
----
-
-## 🧩 Clash Party 分流规则：28 代理组速览
-
-为了让结构更清晰，下面用“**分层卡片 + 关系图**”展示 28 个代理组，而不是单一大表。
-
-```mermaid
-flowchart LR
-    A(入口总控 2组) --> B(核心业务 10组)
-    B --> C(区域选路 8组)
-    C --> D(基础能力 5组)
-    D --> E(兜底直连 3组)
-
-    style A fill:#EAF4FF,stroke:#4A90E2,stroke-width:1px
-    style B fill:#EEF9F1,stroke:#27AE60,stroke-width:1px
-    style C fill:#FFF6E9,stroke:#F39C12,stroke-width:1px
-    style D fill:#F3F0FF,stroke:#8E44AD,stroke-width:1px
-    style E fill:#FFEFF0,stroke:#E74C3C,stroke-width:1px
-```
-
-### 🗂️ 代理组与主要 Rule-Providers 对照（Clash Party 实际 28 业务组）
-
-> 只列“主要/高频命中”项，并标明规则来源仓库；不再混入节点组（HK/US/全球节点等）。
-
-| 代理组（与脚本一致） | 主要 rule-providers（示例） | 主要来源仓库 |
-|---|---|---|
-| 🤖 AI 服务 | `openai` `claude` `gemini` `copilot` `szkane-ai` `acc-copilot` | MetaCubeX / blackmatrix7 / szkane / Accademia |
-| 💰 加密货币 | `cryptocurrency` `binance` `szkane-web3` | blackmatrix7 / szkane |
-| 🏦 金融支付 | `paypal` `stripe` `visa` `tigerfintech` `acc-bank-*` `acc-vf-*` | blackmatrix7 / Accademia |
-| 📧 邮件服务 | `mail` `mailru` `protonmail` `spark` | blackmatrix7 |
-| 💬 即时通讯 | `telegram` `telegram-ip` `discord` `whatsapp` `line` `kakaotalk` `acc-signal` | MetaCubeX / blackmatrix7 / Accademia |
-| 📱 社交媒体 | `twitter` `twitter-ip` `tiktok` `facebook` `instagram` `snapchat` `reddit` | MetaCubeX / blackmatrix7 |
-| 🧑‍💼 会议协作 | `zoom` `slack` `teams` `atlassian` `notion` `remotedesktop` `acc-rustdesk` | ACL4SSR / blackmatrix7 / Accademia |
-| 📺 国内流媒体 | `bilibili` `iqiyi` `youku` `tencentvideo` `douyin` `neteasemusic` | blackmatrix7 |
-| 📺 东南亚流媒体 | `viu` `biliintl` `iqiyiintl` `wetv` `viki` `acc-kwai` | blackmatrix7 / Accademia |
-| 🇺🇸 美国流媒体 | `youtube` `netflix` `netflix-ip` `spotify` `disney` `hulu` `primevideo` | MetaCubeX / blackmatrix7 / szkane |
-| 🇭🇰 香港流媒体 | `mytvsuper` `tvb` `encoretvb` `nowe` `rthk` `szkane-bilihmt` | blackmatrix7 / szkane |
-| 🇹🇼 台湾流媒体 | `bahamut` `kktv` `litv` `hamivideo` `linetv` `friday` | blackmatrix7 |
-| 🇯🇵 日韩流媒体 | `abema` `dazn` `dmm` `tver` `niconico` `rakuten` | blackmatrix7 |
-| 🇪🇺 欧洲流媒体 | `bbc` `itv` `all4` `my5` `skygo` `britboxuk` `szkane-uk` | MetaCubeX / blackmatrix7 / szkane |
-| 🕹️ 国内游戏 | `steamcn` `wanmeishijie` `wankahuanju` `majsoul` | blackmatrix7 |
-| 🎮 国外游戏 | `steam` `epic` `playstation` `xbox` `riot` `ea` `hoyoverse` | blackmatrix7 |
-| 🔍 搜索引擎 | `google` `google-ip` `googlesearch` `bing` `scholar` `yandex` | MetaCubeX / blackmatrix7 |
-| 📟 开发者服务 | `github` `docker` `gitlab` `python` `developer` `szkane-developer` | blackmatrix7 / szkane |
-| Ⓜ️ 微软服务 | `onedrive` `microsoft` `microsoftedge` `acc-microsoftapps` | blackmatrix7 / Accademia |
-| 🍎 苹果服务 | `apple` `icloud` `appstore` `appletv` `applemusic` `acc-apple` `acc-applenews` | blackmatrix7 / Accademia |
-| 📥 下载更新 | `googlefcm` `systemota` `download` `ubuntu` `mozilla` `android` `acc-macappupgrade` | blackmatrix7 / Accademia |
-| ☁️ 云与CDN | `cloudflare` `cloudflare-ip` `cloudfront-ip` `fastly-ip` `akamai` `acc-fastly` | MetaCubeX / blackmatrix7 / Accademia |
-| 🛰️ BT/PT Tracker | `privatetracker` `acc-emuleserver` | blackmatrix7 / Accademia |
-| 🏠 国内网站 | `cn` `cn-ip` `acc-geositecn` `acc-chinamax` `acc-china` `acc-geo-d-asia-china` | MetaCubeX / blackmatrix7 / Accademia |
-| 🚫 受限网站 | `loyalsoldier-gfw` `loyalsoldier-greatfire` `szkane-proxygfw` | Loyalsoldier / szkane |
-| 🌐 国外网站 | `proxy` `cnn` `nytimes` `bloomberg` `ebay` `wikipedia` `acc-waybackmachine` | blackmatrix7 / Accademia / szkane |
-| 🐟 漏网之鱼 | 以 GEOSITE/GEOIP/FINAL 兜底为主（非单一固定 provider） | MetaCubeX（geo 规则） |
-| 🛑 广告拦截 | `anti-ad` `sukka-phishing` `hagezi-tif` `advertising` `privacy` `acc-unsupportvpn` | DustinWin / SukkaW / Hagezi / blackmatrix7 / Accademia |
-
-> 仓库对照：
-> - **MetaCubeX**：`MetaCubeX/meta-rules-dat`
-> - **blackmatrix7**：`blackmatrix7/ios_rule_script`
-> - **Accademia**：`Accademia/Additional_Rule_For_Clash`
-> - **ACL4SSR**：`ACL4SSR/ACL4SSR`（Zoom）
-> - **Loyalsoldier**：`Loyalsoldier/clash-rules`
-> - **DustinWin**：`DustinWin/ruleset_geodata`（anti-ad）
-> - **SukkaW**：`SukkaW/Surge`（phishing）
-> - **Hagezi**：`hagezi/dns-blocklists`（TIF）
-> - **szkane**：`szkane/Rules`（AI/UK/开发等补充）
-
 
 ---
 


### PR DESCRIPTION
Three related changes per maintainer:

1. Reorder: 🧩 section moves up from "between 🎯 and 🛡️" to "between 🧭 设计框架 and 🎯 差异化价值"

   New reading flow:
     🧭 设计框架        (abstract 5-layer architecture)
     🧩 28 代理组速览   ← shows the concrete 28 groups + rule-provider
                         mapping (the "what")
     🎯 差异化价值       ← explains why those ~300 rule-providers are
                         needed beyond raw geosite/geoip (the "why
                         not simpler")
     🛡️ DNS 净化
     🔌 协议 + 导入速查
     ...

   Logic: readers see the concrete group layout + rule-provider inventory FIRST, then understand why those supplementary providers are there. Previous order had the "why" before the "what" which was less intuitive.

2. Rename: "🧩 Clash Party 分流规则：28 代理组速览" → "🧩 Smart 分流规则：28 代理组速览"

   Reason: the 28-group design is the semantic core of the whole repo and applies to ALL 10 products, not just Clash Party. Using "Smart 分流规则" (referring to the Smart groups / LightGBM-backed architecture) is more accurate about what is being described.

3. Delete redundant 「仓库对照」 legend at the end of the section:

      > 仓库对照：
      > - MetaCubeX: MetaCubeX/meta-rules-dat
      > - blackmatrix7: blackmatrix7/ios_rule_script
      > - Accademia: Accademia/Additional_Rule_For_Clash
      > - ACL4SSR: ACL4SSR/ACL4SSR (Zoom)
      > - Loyalsoldier: Loyalsoldier/clash-rules
      > - DustinWin: DustinWin/ruleset_geodata (anti-ad)
      > - SukkaW: SukkaW/Surge (phishing)
      > - Hagezi: hagezi/dns-blocklists (TIF)
      > - szkane: szkane/Rules (AI/UK/dev 补充)

   All 9 repos already listed in 🙏 致谢 section (with hyperlinks + categorization). Duplicating here was redundant.

README: 602 → 589 lines.