### PR TITLE
feat(ci): auto-cleanup old Actions runs (daily, >1 day)

### DIFF
--- a/.github/workflows/cleanup-old-runs.yml
+++ b/.github/workflows/cleanup-old-runs.yml
@@ -1,0 +1,111 @@
+name: Cleanup Old Workflow Runs
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 定期清理 Actions 历史 run（默认：保留 1 天内的）
+# ───────────────────────────────────────────────────────────────────────────
+# 触发方式：
+#   1. schedule 每天 02:30 UTC（北京时间 10:30）自动跑
+#   2. workflow_dispatch 手动触发（可覆盖保留天数）
+#
+# 工作原理：
+#   - 列出全仓所有 workflow run（github.paginate 处理翻页）
+#   - 过滤：创建时间早于 cutoff（默认 now - 1 天）
+#   - 跳过：in_progress / queued / waiting 等活跃 run（API 也不允许删）
+#   - 逐个调用 DELETE /repos/{owner}/{repo}/actions/runs/{run_id}
+#
+# 权限：actions: write（删 run 必须）
+#
+# 安全提示：
+#   - 被删除的 run log 无法恢复；如果要留证据做长期审计，
+#     调大 RETAIN_DAYS 或整个删掉本 workflow
+#   - 本 workflow 自己的 run 也会在第二天被下一次运行清掉，这是预期行为
+# ═══════════════════════════════════════════════════════════════════════════
+
+on:
+  schedule:
+    # 每天 02:30 UTC（北京 10:30）——选低峰避免和其他 scheduled workflow 挤
+    - cron: '30 2 * * *'
+
+  workflow_dispatch:
+    inputs:
+      retain_days:
+        description: '保留天数（删除创建时间超过这个天数的 run）。手动调试时可填 0 = 全删'
+        type: string
+        required: false
+        default: '1'
+
+permissions:
+  actions: write       # 删 run 必须
+  contents: read       # 读 repo 元信息（default）
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Delete runs older than RETAIN_DAYS
+        uses: actions/github-script@v7
+        env:
+          # schedule 触发时 github.event.inputs 为空，用 '1' 兜底
+          RETAIN_DAYS: ${{ github.event.inputs.retain_days || '1' }}
+        with:
+          script: |
+            const retainDays = Number(process.env.RETAIN_DAYS) || 1;
+            const cutoff = new Date(Date.now() - retainDays * 86_400_000);
+            console.log(`🗓️  Cutoff: ${cutoff.toISOString()}  (retain_days=${retainDays})`);
+            console.log(`🎯  Will delete runs created BEFORE the cutoff above`);
+
+            // 翻页拉全仓 run（一页 100 条，paginate 自动走完所有页）
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRunsForRepo,
+              { owner: context.repo.owner, repo: context.repo.repo, per_page: 100 }
+            );
+            console.log(`📊  Found ${runs.length} total workflow run(s) in repo`);
+
+            const ACTIVE = new Set(['in_progress', 'queued', 'waiting', 'requested', 'pending']);
+            let deleted = 0, kept = 0, skippedActive = 0, failed = 0;
+
+            for (const run of runs) {
+              if (ACTIVE.has(run.status)) {
+                skippedActive++;
+                continue;
+              }
+              if (new Date(run.created_at) >= cutoff) {
+                kept++;
+                continue;
+              }
+              try {
+                await github.rest.actions.deleteWorkflowRun({
+                  owner:  context.repo.owner,
+                  repo:   context.repo.repo,
+                  run_id: run.id,
+                });
+                deleted++;
+                console.log(`🗑️  #${run.id}  ${run.name}  (${run.created_at})`);
+              } catch (e) {
+                failed++;
+                console.error(`❌  #${run.id}  ${run.name}: ${e.message}`);
+              }
+            }
+
+            console.log('─────────────────────────────────────────');
+            console.log(`✅  Deleted:         ${deleted}`);
+            console.log(`⏭️  Kept (≤ cutoff): ${kept}`);
+            console.log(`⚙️  Skipped active:  ${skippedActive}`);
+            console.log(`❌  Failed:          ${failed}`);
+
+            // 把统计写进 GitHub Actions summary，Actions 页面能直接看
+            await core.summary
+              .addHeading('Workflow Runs Cleanup')
+              .addTable([
+                [{data: 'Metric', header: true}, {data: 'Count', header: true}],
+                ['Retain days',       String(retainDays)],
+                ['Cutoff (UTC)',      cutoff.toISOString()],
+                ['Total scanned',     String(runs.length)],
+                ['Deleted',           String(deleted)],
+                ['Kept (too recent)', String(kept)],
+                ['Skipped (active)',  String(skippedActive)],
+                ['Failed',            String(failed)],
+              ])
+              .write();


### PR DESCRIPTION
新增 .github/workflows/cleanup-old-runs.yml：
- 每天 02:30 UTC（北京 10:30）schedule 自动跑，删除超过 1 天的 workflow run
- 也支持 workflow_dispatch 手动触发，可在 UI 里传 retain_days 覆盖默认值 （填 0 = 全删，适合一次性清理）
- 使用 actions/github-script@v7 内嵌调 Octokit：
  - github.paginate 翻页拉全仓 run
  - 跳过 in_progress/queued/waiting 等活跃 run
  - 调 actions.deleteWorkflowRun 删除超龄 run
- 结果写入 GitHub Actions job summary，页面直接可看统计
- 权限：actions:write（删 run 必须）+ contents:read（默认）

实现选择说明：
- 没用第三方 action（如 Mattraks/delete-workflow-runs）——保持零外部依赖， 和 ai-responder.yml 已用的 github-script 一致
- 没加 "每个 workflow 至少保留 N 条" 的安全网——用户明确要求"超过 1 天就删" 需要保留长期审计就调大 retain_days