### PR TITLE
fix(ci): remove literal empty GitHub expressions from comments

### DIFF
--- a/.github/workflows/ai-responder.yml
+++ b/.github/workflows/ai-responder.yml
@@ -88,7 +88,7 @@ jobs:
             head -150 README.md 2>/dev/null || echo "(README.md not found)"
           } > /tmp/context.txt
           # 不再走 GITHUB_OUTPUT 回传 + jq -Rs 编码——下一步直接 jq --rawfile 读 /tmp/context.txt，
-          # 既绕开了 ${{ }} 文本替换破坏 JSON 引号的坑，又少 30 行代码。
+          # 既绕开了 GitHub Actions 模板替换破坏 JSON 引号的坑，又少 30 行代码。
           echo "✅ context built: $(wc -l < /tmp/context.txt) lines, $(wc -c < /tmp/context.txt) bytes"
 
       - name: Call DeepSeek API
@@ -96,7 +96,8 @@ jobs:
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           # 全部走 env 把不可信用户输入隔离到环境变量，bash 不会再次解释——
-          # 直接 ${{ }} 拼到 run: 里会被 GitHub Actions 文本替换，留下引号注入风险。
+          # 如果把 GitHub Actions 表达式直接拼到 run: 里，会在 YAML 阶段做纯文本替换，
+          # 留下引号注入风险（评论含 " 或反引号就炸）。
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
@@ -259,8 +260,8 @@ jobs:
         if: steps.llm.outputs.skipped != 'true'
         uses: actions/github-script@v7
         env:
-          # 走 env 而不是直接 ${{ }} 拼到 script 里——AI 回复必含反引号（markdown 代码块），
-          # 直接拼进 JS 模板字符串会破坏语法。env 走 process.env 安全。
+          # 走 env 而不是直接把 GitHub Actions 表达式拼到 script 里——AI 回复必含反引号
+          # （markdown 代码块），直接拼进 JS 模板字符串会破坏语法。env 走 process.env 安全。
           AI_REPLY: ${{ steps.llm.outputs.reply }}
           AI_MODEL: ${{ steps.llm.outputs.model }}
           AI_TIER:  ${{ steps.llm.outputs.tier_label }}


### PR DESCRIPTION
真正的失败原因：workflow 文件里 3 处注释包含裸 \${{ }}（空表达式）。
GitHub 的 workflow 解析器**扫描整个 YAML** 寻找 \${{ ... }} 表达式做预处理， **不管是不是在 shell # 注释里**。看到空的 \${{ }} 就 Expected an expression 解析失败 → workflow 整个文件被标为 invalid → 所有触发事件（包括 issue_comment /ai-help）都不会执行，连失败 log 都不会出现在 action 历史里。

之前的"exit code 2"是 workflow 在某次真正跑起来时 jq 的失败，引号问题修复后 commit 到 main，但那个 commit 同时引入了这 3 处注释里的 \${{ }}——新的解析错误 直接让 workflow 对所有后续事件都失效。

修复：把 3 处注释里的 \${{ }} 改成中文描述（"GitHub Actions 模板替换" / "GitHub Actions 表达式"），既表达意思又不触发解析器。

诊断线索：Actions tab 看到 "Invalid workflow file" 错误，报第 77 行 14 列 "Expected an expression"（中文 UI 误译为"期待一个表情"），实际是 \${{ }} 空表达式报错的定位——GitHub 把整个 run: 块的错误归到 run: | 那行。

附带观察：这也解释了为什么前几次提交都"没反应"——每次改动都把 workflow
push 上去，GitHub 都尝试解析，一直失败。