### PR TITLE
fix(loon): swap anti-ad.net to jsDelivr upstream (v5.2.4-Loon.3)

### DIFF
--- a/Loon/CHANGELOG.md
+++ b/Loon/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ---
 
+## v5.2.4-Loon.3 (2026-04-22) — anti-AD 规则源改用 jsDelivr 镜像
+
+- ★ FIX#Loon-14-P0：`RULE-SET,https://anti-ad.net/surge.txt,🛑 广告拦截`
+  → `RULE-SET,https://fastly.jsdelivr.net/gh/privacy-protection-tools/anti-AD@master/anti-ad-surge.txt,🛑 广告拦截`
+  - 现象：Loon 启用配置时弹窗 "第 229 行出现语法错误"（用户截图反馈）
+  - 原因：`anti-ad.net` 是项目自建的裸域名（非 CDN），部分国内 ISP / DNS 劫持会返回 HTML
+    captive 页或 403，Loon 把 HTML 当规则解析就报语法错；而仓库里其他 287 条 RULE-SET 全部
+    走 `fastly.jsdelivr.net` 或 `ruleset.skk.moe` CDN，从未出现此类问题
+  - 修复：改指 anti-AD 官方 GitHub 仓库 `privacy-protection-tools/anti-AD` 的
+    `anti-ad-surge.txt`（与 `surge.txt` 语义一致，但走 jsDelivr CDN 镜像）
+- ★ 附带扫描：除 anti-ad.net 外，[Rule] 段内所有 288 条 RULE-SET 全部走
+  `fastly.jsdelivr.net` / `ruleset.skk.moe`，无同类隐患
+
+---
+
 ## v5.2.4-Loon.2 (2026-04-22) — Loon 原生语法兼容性大修
 
 用户反馈"Loon 用不了好像 好多和配置文件冲突" — 复核后确认 v5.2.3-Loon.1 把

--- a/Loon/README.md
+++ b/Loon/README.md
@@ -1,7 +1,7 @@
 # Loon 使用教程（对齐 Clash Party v5.2.4）
 
 > 配置文件：`Loon/loon-smart.conf`
-> 版本：**v5.2.4-Loon.2**（Build 2026-04-22，Loon 原生语法兼容性大修，见 `Loon/CHANGELOG.md`）
+> 版本：**v5.2.4-Loon.3**（Build 2026-04-22，anti-AD 规则源换 jsDelivr 镜像 + v5.2.4-Loon.2 原生语法大修，见 `Loon/CHANGELOG.md`）
 > 目标：**Loon iOS（App Store 付费正版）**
 > 架构：9 区域 url-test 组（[Remote Filter] NameRegex）+ 28 业务策略组 + 250+ RULE-SET
 

--- a/Loon/loon-smart.conf
+++ b/Loon/loon-smart.conf
@@ -1,5 +1,5 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Loon Smart v5.2.4-Loon.2 — Loon 版（从 Clash Party v5.2.4 迁移）
+#  Loon Smart v5.2.4-Loon.3 — Loon 版（从 Clash Party v5.2.4 迁移）
 #  Build: 2026-04-22 | Target: Loon iOS (App Store 付费正版)
 #  架构：9 区域 url-test 组（[Remote Filter] NameRegex）+ 28 业务 select 组 + 250+ RULE-SET
 #  基线：Clash Party v5.2.4（唯一主线）
@@ -225,8 +225,8 @@ AF_Filter     = NameRegex, FilterKey = "(?i)(🇿🇦|🇪🇬|🇳🇬|🇰🇪
 
 [Rule]
 # ─── 阶段 1: 广告拦截与威胁情报 ───────────────────────────────────────────────
-# anti-AD（DustinWin 同源 privacy-protection-tools/anti-AD）
-RULE-SET,https://anti-ad.net/surge.txt,🛑 广告拦截
+# anti-AD（privacy-protection-tools/anti-AD 官方源；anti-ad.net 无 CDN 且部分 ISP 会劫持返回 HTML，Loon 会当规则解析报语法错）
+RULE-SET,https://fastly.jsdelivr.net/gh/privacy-protection-tools/anti-AD@master/anti-ad-surge.txt,🛑 广告拦截
 # SukkaW 钓鱼域名拦截（13 万条；Loon 用 non_ip .conf，domainset 是 Surge 专属二级格式）
 RULE-SET,https://ruleset.skk.moe/List/non_ip/reject_phishing.conf,🛑 广告拦截
 # Hagezi TIF（威胁情报：malware/cryptojacking/C2/scam/spam）


### PR DESCRIPTION
## 现象

用户截图反馈：导入 `loon-smart.conf` 后 Loon 启用时弹窗：

> **提示**：第 229 行出现语法错误：RULE-SET,https://anti-ad.net/surge.txt,🛑 广告拦截

## 根因

`anti-ad.net` 是 `privacy-protection-tools/anti-AD` 项目的自建裸域名（无 CDN）。部分国内 ISP / DNS 在没代理时会：

- 解析失败 / 劫持到 captive portal
- 返回 HTML 错误页（非 Surge 格式规则）

Loon 把 HTML 当规则解析，第一行就非法，于是整行 RULE-SET 报"语法错误"。

与此形成对照：仓库里其他 **287 条 RULE-SET 全部走 `fastly.jsdelivr.net` 或 `ruleset.skk.moe` CDN**，都是稳定大流量 CDN，从未踩过这种坑。

## 修复

```diff
-# anti-AD（DustinWin 同源 privacy-protection-tools/anti-AD）
-RULE-SET,https://anti-ad.net/surge.txt,🛑 广告拦截
+# anti-AD（privacy-protection-tools/anti-AD 官方源；anti-ad.net 无 CDN 且部分 ISP 会劫持返回 HTML，Loon 会当规则解析报语法错）
+RULE-SET,https://fastly.jsdelivr.net/gh/privacy-protection-tools/anti-AD@master/anti-ad-surge.txt,🛑 广告拦截
```

指向上游 GitHub 仓库的 `anti-ad-surge.txt`（与 `surge.txt` 语义一致，Surge/Loon 兼容格式），走 jsDelivr CDN，与配置里其他 287 条 RULE-SET 走同一模式。

附带扫描：`grep -E "^RULE-SET,"` 过滤 `fastly.jsdelivr.net|ruleset.skk.moe` 后 0 条剩余 → 没有其他同类隐患。

## 元信息

- 版本：`v5.2.4-Loon.2` → **`v5.2.4-Loon.3`**
- Build：2026-04-22（当日）
- `Loon/CHANGELOG.md`：新增 FIX#Loon-14-P0 条目
- `Loon/README.md`：头部版本号同步

## Test plan

- [ ] 手机上重新订阅配置，Loon 启用无"第 229 行语法错误"弹窗
- [ ] 「规则」面板 anti-AD 规则集数量 ≈ 10 万 6 千条（anti-AD 实际体量），有正常流量命中
- [ ] 首页版本号显示 `Loon Smart v5.2.4-Loon.3`

https://claude.ai/code/session_016pAnSQpbR2mB55QrU2fnAH