### PR TITLE
fix(loon): align v5.2.4-Loon.2 with Loon native syntax

### DIFF
--- a/Loon/CHANGELOG.md
+++ b/Loon/CHANGELOG.md
@@ -4,6 +4,87 @@
 
 ---
 
+## v5.2.4-Loon.2 (2026-04-22) — Loon 原生语法兼容性大修
+
+用户反馈"Loon 用不了好像 好多和配置文件冲突" — 复核后确认 v5.2.3-Loon.1 把
+多处 Surge 语法直接搬进了 Loon（Loon 不识别 → 段/规则大面积沉默失效）。本版
+以 YueChan/Loon、Loon0x00/LoonExampleConfig、fmz200/wool_scripts 三份权威
+Loon 配置为对照，逐项对齐 Loon 官方字段。
+
+### [General] 段字段对齐（P0）
+
+- ★ FIX#Loon-01-P0：`tun-excluded-routes = ...` → **`bypass-tun = ...`**（Loon 官方字段）
+- ★ FIX#Loon-02-P0：`dns-server` 剥离 DoH URL — DoH 必须放 `doh-server`，`dns-server`
+  仅接受 `system` 与纯 IP（v5.2.3 把 `https://doh.pub/dns-query` 混进 dns-server 会被 Loon 丢弃）
+- ★ FIX#Loon-03-P0：`ipv6-enabled = true` → **`ipv6 = true`**（Loon 原生字段名无 `-enabled` 后缀）
+- ★ FIX#Loon-04-P0：`udp-policy-not-supported-behaviour = REJECT` → **`udp-fallback-mode = REJECT`**
+- ★ FIX#Loon-05-P0：删除 `bypass-system = true`（Loon 无此字段，Surge 专属）
+- ★ FIX#Loon-06-P0：删除 `hijack-dns = 8.8.8.8:53, 8.8.4.4:53`（Loon 无此字段）
+- ★ FIX#Loon-07-P1：新增 `geoip-url = https://fastly.jsdelivr.net/gh/Loyalsoldier/geoip@release/Country.mmdb`
+  —— Loon 支持 `geoip-url`，v5.2.3 头部注释误称"Loon 不支持在配置里指定 MMDB"，现已纠正
+  并自动化 MMDB 下载；不再需要 UI 手动操作
+
+### [Remote Filter] + [Proxy Group] 结构性重构（P0）
+
+- ★ FIX#Loon-08-P0：**新增 `[Remote Filter]` 段**，用 Loon 原生 `NameRegex + FilterKey`
+  定义 9 个区域 Filter（GLOBAL / HK / TW / JPKR / APAC / US / EU / AM / AF），
+  替代 Surge 的 url-test 内联 `policy-regex-filter=`（Loon 不识别该参数）
+- ★ FIX#Loon-09-P0：9 个 url-test 组改为引用 Filter 名字（`= url-test,<Filter>,url=...,interval=600,tolerance=50`），
+  同时删除 Loon 不支持的 `timeout=` 与 `select=0` 参数（此前整列区域组都被解析异常 → 区域聚合失效）
+
+### [Rule] 段格式对齐（P0）
+
+- ★ FIX#Loon-10-P0：**删除 72 条 Clash classical `.yaml` RULE-SET**（71 条 Accademia + 1 条 ACL4SSR Zoom.yaml）
+  —— Loon 的 RULE-SET 仅解析 Surge/Loon `.list` 与 `.conf` 纯文本，YAML 直接报错或静默丢弃
+- ★ FIX#Loon-11-P0：`IP-CIDR6,::1/128,...` × 3 → `IP-CIDR,::1/128,...`（Loon 只有 `IP-CIDR`，自动识别 IPv4/IPv6）
+- ★ FIX#Loon-12-P0：`FINAL,🐟 漏网之鱼,dns-failed` → `FINAL,🐟 漏网之鱼`（Loon 不接 `dns-failed` 后缀，那是 Surge 专属）
+- ★ FIX#Loon-13-P0：`ruleset.skk.moe/List/domainset/reject_phishing.conf`
+  → `ruleset.skk.moe/List/non_ip/reject_phishing.conf`（Sukka `domainset/` 是 Surge 专属二级格式；
+  `non_ip/` 是 Surge/Loon 通用 `.conf` 明文 RULE 列表）
+
+### [Rule] 段兜底补丁（P1，最小化功能回归）
+
+删除 72 条 Accademia YAML 后，大部分覆盖由 bm7 / szkane / sukka 吸收；少量 Accademia
+专属业务补 DOMAIN-SUFFIX 兜底，避免关键域名掉到 FINAL：
+
+- 🏦 金融支付：Monzo / N26 / Chime；主要国际银行 24 域名（Chase / BofA / WellsFargo /
+  Citi / HSBC / Barclays / Lloyds / Santander / DB / ING / BNP / SG / OCBC / UOB /
+  DBS / MUFG / SMBC / Mizuho / RBC / TD / Scotia / CBA / ANZ / Westpac）
+- 🧑‍💼 会议协作：Zoom（5 域名）、RustDesk、Parsec（3 域名）
+- 🌐 国外网站：Wayback Machine、Pornhub（3 域名）
+- 已接受的回归损失：Accademia `FakeLocation × 10`（国内 APP IP 归属地伪装）、
+  `GeoRouting × 17 区域`（国家/地区 ccTLD 细分）、`eMuleServer`、`HomeIP`
+  —— 这些是 Clash classical 专属规则集，没有 Loon `.list` 等价源；
+  如需完整覆盖请使用 CMFA / OpenClash / SingBox
+
+### 头部 + 元信息
+
+- ★ 版本号：`v5.2.3-Loon.1` → `v5.2.4-Loon.2`；主版本对齐 Clash Party v5.2.4
+- ★ Build：2026-04-20 → 2026-04-22
+- ★ 架构一句话：`9 区域 url-test 组（policy-regex-filter）` → `9 区域 url-test 组（[Remote Filter] NameRegex）`
+- ★ 删除头部的"Loon 不支持配置文件指定 MMDB" 误导性警告；改为在 [General] 用 `geoip-url` 自动配置
+- ★ 规则源说明：删除 `acc = Accademia/Additional_Rule_For_Clash`（已整体移除）
+
+### 自检结果
+
+- 代理组总数 37（9 url-test + 28 select）✓
+- [Remote Filter] 定义 9 个 filter，与 9 个 url-test 引用一一匹配 ✓
+- `.yaml` RULE-SET 残留 0 条 ✓
+- `IP-CIDR6,` / `FINAL,...,dns-failed` / `policy-regex-filter=` / `bypass-system` /
+  `tun-excluded-routes` / `ipv6-enabled` / `hijack-dns` / `udp-policy-not-supported-behaviour`
+  均为 0 次出现 ✓
+- `bypass-tun` / `ipv6 =` / `udp-fallback-mode` / `geoip-url` 各 1 次 ✓
+- 总行数 1346（v5.2.3: 1383；删除 72 条 yaml + 加 ~40 条兜底 DOMAIN-SUFFIX，净减 37 行）
+
+### 官方文档证据
+
+- Loon 官方示例 Loon0x00/LoonExampleConfig `example.conf`（`bypass-tun` / `doh-server` / `dns-server = system,IP`）
+- YueChan/Loon `Default.Conf`（`ipv6` / `udp-fallback-mode` / `geoip-url` / `ipasn-url`）
+- fmz200/wool_scripts `Loon.conf`（`[Remote Filter]` NameRegex 8 区域定义；`FINAL` 无 dns-failed 后缀）
+- TiyNa/LoonManual + chiupam/tutorial（`NameRegex, FilterKey = "regex"` 语法）
+
+---
+
 ## v5.2.3-Loon.1 (2026-04-20) — 初版
 
 - ★ 从 Surge v5.2.3-Surge.1 迁移，保留 9 区域 url-test 组 + 28 业务 select 组 + ~930 条规则

--- a/Loon/README.md
+++ b/Loon/README.md
@@ -1,9 +1,9 @@
-# Loon 使用教程（对齐 Clash Party v5.2.3）
+# Loon 使用教程（对齐 Clash Party v5.2.4）
 
 > 配置文件：`Loon/loon-smart.conf`
-> 版本：**v5.2.3-Loon.1**（Build 2026-04-20，从 Surge v5.2.3-Surge.1 迁移）
+> 版本：**v5.2.4-Loon.2**（Build 2026-04-22，Loon 原生语法兼容性大修，见 `Loon/CHANGELOG.md`）
 > 目标：**Loon iOS（App Store 付费正版）**
-> 架构：9 区域 url-test 组 + 28 业务策略组 + 250+ RULE-SET
+> 架构：9 区域 url-test 组（[Remote Filter] NameRegex）+ 28 业务策略组 + 250+ RULE-SET
 
 ---
 
@@ -29,24 +29,26 @@
 | 插件生态 | ❌ | **✅ Plugin** | ⚠️ Modules | ⚠️ Scripts |
 
 ### 术语速查
-- **Loon 配置 `.conf`**：和 Surge 几乎同语法；`[General]` 里的 DNS 字段名有小差异
-- **RULE-SET**：规则列表 URL，Loon 启动时下载（本配置放在 `[Rule]` 段内，与 Surge 格式兼容）
-- **MMDB**：GeoIP 数据库。Loon **不支持**在配置里指定 URL，**必须 UI 手动下载**（见下一步 2）
+- **Loon 配置 `.conf`**：与 Surge 有几处**关键语法差异**（详见下方第五/六章），**不能**直接喂 Surge 的 `.conf` 给 Loon
+- **RULE-SET**：规则列表 URL，Loon 启动时下载。Loon 只吃 `.list` / `.conf` 纯文本格式，**不认 Clash classical `.yaml`**
+- **[Remote Filter]**：Loon 原生的订阅节点过滤段，用 `NameRegex + FilterKey` 匹配节点名；url-test/select 组通过 Filter 名引用（**Loon 不支持** Surge 的 url-test 内联 `policy-regex-filter=`）
+- **MMDB**：GeoIP 数据库。Loon 支持 `[General]` 里 `geoip-url` 字段自动下载（本配置已预设 Loyalsoldier 加强版）；UI 下载仍然可用作为后备
 
 ### 3 步走完
 1. **App Store 搜 "Loon" → 购买 → 安装 → 允许 VPN 权限**。
-2. **先装 MMDB**（Loon 独有的小麻烦）：Loon → 设置 → GeoLite2 数据库 → 填入 `https://fastly.jsdelivr.net/gh/Loyalsoldier/geoip@release/Country.mmdb` → 下载。
-3. **导入**：把 `loon-smart.conf` 托管到 URL → Loon → 配置 → ⊕ → 从 URL 下载 → 启用。节点来源：底部「节点」→ ⊕ → 粘贴机场订阅 URL → 下载。
+2. **导入配置**：把 `loon-smart.conf` 托管到 URL → Loon → 配置 → ⊕ → 从 URL 下载 → 启用。配置里 `geoip-url` 已指向 Loyalsoldier 加强版 MMDB，首次启用会自动下载，**无需**再去 UI 手动填。
+3. **加机场订阅**：底部「节点」→ ⊕ → 粘贴机场订阅 URL → 下载。Loon 会按配置里 `[Remote Filter]` 的 9 条 NameRegex 自动把节点分到 🌍 / 🇭🇰 / 🇹🇼 / 🇯🇵日韩 / 🌏亚太 / 🇺🇸 / 🇪🇺 / 🌎美洲 / 🌍非洲 九个区域组。
 
 ### 跑起来验证？
 - 浏览器打开 `https://www.google.com` 能打开
 - Loon「策略组」面板应看到 37 组
-- Loon「设置 → 运行日志」看规则集下载状态
+- Loon「过滤器」面板应看到 9 个 Filter（GLOBAL / HK / TW / JPKR / APAC / US / EU / AM / AF）
+- Loon「设置 → 运行日志」看规则集 + MMDB 下载状态
 
 ### 最常见踩坑
-- ❌ **忘了装 MMDB**：精准标签规则（`GEOIP,netflix,...`）会失效，但 `GEOIP,CN,DIRECT` 仍工作（Loon 内置）。强烈建议补上 MMDB。
-- ❌ **规则集下载失败**：首次安装**必须先开代理**；Loon → 设置 → 自动更新配置 调频率。
-- ❌ **我把 Surge 的 `surge-smart.conf` 直接给 Loon 行不行**：大部分兼容，但 `encrypted-dns-server` / `geoip-maxmind-url` 等 Surge 独有字段 Loon 会报警告。**用本目录的 `loon-smart.conf`**（字段已适配）。
+- ❌ **规则集下载失败**：首次安装**必须先开代理**（没代理则 GitHub/jsDelivr 访问不稳定）；Loon → 设置 → 自动更新配置 调频率。
+- ❌ **区域组里没有节点**：检查 Loon 是否识别了 `[Remote Filter]` 段；如果机场节点命名奇葩（例如纯英文代号），可能没匹配到 FilterKey，打开 Loon → 过滤器 → 手动 Edit 调 regex。
+- ❌ **我把 Surge 的 `surge-smart.conf` 直接给 Loon 行不行**：**不行**。`bypass-system` / `tun-excluded-routes` / `ipv6-enabled` / `udp-policy-not-supported-behaviour` / `hijack-dns` / `encrypted-dns-server` / url-test 的 `policy-regex-filter=` 这些 Loon 全都不识别，配置会大面积沉默失效。**用本目录的 `loon-smart.conf`**（v5.2.4-Loon.2 已完整对齐 Loon 官方语法）。
 - ❌ **想要 LightGBM**：Loon 不是 mihomo 内核，不支持。要就用桌面端 Clash Verge Rev / Mihomo Party。
 
 ---
@@ -118,48 +120,58 @@ Loon 必须从 URL 安装配置（和 Surge 一样）：
 
 Loon 的节点来源：
 1. 底部 **节点（Node）** → ⊕ → 粘贴机场订阅 URL → **下载**。
-2. Loon 会解析节点并自动填充到 9 区域组（按 `policy-regex-filter` 匹配地区名）。
-3. 也可以在 `[Proxy]` 段直接粘贴节点（不推荐，手工维护麻烦）。
+2. Loon 会按 `[Remote Filter]` 段里 9 条 NameRegex 自动把节点分到 9 个区域 Filter。
+3. url-test 组（🌍 全球 / 🇭🇰 / 🇹🇼 / 🇯🇵 日韩 / 🌏 亚太 / 🇺🇸 / 🇪🇺 / 🌎 美洲 / 🌍 非洲）各自引用对应 Filter 名，组内自动选最低延迟节点。
+4. 也可以在 `[Proxy]` 段直接粘贴本地节点（不推荐，手工维护麻烦）。
 
 ---
 
 ## 四、9 区域 × 28 业务组说明
 
-结构与 Surge 版完全一致（本文件从 Surge 版迁移而来）：
+- **9 区域组**：`url-test,<区域Filter>,url=...,interval=600,tolerance=50`
+  - 区域 Filter 在 `[Remote Filter]` 段用 `NameRegex + FilterKey="..."` 定义
+  - 测速间隔 **600s**，tolerance **50ms**（Loon 不支持 `timeout=` / `select=` 参数）
+- **28 业务组**：select 手动选择，候选列表默认为所有区域组 + DIRECT
 
-- **9 区域组**：url-test + `policy-regex-filter` 自动按地区聚合节点；测速间隔 **600s**，tolerance **50ms**。
-- **28 业务组**：select 手动选择，候选列表默认为所有区域组 + DIRECT。
+业务组语义映射与 Surge 版完全一致，参考 `Surge/README.md` 第五章。
 
-推荐配置参考 `Surge/README.md` 第五章（映射关系完全一致，不在此重复）。
-
----
-
-## 五、DNS 配置（与 Clash Party 对齐）
-
-| Loon 字段 | 对应 Clash 字段 | 值 |
-|-----------|-----------------|------|
-| `dns-server` | `default-nameserver` + `nameserver` | `223.5.5.5, 119.29.29.29, https://doh.pub/dns-query, https://dns.alidns.com/dns-query` |
-| `doh-server` | `nameserver` + `fallback` | `doh.pub / alidns / 1.1.1.1 / 8.8.8.8` |
-| `hijack-dns` | `hijack-dns` | `8.8.8.8:53, 8.8.4.4:53` |
-
-**Loon 与 Surge 的 DNS 差异**：
-- Loon 用 `doh-server` 作为 DoH 专用通道（Surge 用 `encrypted-dns-server`）。
-- Loon 没有 `encrypted-dns-follow-outbound-mode`（Surge 独有）。
+> **与 Surge 版最大的结构差异**：Surge 用 url-test 内联 `policy-regex-filter="..."`，
+> Loon 把 filter 拆成独立 `[Remote Filter]` 段并由 url-test 组通过 Filter 名引用。
+> 这是 Loon 引擎层面的设计，不是本配置"特有"写法，所有 Loon 官方示例（YueChan / Loon0x00 / fmz200）均如此。
 
 ---
 
-## 六、MMDB 数据库（⚠️ 必须 UI 操作）
+## 五、DNS 配置（Loon 原生语法，≠ Surge）
 
-**Loon 不支持在配置文件里指定 MMDB URL**（Surge 的独有优势）。你必须：
+| Loon 字段 | 值 | 说明 |
+|-----------|------|------|
+| `dns-server` | `system, 223.5.5.5, 119.29.29.29` | ⚠️ Loon 的 `dns-server` **仅接受** `system` 与纯 IP，**不接受** DoH URL |
+| `doh-server` | `doh.pub / alidns / 1.1.1.1 / 8.8.8.8` | DoH URL **必须**放这里，不能塞进 dns-server |
+| `ipv6` | `true` | Loon 字段名是 `ipv6`，不是 `ipv6-enabled` |
+| `udp-fallback-mode` | `REJECT` | Loon 对应 Surge 的 `udp-policy-not-supported-behaviour` |
+| `disable-udp-ports` | `443` | 对应 Surge 的 `block-quic`（封 HTTP/3） |
+| `bypass-tun` | 私有网段列表 | Loon 对应 Surge 的 `tun-excluded-routes`；Loon **没有** `bypass-system` |
 
-1. Loon → **设置** → **GeoLite2 数据库**。
-2. 填入：
-   ```
-   https://fastly.jsdelivr.net/gh/Loyalsoldier/geoip@release/Country.mmdb
-   ```
-3. 点击 **下载**。
+**Loon 没有以下 Surge 字段**（v5.2.3 错误地用过，v5.2.4-Loon.2 已全部清除）：
+- `bypass-system` / `tun-excluded-routes` / `ipv6-enabled` / `udp-policy-not-supported-behaviour` / `hijack-dns` / `encrypted-dns-server` / `encrypted-dns-follow-outbound-mode` / `block-quic` / `geoip-maxmind-url`
 
-下载完成后，`GEOIP,CN,DIRECT` / `GEOIP,netflix,🇺🇸 美国流媒体` 等精准标签路由才会生效。若不替换 MMDB，只有 `GEOIP,CN` 能命中（Loon 内置库），其他标签规则会空跑。
+---
+
+## 六、MMDB 数据库（配置文件自动下载，无需 UI 手动操作）
+
+本配置在 `[General]` 里预设了：
+
+```
+geoip-url = https://fastly.jsdelivr.net/gh/Loyalsoldier/geoip@release/Country.mmdb
+```
+
+Loon 启动时会自动下载这份 Loyalsoldier 加强版 MMDB（含 cloudflare / telegram / netflix / google 等精准标签），
+`GEOIP,CN,🏠 国内网站` 以及其他 GEOIP 标签规则开箱即用。
+
+> 早期版本的文档曾说 "Loon 不支持配置文件指定 MMDB"，那是误解。Loon 的 `geoip-url` 字段自 3.x 起一直可用，
+> 在 YueChan/Loon `Default.Conf` 与 fmz200/wool_scripts `Loon.conf` 官方示例里均有使用。
+
+如需回落到 UI 手动下载（例如想换其他 MMDB 源）：Loon → 设置 → GeoLite2 数据库 → 填 URL → 下载。
 
 ---
 
@@ -188,18 +200,38 @@ https://example.com/rule.list, policy=POLICY, tag=some-tag, enabled=true
 | ❌ 无 Mihomo Smart 组 / LightGBM | Loon 不是 Mihomo 核 |
 | ❌ 无 TLS 指纹注入 | Loon 不暴露 uTLS 控制 |
 | ❌ PROCESS-NAME | iOS 无进程 API |
-| ⚙️ GEOSITE → RULE-SET | Loon 同样只支持 RULE-SET + GEOIP |
+| ❌ Clash classical `.yaml` RULE-SET | Loon 只支持 `.list` / `.conf` 纯文本；v5.2.4-Loon.2 已清理掉 72 条 Accademia YAML |
+| ❌ Sukka `List/domainset/*.conf` | 该二级格式是 Surge 专属；Loon 用 `List/non_ip/*.conf` 代替 |
+| ⚙️ GEOSITE → RULE-SET | Loon 只支持 RULE-SET + GEOIP（`geoip-url` 可自定义 MMDB） |
 | ⚙️ Meta `.mrs` → blackmatrix7 Loon `.list` | 格式兼容性 |
+| ⚙️ `policy-regex-filter=` → `[Remote Filter] NameRegex` | Loon 引擎的独立 filter 段 |
+
+### 已接受的规则回归损失（v5.2.4-Loon.2）
+
+以下 Accademia Clash classical 规则集没有 Loon `.list` 等价源，已随 72 条 YAML
+一并移除；关键域名已补 DOMAIN-SUFFIX 兜底（见 [Rule] 段 Monzo / Bank×24 / RustDesk /
+Parsec / Zoom / Pornhub / Wayback）：
+
+- `Bank/Bank<国家>.yaml × 10`（各国本地银行细粒度，用 24 条 DOMAIN-SUFFIX 代替主流国际银行）
+- `FakeLocation × 10`（国内 APP IP 归属地伪装）
+- `GeoRouting × 17 区域`（ccTLD 细分）
+- `HomeIP/HomeIP<JP|US>.yaml`、`eMuleServer`、`MacAppUpgrade`、`Fastly`、`Kwai`、
+  `MicrosoftAPPs`、`AppleNews`、`Alipan/BaiduNetDisk/WeiYun`、`AqaraCN/AqaraGlobal`、
+  `HijackingPlus/BlockHttpDNSPlus/PreRepairEasyPrivacy/UnsupportVPN`、
+  `AppleAI/Grok/Gemini/Copilot`、`Signal`、`RustDesk/Parsec`、`Pornhub`、`WaybackMachine`
+
+**需要完整的 Accademia 覆盖？** 请切到 CMFA / OpenClash / SingBox —— 这些平台原生支持 Clash classical YAML RULE-SET。
 
 ---
 
 ## 九、验证
 
-1. Loon → **首页** → 应显示 `Loon Smart v5.2.3-Loon.1`，协议已启用。
+1. Loon → **首页** → 应显示 `Loon Smart v5.2.4-Loon.2`，协议已启用。
 2. **策略组** 面板应出现 37 组（9 区域 + 28 业务）。
-3. 测试分流：
+3. **过滤器** 面板应出现 9 个 Filter（GLOBAL_Filter / HK_Filter / TW_Filter / JPKR_Filter / APAC_Filter / US_Filter / EU_Filter / AM_Filter / AF_Filter）。
+4. 测试分流：
    - `chat.openai.com` → 🤖 AI 服务
-   - `www.netflix.com` → 🇺🇸 美国流媒体（需 MMDB 替换后精准命中；否则靠 RULE-SET）
+   - `www.netflix.com` → 🇺🇸 美国流媒体（需 geoip-url 下载完成后精准命中；否则靠 RULE-SET）
    - `www.bilibili.com` → DIRECT / 📺 国内流媒体
    - `raw.githubusercontent.com` → 📟 开发者服务
 
@@ -208,7 +240,7 @@ https://example.com/rule.list, policy=POLICY, tag=some-tag, enabled=true
 ## 十、常见问题
 
 ### Q1：我能直接导入 Surge 的 `surge-smart.conf` 到 Loon 吗？
-- 大部分字段兼容，但 `encrypted-dns-server` / `read-etc-hosts` / `exclude-simple-hostnames` / `geoip-maxmind-url` Loon 会报未知字段警告。建议用本目录的 `loon-smart.conf`。
+- **不能**。Surge 的 `bypass-system` / `tun-excluded-routes` / `ipv6-enabled` / `udp-policy-not-supported-behaviour` / `hijack-dns` / `encrypted-dns-server` / `geoip-maxmind-url` 都不是 Loon 字段；url-test 内联 `policy-regex-filter=` / `select=0` / `timeout=5` Loon 也不认；Clash classical `.yaml` RULE-SET Loon 解析不了。本目录的 `loon-smart.conf` 已经完整对齐 Loon 官方语法。
 
 ### Q2：想要 Mihomo Smart + LightGBM 怎么办？
 - Loon 做不到，需换客户端。iOS 上目前没有支持 JS 覆写 + LightGBM 的客户端；桌面端用 Clash Verge Rev / Mihomo Party。
@@ -229,4 +261,5 @@ https://example.com/rule.list, policy=POLICY, tag=some-tag, enabled=true
 - [Loon](https://apps.apple.com/app/loon/id1373567447)
 - [blackmatrix7/ios_rule_script](https://github.com/blackmatrix7/ios_rule_script) - Loon `.list` 规则源
 - [Loyalsoldier/geoip](https://github.com/Loyalsoldier/geoip) - GeoIP MMDB
-- 原版 Clash Party v5.2.3 所有参考作者
+- Clash Party v5.2.4 主线基线
+- [YueChan/Loon](https://github.com/YueChan/Loon) / [Loon0x00/LoonExampleConfig](https://github.com/Loon0x00/LoonExampleConfig) / [fmz200/wool_scripts](https://github.com/fmz200/wool_scripts) — 三份 Loon 官方/权威示例，v5.2.4-Loon.2 语法对齐的对照来源

--- a/Loon/loon-smart.conf
+++ b/Loon/loon-smart.conf
@@ -1,12 +1,9 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Loon Smart v5.2.3-Loon.1 — Loon 版（从 Clash Party v5.2.4 迁移）
-#  Build: 2026-04-20 | Target: Loon iOS (App Store 付费正版)
-#  架构：9 区域 url-test 组（policy-regex-filter）+ 28 业务 select 组 + 250+ RULE-SET
+#  Loon Smart v5.2.4-Loon.2 — Loon 版（从 Clash Party v5.2.4 迁移）
+#  Build: 2026-04-22 | Target: Loon iOS (App Store 付费正版)
+#  架构：9 区域 url-test 组（[Remote Filter] NameRegex）+ 28 业务 select 组 + 250+ RULE-SET
 #  基线：Clash Party v5.2.4（唯一主线）
 #  变更历史：见 `Loon/CHANGELOG.md`
-#  ⚠️ MMDB 需在 Loon UI 手动下载：
-#     设置 → GeoLite2 → 填入 https://fastly.jsdelivr.net/gh/Loyalsoldier/geoip@release/Country.mmdb
-#     （Loon 不支持在配置文件里指定 MMDB URL）
 # ══════════════════════════════════════════════════════════════════════════════
 
 [General]
@@ -15,28 +12,24 @@ internet-test-url = http://www.apple.com/library/test/success.html
 proxy-test-url = http://www.gstatic.com/generate_204
 test-timeout = 5
 
-# ─── 旁路系统 + 跳过代理（私有网段 + iOS 敏感域名） ──────────────────────────
-bypass-system = true
+# ─── 跳过代理（私有网段 + iOS 敏感域名；HTTP Proxy 模式直通） ────────────────
 skip-proxy = 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,127.0.0.0/8,100.64.0.0/10,169.254.0.0/16,224.0.0.0/4,240.0.0.0/4,localhost,*.local,captive.apple.com,*.ccb.com,*.abchina.com.cn,*.psbc.com,*.icbc.com.cn,*.bankcomm.com,*.alipay.com,*.wxpay.com,*.tenpay.com
 
-# ─── TUN 旁路路由 ─────────────────────────────────────────────────────────────
-tun-excluded-routes = 10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,192.0.0.0/24,192.0.2.0/24,192.88.99.0/24,192.168.0.0/16,198.18.0.0/15,198.51.100.0/24,203.0.113.0/24,224.0.0.0/4,240.0.0.0/4,255.255.255.255/32,239.255.255.250/32
+# ─── TUN 旁路路由（Loon 官方字段 `bypass-tun`） ──────────────────────────────
+bypass-tun = 10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,192.0.0.0/24,192.0.2.0/24,192.88.99.0/24,192.168.0.0/16,198.18.0.0/15,198.51.100.0/24,203.0.113.0/24,224.0.0.0/4,240.0.0.0/4,255.255.255.255/32,239.255.255.250/32
 
-# ─── DNS （对齐 Clash Party 基线：国内 DoH 为主 + 国外 DoH 备用） ─────────────
-# Loon 的 dns-server 支持明文 IP + DoH URL 并列，查询时按顺序轮询。
-dns-server = 223.5.5.5, 119.29.29.29, https://doh.pub/dns-query, https://dns.alidns.com/dns-query
+# ─── DNS （对齐 Clash Party 基线：国内明文 DNS + 国外 DoH 备用） ─────────────
+# Loon `dns-server` 仅接受 `system` 与纯 IP；DoH URL 必须放 `doh-server`。
+dns-server = system, 223.5.5.5, 119.29.29.29
 doh-server = https://doh.pub/dns-query, https://dns.alidns.com/dns-query, https://1.1.1.1/dns-query, https://8.8.8.8/dns-query
 
-# DNS 劫持（劫持硬编码 8.8.8.8/4.4.4.4 查询到 Loon DNS）
-hijack-dns = 8.8.8.8:53, 8.8.4.4:53
+# IPv6（Loon 原生字段名 `ipv6`，不是 `ipv6-enabled`）
+ipv6 = true
 
-# IPv6
-ipv6-enabled = true
+# UDP 回退策略（Loon 原生字段名 `udp-fallback-mode`）
+udp-fallback-mode = REJECT
 
-# UDP 回退策略
-udp-policy-not-supported-behaviour = REJECT
-
-# QUIC 屏蔽（HTTP/3 跨境表现差；Loon 没有 block-quic，用 disable-udp-ports 代替）
+# QUIC 屏蔽（HTTP/3 跨境表现差；Loon 无 block-quic，用 disable-udp-ports 代替）
 disable-udp-ports = 443
 
 # WiFi 端口
@@ -44,19 +37,9 @@ allow-wifi-access = false
 wifi-access-http-port = 7222
 wifi-access-socks5-port = 7221
 
-# ══════════════════════════════════════════════════════════════════════════════
-#  GeoIP MMDB 配置说明
-#  ────────────────────────────────────────────────────────────────────────────
-#  ⚠️ Loon **不支持**在配置文件里直接指定 MMDB URL（这点不如 Surge）。
-#  必须在 UI 手动下载：
-#
-#     设置 → GeoLite2 数据库 → 填入下方 URL → 下载
-#
-#  推荐（Loyalsoldier 加强版，含 cloudflare/telegram/netflix/google 标签）：
-#     https://fastly.jsdelivr.net/gh/Loyalsoldier/geoip@release/Country.mmdb
-# ══════════════════════════════════════════════════════════════════════════════
-
-# http-api-web-dashboard = true
+# ─── GeoIP MMDB（Loon 支持 `geoip-url`，配置文件内即可指定） ──────────────────
+# Loyalsoldier 加强版（含 cloudflare/telegram/netflix/google 标签）
+geoip-url = https://fastly.jsdelivr.net/gh/Loyalsoldier/geoip@release/Country.mmdb
 
 # ══════════════════════════════════════════════════════════════════════════════
 #  [Proxy]
@@ -73,47 +56,62 @@ wifi-access-socks5-port = 7221
 # 本地节点留空 → 完全使用订阅节点（推荐）
 
 # ══════════════════════════════════════════════════════════════════════════════
+#  [Remote Filter] — 订阅节点过滤（Loon 原生 NameRegex）
+#  ────────────────────────────────────────────────────────────────────────────
+#  Loon 不支持 Surge 的 url-test 内联 `policy-regex-filter=` 参数。
+#  等价做法：在这里用 NameRegex 定义 FilterKey，再让 url-test 组引用 Filter 名。
+#  9 个区域 Filter 与 Clash Party v5.2.4 基线区域语义一致。
+# ══════════════════════════════════════════════════════════════════════════════
+
+[Remote Filter]
+# 全球节点：所有节点聚合，排除信息节点/倍率节点/回国节点
+GLOBAL_Filter = NameRegex, FilterKey = "^((?!(导航|剩余|套餐|到期|重置|官网|订阅|10x|20x|100x|回国|回程|国内专线)).)*$"
+HK_Filter     = NameRegex, FilterKey = "(?i)(🇭🇰|HK|Hong|HongKong|HKG|香港|深港|沪港|京港|中港|Hong Kong)"
+TW_Filter     = NameRegex, FilterKey = "(?i)(🇹🇼|TW|Taiwan|TWN|Taipei|TPE|台湾|台灣|台北|台中|高雄|新北|桃园)"
+JPKR_Filter   = NameRegex, FilterKey = "(?i)(🇯🇵|🇰🇷|JP|Japan|JPN|Tokyo|Osaka|NRT|HND|KIX|日本|东京|大阪|横滨|名古屋|KR|Korea|KOR|Seoul|ICN|韩国|首尔|釜山|仁川)"
+APAC_Filter   = NameRegex, FilterKey = "(?i)(🇭🇰|🇹🇼|🇯🇵|🇰🇷|🇸🇬|🇲🇾|🇹🇭|🇻🇳|🇵🇭|🇮🇩|🇮🇳|HK|TW|JP|KR|SG|MY|TH|VN|PH|ID|IN|Hong|Taiwan|Japan|Korea|Singapore|Malaysia|Thailand|Vietnam|Philippines|Indonesia|India|香港|台湾|日本|韩国|新加坡|狮城|马来|泰国|越南|菲律宾|印尼|印度|亚太|iplc|IEPL|专线|cn2|GIA)"
+US_Filter     = NameRegex, FilterKey = "(?i)(🇺🇸|US|USA|America|United States|LAX|SJC|SFO|SEA|JFK|ORD|DFW|IAD|ATL|MIA|美国|洛杉矶|圣何塞|旧金山|西雅图|纽约|芝加哥|达拉斯|凤凰城|亚特兰大|迈阿密|波士顿|华盛顿|休斯顿|硅谷|弗吉尼亚|奥斯汀|拉斯维加斯)"
+EU_Filter     = NameRegex, FilterKey = "(?i)(🇬🇧|🇫🇷|🇩🇪|🇳🇱|🇨🇭|🇮🇹|🇪🇸|🇷🇺|EU|UK|GB|FR|DE|NL|CH|IT|ES|PT|SE|FI|NO|DK|PL|IE|RU|AT|BE|Europe|London|Paris|Berlin|Frankfurt|Amsterdam|Moscow|Zurich|Vienna|Stockholm|Madrid|Rome|Helsinki|Warsaw|Prague|LHR|CDG|FRA|AMS|SVO|ZRH|VIE|MAD|FCO|欧洲|英国|法国|德国|荷兰|瑞士|意大利|西班牙|俄罗斯|奥地利|瑞典|芬兰|挪威|丹麦|波兰|爱尔兰|伦敦|巴黎|柏林|法兰克福|阿姆斯特丹|莫斯科|苏黎世|维也纳|斯德哥尔摩|马德里|罗马)"
+AM_Filter     = NameRegex, FilterKey = "(?i)(🇺🇸|🇨🇦|🇲🇽|🇧🇷|🇦🇷|🇨🇱|🇵🇪|🇨🇴|US|USA|CA|MX|BR|AR|CL|PE|CO|Americas|America|Canada|Mexico|Brazil|Argentina|Chile|Peru|Colombia|Toronto|Vancouver|Montreal|YYZ|YVR|GRU|GIG|EZE|美洲|加拿大|墨西哥|巴西|阿根廷|智利|秘鲁|哥伦比亚|多伦多|温哥华|蒙特利尔|圣保罗)"
+AF_Filter     = NameRegex, FilterKey = "(?i)(🇿🇦|🇪🇬|🇳🇬|🇰🇪|AF|ZA|EG|NG|KE|MA|TN|DZ|Africa|South Africa|Egypt|Nigeria|Kenya|Morocco|Johannesburg|Cairo|Lagos|Nairobi|JNB|CAI|NBO|非洲|南非|埃及|尼日利亚|肯尼亚|摩洛哥|约翰内斯堡|开罗|拉各斯|内罗毕)"
+
+# ══════════════════════════════════════════════════════════════════════════════
 #  [Proxy Group] — 9 Smart 区域组 + 28 业务策略组
 #  ────────────────────────────────────────────────────────────────────────────
-#  Smart 区域组（url-test + 正则过滤）
-#    • 原版 Clash Smart 使用 lightgbm 机器学习，SR 无此能力 → 用 url-test 退化
-#    • policy-regex-filter 在导入时一次性扫描所有节点名，按地区自动聚合
+#  Smart 区域组（url-test + NameRegex Filter 引用）
+#    • 原版 Clash Smart 使用 lightgbm 机器学习，Loon 无此能力 → 用 url-test 退化
+#    • 区域 Filter 在 [Remote Filter] 段定义；组行第一个参数即 Filter 名
 #    • interval=600s（10 分钟重测），tolerance=50ms（防抖动）
-#    • select=0 表示默认选第一个（最低延迟）节点
+#    • Loon 的 url-test **不支持** Surge 的 timeout= / select= / policy-regex-filter= 参数
 #
 #  业务策略组（select 手动）
 #    • 默认选择 Smart 区域组（非具体节点），实现「组 → 组」级联自动切换
-#    • 用户可在 SR UI 中按需覆盖默认选择
+#    • 用户可在 Loon UI 中按需覆盖默认选择
 # ══════════════════════════════════════════════════════════════════════════════
 
 [Proxy Group]
-# ─── 9 Smart 区域组 ──────────────────────────────────────────────────────────
-# 全球节点：所有节点聚合，排除信息节点/倍率节点/回国节点
-🌍 全球节点 = url-test,url=http://www.gstatic.com/generate_204,interval=600,timeout=5,tolerance=50,select=0,policy-regex-filter=^((?!(导航|剩余|套餐|到期|重置|官网|订阅|10x|20x|100x|回国|回程|国内专线)).)*$
+# ─── 9 Smart 区域组（引用 [Remote Filter] 里的 NameRegex） ────────────────────
+🌍 全球节点 = url-test,GLOBAL_Filter,url=http://www.gstatic.com/generate_204,interval=600,tolerance=50
 
-# 香港节点
-🇭🇰 香港节点 = url-test,url=http://www.gstatic.com/generate_204,interval=600,timeout=5,tolerance=50,select=0,policy-regex-filter=🇭🇰|HK|Hong|hong|HongKong|hongkong|HKG|香港|深港|沪港|京港|中港|Hong Kong
+🇭🇰 香港节点 = url-test,HK_Filter,url=http://www.gstatic.com/generate_204,interval=600,tolerance=50
 
-# 台湾节点
-🇹🇼 台湾节点 = url-test,url=http://www.gstatic.com/generate_204,interval=600,timeout=5,tolerance=50,select=0,policy-regex-filter=🇹🇼|TW|Taiwan|taiwan|TWN|Taipei|taipei|TPE|台湾|台灣|台北|台中|高雄|新北|桃园
+🇹🇼 台湾节点 = url-test,TW_Filter,url=http://www.gstatic.com/generate_204,interval=600,tolerance=50
 
 # 日韩节点（JP + KR 合并）
-🇯🇵 日韩节点 = url-test,url=http://www.gstatic.com/generate_204,interval=600,timeout=5,tolerance=50,select=0,policy-regex-filter=🇯🇵|🇰🇷|JP|Japan|japan|JPN|Tokyo|tokyo|Osaka|osaka|NRT|HND|KIX|日本|东京|大阪|横滨|名古屋|KR|Korea|korea|KOR|Seoul|seoul|ICN|韩国|首尔|釜山|仁川
+🇯🇵 日韩节点 = url-test,JPKR_Filter,url=http://www.gstatic.com/generate_204,interval=600,tolerance=50
 
 # 亚太节点（HK + TW + JP + KR + SG + 东南亚）
-🌏 亚太节点 = url-test,url=http://www.gstatic.com/generate_204,interval=600,timeout=5,tolerance=50,select=0,policy-regex-filter=🇭🇰|🇹🇼|🇯🇵|🇰🇷|🇸🇬|🇲🇾|🇹🇭|🇻🇳|🇵🇭|🇮🇩|🇮🇳|HK|TW|JP|KR|SG|MY|TH|VN|PH|ID|IN|Hong|Taiwan|Japan|Korea|Singapore|Malaysia|Thailand|Vietnam|Philippines|Indonesia|India|香港|台湾|日本|韩国|新加坡|狮城|马来|泰国|越南|菲律宾|印尼|印度|亚太|iplc|IEPL|专线|cn2|GIA
+🌏 亚太节点 = url-test,APAC_Filter,url=http://www.gstatic.com/generate_204,interval=600,tolerance=50
 
-# 美国节点
-🇺🇸 美国节点 = url-test,url=http://www.gstatic.com/generate_204,interval=600,timeout=5,tolerance=50,select=0,policy-regex-filter=🇺🇸|US|USA|America|america|United States|LAX|SJC|SFO|SEA|JFK|ORD|DFW|IAD|ATL|MIA|美国|洛杉矶|圣何塞|旧金山|西雅图|纽约|芝加哥|达拉斯|凤凰城|亚特兰大|迈阿密|波士顿|华盛顿|休斯顿|硅谷|弗吉尼亚|奥斯汀|拉斯维加斯
+🇺🇸 美国节点 = url-test,US_Filter,url=http://www.gstatic.com/generate_204,interval=600,tolerance=50
 
-# 欧洲节点
-🇪🇺 欧洲节点 = url-test,url=http://www.gstatic.com/generate_204,interval=600,timeout=5,tolerance=50,select=0,policy-regex-filter=🇬🇧|🇫🇷|🇩🇪|🇳🇱|🇨🇭|🇮🇹|🇪🇸|🇷🇺|EU|UK|GB|FR|DE|NL|CH|IT|ES|PT|SE|FI|NO|DK|PL|IE|RU|AT|BE|Europe|europe|London|Paris|Berlin|Frankfurt|Amsterdam|Moscow|Zurich|Vienna|Stockholm|Madrid|Rome|Helsinki|Warsaw|Prague|LHR|CDG|FRA|AMS|SVO|ZRH|VIE|MAD|FCO|欧洲|英国|法国|德国|荷兰|瑞士|意大利|西班牙|俄罗斯|奥地利|瑞典|芬兰|挪威|丹麦|波兰|爱尔兰|伦敦|巴黎|柏林|法兰克福|阿姆斯特丹|莫斯科|苏黎世|维也纳|斯德哥尔摩|马德里|罗马
+🇪🇺 欧洲节点 = url-test,EU_Filter,url=http://www.gstatic.com/generate_204,interval=600,tolerance=50
 
 # 美洲节点（US + CA + MX + BR + AR + CL 等）
-🌎 美洲节点 = url-test,url=http://www.gstatic.com/generate_204,interval=600,timeout=5,tolerance=50,select=0,policy-regex-filter=🇺🇸|🇨🇦|🇲🇽|🇧🇷|🇦🇷|🇨🇱|🇵🇪|🇨🇴|US|USA|CA|MX|BR|AR|CL|PE|CO|Americas|America|Canada|Mexico|Brazil|Argentina|Chile|Peru|Colombia|Toronto|Vancouver|Montreal|YYZ|YVR|GRU|GIG|EZE|美洲|加拿大|墨西哥|巴西|阿根廷|智利|秘鲁|哥伦比亚|多伦多|温哥华|蒙特利尔|圣保罗
+🌎 美洲节点 = url-test,AM_Filter,url=http://www.gstatic.com/generate_204,interval=600,tolerance=50
 
 # 非洲节点
-🌍 非洲节点 = url-test,url=http://www.gstatic.com/generate_204,interval=600,timeout=5,tolerance=50,select=0,policy-regex-filter=🇿🇦|🇪🇬|🇳🇬|🇰🇪|AF|ZA|EG|NG|KE|MA|TN|DZ|Africa|africa|South Africa|Egypt|Nigeria|Kenya|Morocco|Johannesburg|Cairo|Lagos|Nairobi|JNB|CAI|NBO|非洲|南非|埃及|尼日利亚|肯尼亚|摩洛哥|约翰内斯堡|开罗|拉各斯|内罗毕
+🌍 非洲节点 = url-test,AF_Filter,url=http://www.gstatic.com/generate_204,interval=600,tolerance=50
 
 # ─── 28 业务策略组（默认链式指向区域组，用户可手动覆盖） ────────────────────
 # AI 服务：默认全球；量化模型训练/推理建议手动切换到美国高速节点
@@ -214,28 +212,25 @@ wifi-access-socks5-port = 7221
 #    5. GEOIP CN 兜底
 #    6. FINAL 漏网之鱼
 #
-#  规则源说明
-#    • bm7 = https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket
+#  规则源说明（v5.2.4-Loon.2 起）
+#    • bm7 = https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon
 #    • szkane = https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash
-#    • loyal = https://fastly.jsdelivr.net/gh/Loyalsoldier/surge-rules@release（SR 兼容）
-#    • sukka = https://ruleset.skk.moe（Surge 格式，SR 兼容）
-#    • acc = https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main
-#      （YAML classical，SR 按内容识别解析）
+#    • sukka = https://ruleset.skk.moe（Surge/Loon 兼容 .conf 与 .list）
+#    • hagezi = https://fastly.jsdelivr.net/gh/hagezi/dns-blocklists@main/share（Surge 格式）
+#    • anti-ad = https://anti-ad.net（Surge 格式）
+#
+#  Accademia/* Clash classical YAML 已全部移除（Loon 不支持 YAML RULE-SET）；
+#  等价覆盖由 bm7 / szkane / sukka 吸收，少量专属域名补在 [Rule] 段内（Monzo/RustDesk/Parsec/Zoom/Pornhub 等）。
 # ══════════════════════════════════════════════════════════════════════════════
 
 [Rule]
 # ─── 阶段 1: 广告拦截与威胁情报 ───────────────────────────────────────────────
 # anti-AD（DustinWin 同源 privacy-protection-tools/anti-AD）
 RULE-SET,https://anti-ad.net/surge.txt,🛑 广告拦截
-# SukkaW 钓鱼域名拦截（13 万条）
-RULE-SET,https://ruleset.skk.moe/List/domainset/reject_phishing.conf,🛑 广告拦截
+# SukkaW 钓鱼域名拦截（13 万条；Loon 用 non_ip .conf，domainset 是 Surge 专属二级格式）
+RULE-SET,https://ruleset.skk.moe/List/non_ip/reject_phishing.conf,🛑 广告拦截
 # Hagezi TIF（威胁情报：malware/cryptojacking/C2/scam/spam）
 RULE-SET,https://fastly.jsdelivr.net/gh/hagezi/dns-blocklists@main/share/surge-tif-medium.txt,🛑 广告拦截
-# Accademia 安全补充（劫持/HTTP DNS/隐私修复/不支持VPN）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/HijackingPlus/HijackingPlus.yaml,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/BlockHttpDNSPlus/BlockHttpDNSPlus.yaml,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/PreRepairEasyPrivacy/PreRepairEasyPrivacy.yaml,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/UnsupportVPN/UnsupportVPN.yaml,🛑 广告拦截
 # blackmatrix7 广告/隐私/营销追踪规则集（SR 原生）
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Advertising/Advertising.list,🛑 广告拦截
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AdvertisingMiTV/AdvertisingMiTV.list,🛑 广告拦截
@@ -260,9 +255,10 @@ IP-CIDR,100.64.0.0/10,DIRECT,no-resolve
 IP-CIDR,127.0.0.0/8,DIRECT,no-resolve
 IP-CIDR,169.254.0.0/16,DIRECT,no-resolve
 IP-CIDR,224.0.0.0/4,DIRECT,no-resolve
-IP-CIDR6,::1/128,DIRECT,no-resolve
-IP-CIDR6,fc00::/7,DIRECT,no-resolve
-IP-CIDR6,fe80::/10,DIRECT,no-resolve
+# Loon 只认 IP-CIDR（自动识别 IPv4 / IPv6），无 IP-CIDR6 变体
+IP-CIDR,::1/128,DIRECT,no-resolve
+IP-CIDR,fc00::/7,DIRECT,no-resolve
+IP-CIDR,fe80::/10,DIRECT,no-resolve
 
 # 原版业务 IP 直连（Windows Delivery Optimization 屏蔽 + IP 检测域名）
 DST-PORT,7680,REJECT
@@ -313,13 +309,8 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 # szkane AI 综合（OpenAI/Claude/Grok/Perplexity/Gemini 合并）
 RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/AiDomain.list,🤖 AI 服务
 RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/CiciAi.list,🤖 AI 服务
-# Accademia AI 补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/AppleAI/AppleAI.yaml,🤖 AI 服务
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Grok/Grok.yaml,🤖 AI 服务
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Gemini/Gemini.yaml,🤖 AI 服务
 # 原版 FIX#13-P2: 微软 Delivery Optimization 遥测非 AI，前置拦截
 DOMAIN-SUFFIX,do.dsp.mp.microsoft.com,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Copilot/Copilot.yaml,🤖 AI 服务
 # 常用 AI 域名兜底
 DOMAIN-SUFFIX,perplexity.ai,🤖 AI 服务
 DOMAIN-SUFFIX,mistral.ai,🤖 AI 服务
@@ -431,21 +422,39 @@ DOMAIN-SUFFIX,ksei.co.id,🏦 金融支付
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Stripe/Stripe.list,🏦 金融支付
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/VISA/VISA.list,🏦 金融支付
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TigerFintech/TigerFintech.list,🏦 金融支付
-# Accademia 银行 × 10 国 + 虚拟金融 × 4（原 rule-provider 拆分为子规则集）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankUS.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankUK.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankHK.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankSG.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankJP.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankAU.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankCA.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankDE.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankNL.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankFR.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Paypal.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Wise.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Monzo.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Revolut.yaml,🏦 金融支付
+# 虚拟金融（替代已移除的 Accademia VirtualFinance YAML）
+DOMAIN-SUFFIX,monzo.com,🏦 金融支付
+DOMAIN-SUFFIX,n26.com,🏦 金融支付
+DOMAIN-SUFFIX,chime.com,🏦 金融支付
+# 主要国际银行域名兜底（已移除 Accademia Bank×10 YAML；欲全量覆盖请换 CMFA/OpenClash/SingBox）
+DOMAIN-SUFFIX,chase.com,🏦 金融支付
+DOMAIN-SUFFIX,bankofamerica.com,🏦 金融支付
+DOMAIN-SUFFIX,wellsfargo.com,🏦 金融支付
+DOMAIN-SUFFIX,citi.com,🏦 金融支付
+DOMAIN-SUFFIX,citibank.com,🏦 金融支付
+DOMAIN-SUFFIX,hsbc.com,🏦 金融支付
+DOMAIN-SUFFIX,hsbc.com.hk,🏦 金融支付
+DOMAIN-SUFFIX,barclays.co.uk,🏦 金融支付
+DOMAIN-SUFFIX,lloydsbank.com,🏦 金融支付
+DOMAIN-SUFFIX,santander.com,🏦 金融支付
+DOMAIN-SUFFIX,db.com,🏦 金融支付
+DOMAIN-SUFFIX,deutsche-bank.de,🏦 金融支付
+DOMAIN-SUFFIX,ing.nl,🏦 金融支付
+DOMAIN-SUFFIX,bnpparibas.com,🏦 金融支付
+DOMAIN-SUFFIX,sgmarkets.com,🏦 金融支付
+DOMAIN-SUFFIX,ocbc.com,🏦 金融支付
+DOMAIN-SUFFIX,uobgroup.com,🏦 金融支付
+DOMAIN-SUFFIX,dbs.com,🏦 金融支付
+DOMAIN-SUFFIX,dbs.com.sg,🏦 金融支付
+DOMAIN-SUFFIX,mufg.jp,🏦 金融支付
+DOMAIN-SUFFIX,smbc.co.jp,🏦 金融支付
+DOMAIN-SUFFIX,mizuhobank.com,🏦 金融支付
+DOMAIN-SUFFIX,rbc.com,🏦 金融支付
+DOMAIN-SUFFIX,td.com,🏦 金融支付
+DOMAIN-SUFFIX,scotiabank.com,🏦 金融支付
+DOMAIN-SUFFIX,cba.com.au,🏦 金融支付
+DOMAIN-SUFFIX,anz.com,🏦 金融支付
+DOMAIN-SUFFIX,westpac.com.au,🏦 金融支付
 
 # ─── 阶段 7: 邮件服务 ─────────────────────────────────────────────────────────
 # 微软服务域名前置（防止吞入邮件组）
@@ -516,8 +525,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TelegramUS/TelegramUS.list,💬 即时通讯
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Zalo/Zalo.list,💬 即时通讯
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/iTalkBB/iTalkBB.list,💬 即时通讯
-# Accademia Signal 补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Signal/Signal.yaml,💬 即时通讯
 DOMAIN-SUFFIX,icq.com,💬 即时通讯
 
 # ─── 阶段 9: 社交媒体 ─────────────────────────────────────────────────────────
@@ -555,9 +562,19 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Pixnet/Pixnet.list,📱 社交媒体
 
 # ─── 阶段 10: 会议协作 ────────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/ACL4SSR/ACL4SSR@master/Clash/Providers/Ruleset/Zoom.yaml,🧑‍💼 会议协作
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Slack/Slack.list,🧑‍💼 会议协作
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Teams/Teams.list,🧑‍💼 会议协作
+# Zoom（替代已移除的 ACL4SSR Zoom.yaml）
+DOMAIN-SUFFIX,zoom.us,🧑‍💼 会议协作
+DOMAIN-SUFFIX,zoom.com,🧑‍💼 会议协作
+DOMAIN-SUFFIX,zoomgov.com,🧑‍💼 会议协作
+DOMAIN-SUFFIX,zoomcdn.com,🧑‍💼 会议协作
+DOMAIN-SUFFIX,zoomdev.us,🧑‍💼 会议协作
+# RustDesk / Parsec（替代已移除的 Accademia RustDesk/Parsec YAML）
+DOMAIN-SUFFIX,rustdesk.com,🧑‍💼 会议协作
+DOMAIN-SUFFIX,parsec.app,🧑‍💼 会议协作
+DOMAIN-SUFFIX,parsecgaming.com,🧑‍💼 会议协作
+DOMAIN-SUFFIX,parsecusercontent.com,🧑‍💼 会议协作
 # Webex / Notion / Figma / Atlassian 等协作工具
 DOMAIN-SUFFIX,webex.com,🧑‍💼 会议协作
 DOMAIN-SUFFIX,wbx2.com,🧑‍💼 会议协作
@@ -593,9 +610,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Zendesk/Zendesk.list,🧑‍💼 会议协作
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Intercom/Intercom.list,🧑‍💼 会议协作
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/RemoteDesktop/RemoteDesktop.list,🧑‍💼 会议协作
-# Accademia 远程桌面补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/RustDesk/RustDesk.yaml,🧑‍💼 会议协作
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Parsec/Parsec.yaml,🧑‍💼 会议协作
 # 国内协作工具直连
 DOMAIN-SUFFIX,feishu.cn,DIRECT
 DOMAIN-SUFFIX,dingtalk.com,DIRECT
@@ -688,21 +702,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/56/56.list,📺 国内流媒体
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CETV/CETV.list,📺 国内流媒体
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/YYeTs/YYeTs.list,📺 国内流媒体
-# Accademia 国内云盘/媒体补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Alipan/Alipan.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/BaiduNetDisk/BaiduNetDisk.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/WeiYun/WeiYun.yaml,📺 国内流媒体
-# Accademia FakeLocation × 10 平台（国内 APP IP 归属地伪装）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationBiliBili.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationDouYin.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationKuaiShou.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationXiaoHongShu.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationXiGua.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationWeiBo.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationZhiHu.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationTieBa.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationDouBan.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationXianYu.yaml,📺 国内流媒体
 # 港澳台 B 站需要港区代理解锁
 RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/BilibiliHMT.list,🇭🇰 香港流媒体
 
@@ -738,7 +737,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/WeTV/WeTV.list,📺 东南亚流媒体
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Zee/Zee.list,📺 东南亚流媒体
 # Kwai 国际版（巴西/印尼主战场）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Kwai/Kwai.yaml,📺 东南亚流媒体
 
 # ─── 阶段 13: 美国流媒体 ──────────────────────────────────────────────────────
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/YouTube/YouTube.list,🇺🇸 美国流媒体
@@ -1088,8 +1086,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/D
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/OneDrive/OneDrive.list,Ⓜ️ 微软服务
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Microsoft/Microsoft.list,Ⓜ️ 微软服务
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MicrosoftEdge/MicrosoftEdge.list,Ⓜ️ 微软服务
-# Accademia 微软 APP 补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/MicrosoftAPPs/MicrosoftAPPs.yaml,Ⓜ️ 微软服务
 
 # ─── 阶段 23: 苹果服务 ────────────────────────────────────────────────────────
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleMusic/AppleMusic.list,🍎 苹果服务
@@ -1104,9 +1100,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TestFlight/TestFlight.list,🍎 苹果服务
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleFirmware/AppleFirmware.list,🍎 苹果服务
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/FindMy/FindMy.list,🍎 苹果服务
-# Accademia 苹果补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/AppleNews/AppleNews.yaml,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Apple/Apple.yaml,🍎 苹果服务
 
 # ─── 阶段 24: 下载更新 ────────────────────────────────────────────────────────
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SystemOTA/SystemOTA.list,📥 下载更新
@@ -1152,8 +1145,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HP/HP.list,📥 下载更新
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Canon/Canon.list,📥 下载更新
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LG/LG.list,📥 下载更新
-# Accademia Mac App 升级（Homebrew/Sparkle 源）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/MacAppUpgrade/MacAppUpgrade.yaml,📥 下载更新
 
 # ─── 阶段 25: 云与 CDN ────────────────────────────────────────────────────────
 # bm7 Cloudflare / Fastly / CloudFront IP 段（需要 no-resolve 避免解析消耗）
@@ -1199,8 +1190,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 # 视频 CDN
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BrightCove/BrightCove.list,☁️ 云与CDN
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Jwplayer/Jwplayer.list,☁️ 云与CDN
-# Accademia CDN 补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Fastly/Fastly.yaml,☁️ 云与CDN
 # Let's Encrypt
 DOMAIN-SUFFIX,letsencrypt.org,☁️ 云与CDN
 DOMAIN-SUFFIX,lencr.org,☁️ 云与CDN
@@ -1214,8 +1203,6 @@ DOMAIN-SUFFIX,tracker.openbittorrent.com,🛰️ BT/PT Tracker
 DOMAIN-SUFFIX,tracker.publicbt.com,🛰️ BT/PT Tracker
 DOMAIN-SUFFIX,tracker.dler.org,🛰️ BT/PT Tracker
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PrivateTracker/PrivateTracker.list,🛰️ BT/PT Tracker
-# Accademia eMule 服务器
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/eMuleServer/eMuleServer.yaml,🛰️ BT/PT Tracker
 
 # ─── 阶段 27: 印尼本地服务（电商/出行/外卖/电信/政府/新闻 → 国外网站） ────────
 DOMAIN-SUFFIX,tokopedia.com,🌐 国外网站
@@ -1267,16 +1254,8 @@ DOMAIN-SUFFIX,zxtdjy.com,🏠 国内网站
 # Chiphell 论坛直连（原版 FIX）
 DOMAIN-SUFFIX,chiphell.com,DIRECT
 DOMAIN-SUFFIX,iwipwedabay.com,DIRECT
-# Accademia 国内兜底
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeositeCN/GeositeCN.yaml,🏠 国内网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/ChinaMax/ChinaMax.yaml,🏠 国内网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/China/China.yaml,🏠 国内网站
 # Aqara 国内 / 国际
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Aqara/AqaraCN.yaml,🏠 国内网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Aqara/AqaraGlobal.yaml,🌐 国外网站
 # HomeIP × 2 国（美/日）→ 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/HomeIP/HomeIPUS.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/HomeIP/HomeIPJP.yaml,🌐 国外网站
 # bm7 国内综合（ChinaMax / cn 等）
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ChinaMax/ChinaMax.list,🏠 国内网站
 
@@ -1299,9 +1278,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MEGA/MEGA.list,🌐 国外网站
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Wikipedia/Wikipedia.list,🌐 国外网站
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Duolingo/Duolingo.list,🌐 国外网站
-# Accademia 国外网站补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/WaybackMachine/WaybackMachine.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Pornhub/Pornhub.yaml,🌐 国外网站
 # szkane Education
 RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Khan.list,🌐 国外网站
 RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Edutools.list,🌐 国外网站
@@ -1309,24 +1285,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/E
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Naver/Naver.list,🌐 国外网站
 # EHGallery（非流媒体服务）
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/EHGallery/EHGallery.list,🌐 国外网站
-# Accademia GeoRouting × 17 区域（中国 → CN_SITE，其它 → INTL_SITE）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_China_ccTLD_Domain.yaml,🏠 国内网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_East_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_EastSouth_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_South_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_Central_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_West_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_America_North_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_America_South_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Europe_West_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Europe_East_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Oceania_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Antarctica_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_North_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_South_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_West_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_East_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_Central_ccTLD_Domain.yaml,🌐 国外网站
 # 其它国外网站兜底
 DOMAIN-SUFFIX,archive.org,🌐 国外网站
 DOMAIN-SUFFIX,udemy.com,🌐 国外网站
@@ -1339,16 +1297,21 @@ DOMAIN-SUFFIX,guardianapis.com,🌐 国外网站
 DOMAIN-SUFFIX,box.com,🌐 国外网站
 DOMAIN-SUFFIX,boxcdn.net,🌐 国外网站
 DOMAIN-SUFFIX,noip.com,🌐 国外网站
+# Wayback Machine / Pornhub（替代已移除的 Accademia 国外网站 YAML）
+DOMAIN-SUFFIX,web.archive.org,🌐 国外网站
+DOMAIN-SUFFIX,pornhub.com,🌐 国外网站
+DOMAIN-SUFFIX,phncdn.com,🌐 国外网站
+DOMAIN-SUFFIX,phprcdn.com,🌐 国外网站
 
 # ─── 阶段 31: GEOIP 精准标签路由 + CN 兜底 ────────────────────────────────────
-# 注：SR 原生 GEOIP 仅支持国家码匹配，不支持 cloudflare/telegram 等标签
-# 以下 GEOIP 标签依赖 Loyalsoldier 加强版 MMDB（在 SR 设置 → GeoLite2 数据库中替换）
-# 若未替换 MMDB，以下规则将失效，但规则集 RULE-SET 已覆盖等效分流，不影响功能
-# 推荐 MMDB 源：https://fastly.jsdelivr.net/gh/Loyalsoldier/geoip@release/Country.mmdb
+# Loon 原生 GEOIP 支持国家码匹配 + Loyalsoldier MMDB 的增强标签
+# 若采用 [General] 里 geoip-url = Loyalsoldier 加强版，cloudflare/telegram/netflix/google 等标签可用
+# 否则仅 `GEOIP,CN` 命中（Loon 内置 MaxMind GeoLite2）
 GEOIP,CN,🏠 国内网站,no-resolve
 
 # ─── 阶段 32: FINAL 兜底 ──────────────────────────────────────────────────────
-FINAL,🐟 漏网之鱼,dns-failed
+# Loon 的 FINAL 不接 `dns-failed` 后缀（那是 Surge 专属）
+FINAL,🐟 漏网之鱼
 
 # ══════════════════════════════════════════════════════════════════════════════
 #  [Host] — 本地 DNS 映射


### PR DESCRIPTION
## 背景

用户反馈「Loon 用不了好像 好多和配置文件冲突的」。核查后确认 `v5.2.3-Loon.1` 有一系列 Surge 语法被直接搬进了 Loon，Loon 引擎要么静默丢弃、要么直接报错，导致**区域节点聚合、DNS、MMDB、及 72 条规则集**在实际使用中大面积失效。

本 PR 以三份权威 Loon 配置为对照逐项对齐 Loon 官方字段：
- [YueChan/Loon `Default.Conf`](https://github.com/YueChan/Loon/blob/main/Default.Conf)
- [Loon0x00/LoonExampleConfig `example.conf`](https://github.com/Loon0x00/LoonExampleConfig/blob/master/example.conf)
- [fmz200/wool_scripts `Loon.conf`](https://raw.githubusercontent.com/fmz200/wool_scripts/main/Loon/config/Loon.conf)

## 改动清单

### [General] 段字段对齐（P0）

| 旧（Surge 语法） | 新（Loon 官方） | 影响 |
|---|---|---|
| `tun-excluded-routes = ...` | `bypass-tun = ...` | TUN 路由被忽略 |
| `dns-server = IP..., https://doh.pub/...` | `dns-server = system, IP...` + DoH 进 `doh-server` | DoH 查询被丢弃 |
| `ipv6-enabled = true` | `ipv6 = true` | IPv6 开关不生效 |
| `udp-policy-not-supported-behaviour = REJECT` | `udp-fallback-mode = REJECT` | UDP 回退策略丢失 |
| `bypass-system = true` | **删除**（Loon 无此字段） | 未知字段警告 |
| `hijack-dns = 8.8.8.8:53, ...` | **删除**（Loon 无此字段） | DNS 劫持段被忽略 |
| — | **新增** `geoip-url = .../Loyalsoldier/...Country.mmdb` | MMDB 自动下载（原说"Loon 不支持"是误解） |

### [Remote Filter] + [Proxy Group] 结构性重构（P0）

- **新增 `[Remote Filter]` 段**：9 个区域 `NameRegex + FilterKey` 定义（GLOBAL / HK / TW / JPKR / APAC / US / EU / AM / AF），替代 Surge 的 url-test 内联 `policy-regex-filter=`（Loon 不识别）
- **9 个 url-test 组**改为引用 Filter 名：`= url-test,<Filter>,url=...,interval=600,tolerance=50`
- 删除 Loon 不支持的 `timeout=` 与 `select=0` 参数

### [Rule] 段格式对齐（P0）

- **删除 72 条 Clash classical `.yaml` RULE-SET**（71 条 Accademia + 1 条 ACL4SSR Zoom.yaml）—— Loon 只解析 `.list` / `.conf` 纯文本，YAML 被静默丢弃
- `IP-CIDR6,::1/128,...` × 3 → `IP-CIDR,::1/128,...`（Loon 只有 `IP-CIDR`，自动识别 IPv4/IPv6）
- `FINAL,🐟 漏网之鱼,dns-failed` → `FINAL,🐟 漏网之鱼`（Loon 无 `dns-failed` 后缀）
- Sukka `domainset/reject_phishing.conf` → `non_ip/reject_phishing.conf`（domainset 是 Surge 专属二级格式）

### [Rule] 兜底补丁（P1）

72 条 YAML 删除后，大部分覆盖由 bm7 / szkane / sukka 吸收；少量 Accademia 专属业务补 DOMAIN-SUFFIX 兜底：

- 🏦 金融支付：Monzo / N26 / Chime + 24 个国际银行（Chase / BofA / HSBC / Barclays / DBS / MUFG / RBC / ANZ 等）
- 🧑‍💼 会议协作：Zoom × 5 域名、RustDesk、Parsec × 3 域名
- 🌐 国外网站：Wayback Machine、Pornhub × 3 域名

**已接受的回归损失**（没有 Loon `.list` 等价源）：Accademia `FakeLocation × 10` / `GeoRouting × 17 区域` / `eMuleServer` / `HomeIP` / `Bank × 10 国家级细粒度`。如需完整覆盖请换 CMFA / OpenClash / SingBox。

### 文档

- `Loon/CHANGELOG.md`：完整 FIX#Loon-01..13 清单 + 官方文档证据链
- `Loon/README.md`：重写 DNS 配置表、MMDB 章节、与 Surge 差异说明、常见问题
- 版本号：`v5.2.3-Loon.1` → `v5.2.4-Loon.2`（主版本对齐 Clash Party v5.2.4）
- Build：2026-04-20 → 2026-04-22

## 自检输出（CLAUDE.md §5 适用子集）

```
=== proxy-group count (期望 37) ===
37
=== url-test count (期望 9) ===
9
=== select count (期望 28) ===
28
=== remote filter count (期望 9) ===
9
=== yaml rule-sets (期望 0) ===
0
=== bypass-system / tun-excluded-routes / ipv6-enabled / hijack-dns /
    udp-policy-not-supported-behaviour / IP-CIDR6 / FINAL,...,dns-failed ===
全部 0
=== bypass-tun / ipv6 / udp-fallback-mode / geoip-url (期望各 1) ===
全部 1
=== 9 url-test 引用的 Filter 名 vs [Remote Filter] 定义 ===
MATCHED（完全一一对应）
```

## 影响面

- 仅 `Loon/` 子目录（`loon-smart.conf` / `CHANGELOG.md` / `README.md`）
- 按 `CLAUDE.md §1.4` 平台专属 bug 修复豁免：Surge / Shadowrocket / Quantumult X 等兄弟产物不需要联动（它们各自的语法本就正确，不受此次 Loon 字段对齐影响）

## Test plan

- [ ] 导入 `loon-smart.conf` 到 Loon，**启用**后无 unknown-field 警告
- [ ] 「过滤器」面板出现 9 个 Filter，区域 url-test 组中看到节点按 regex 归拢
- [ ] 「策略组」面板 37 组（9 区域 + 28 业务）
- [ ] 首次启用后 `geoip-url` 自动下载 MMDB；`GEOIP,CN,🏠 国内网站` 命中国内域名
- [ ] 分流冒烟：`chat.openai.com → 🤖 AI 服务` / `youtube.com → 🇺🇸 美国流媒体` / `bilibili.com → DIRECT` / `raw.githubusercontent.com → 📟 开发者服务`

https://claude.ai/code/session_016pAnSQpbR2mB55QrU2fnAH