### PR TITLE
fix(loon): migrate 288 RULE-SETs to [Remote Rule] section (v5.2.4-Loon.4)

### DIFF
--- a/Loon/CHANGELOG.md
+++ b/Loon/CHANGELOG.md
@@ -4,6 +4,64 @@
 
 ---
 
+## v5.2.4-Loon.4 (2026-04-22) — 根治"第 229 行语法错误"：288 条 RULE-SET 迁移到 [Remote Rule]
+
+用户反馈 v5.2.4-Loon.3 仍然弹"第 229 行出现语法错误"（anti-ad-surge.txt）；同一天朋友指出 Loon
+的订阅规则集正确写法是：
+
+    URL, policy=<策略组>, tag=<显示名>, enabled=true
+
+放在 `[Remote Rule]` 段，而不是 `[Rule]` 段里的 Surge 风格 `RULE-SET,URL,policy`。
+
+复核 fmz200/wool_scripts Loon.conf（与 YueChan/Loon 权威示例）后确认：
+
+- Loon 的 `[Rule]` 段只接受**内联规则**（`DOMAIN-SUFFIX,x,p` / `IP-CIDR,x,p` / `GEOIP,CN,p` / `FINAL,p`）
+- **远程订阅 RULE-SET 必须放 `[Remote Rule]` 段**，用 URL 开头的 key=value 语法；写成 Surge 风格的
+  `RULE-SET,URL,policy` Loon 会从第一行开始就报语法错
+
+我们从 v5.2.3-Loon.1 初版起就用错了段，v5.2.4-Loon.2 大修时也没发现（官方文档在这一点上说得不清楚，
+三份示例参考里也只有 YueChan 的 `[Rule]` 是干净的，fmz200 的 `[Remote Rule]` 才给出了完整语法）。
+
+### 本次改动（一次性彻底修）
+
+- ★ FIX#Loon-15-P0：**新增 `[Remote Rule]` 段**，位置在 `[Proxy Group]` 与 `[Rule]` 之间
+- ★ FIX#Loon-16-P0：**288 条 RULE-SET 全量迁移**到 `[Remote Rule]`：
+  - `RULE-SET,<URL>,<policy>` → `<URL>, policy=<policy>, tag=<file_basename>, enabled=true`
+  - tag 自动取 URL 路径最后一段（例如 `Advertising.list` / `anti-ad-surge.txt`），Loon UI 里看规则源面板更直观
+  - 288 条 tag 全部唯一，无重复（脚本 `uniq -c` 验证）
+- ★ `[Rule]` 段现在只剩**内联规则**（DOMAIN / DOMAIN-SUFFIX / IP-CIDR / DST-PORT / HOST / GEOIP / FINAL），
+  614 行，和 fmz200 / YueChan 的 Loon 配置结构一致
+- ★ 头部架构一句话：`... + 250+ RULE-SET` → `... + 288 [Remote Rule] 订阅规则集`
+
+### 迁移自动化
+
+本次迁移用 Python 脚本 `tmp/migrate_loon.py` 批量完成（288 条手工 Edit 太易错）：
+
+1. 正则扫描 `^RULE-SET,(https?://[^,]+),(.+)$` 提取 URL + policy
+2. 从 URL 末段生成 `tag=` 值
+3. 按阶段注释分组插入 `[Remote Rule]` 段，保留原有注释上下文
+4. `[Rule]` 段只保留非 RULE-SET 行
+
+### 自检
+
+- 代理组 37 个 ✓
+- 9 区域 Filter × 9 url-test 引用一一匹配 ✓
+- `[Remote Rule]` 288 条 ✓
+- `[Rule]` 段内残留 `RULE-SET,` 0 条 ✓
+- `IP-CIDR6` / `FINAL,...,dns-failed` / `bypass-system` / `ipv6-enabled` / `tun-excluded-routes` /
+  `hijack-dns` / `udp-policy-not-supported` 全部 0 次出现 ✓
+- 288 条 tag 全部唯一 ✓
+
+### 官方文档证据
+
+- `[Remote Rule]` 语法：[fmz200/wool_scripts Loon.conf](https://raw.githubusercontent.com/fmz200/wool_scripts/main/Loon/config/Loon.conf)
+- 用户朋友的原版示例：
+  ```
+  https://raw.githubusercontent.com/blackmatrix7/ios_rule_script/master/rule/Loon/Duckduckgo/Duckduckgo.list, policy=美国节点-兔子, tag=Duckduckgo.list, enabled=true
+  ```
+
+---
+
 ## v5.2.4-Loon.3 (2026-04-22) — anti-AD 规则源改用 jsDelivr 镜像
 
 - ★ FIX#Loon-14-P0：`RULE-SET,https://anti-ad.net/surge.txt,🛑 广告拦截`

--- a/Loon/README.md
+++ b/Loon/README.md
@@ -1,9 +1,9 @@
 # Loon 使用教程（对齐 Clash Party v5.2.4）
 
 > 配置文件：`Loon/loon-smart.conf`
-> 版本：**v5.2.4-Loon.3**（Build 2026-04-22，anti-AD 规则源换 jsDelivr 镜像 + v5.2.4-Loon.2 原生语法大修，见 `Loon/CHANGELOG.md`）
+> 版本：**v5.2.4-Loon.4**（Build 2026-04-22，288 条 RULE-SET 迁移至 [Remote Rule] 段；此前累计修 v5.2.4-Loon.2/.3，见 `Loon/CHANGELOG.md`）
 > 目标：**Loon iOS（App Store 付费正版）**
-> 架构：9 区域 url-test 组（[Remote Filter] NameRegex）+ 28 业务策略组 + 250+ RULE-SET
+> 架构：9 区域 url-test 组（[Remote Filter] NameRegex）+ 28 业务策略组 + 288 [Remote Rule] 订阅规则集
 
 ---
 
@@ -186,10 +186,18 @@ Loon 启动时会自动下载这份 Loyalsoldier 加强版 MMDB（含 cloudflare
 | 在配置里设置 MMDB URL | ❌ 只能 UI 下载 | ✅ `geoip-maxmind-url` |
 | macOS 版本 | ❌ 仅 iOS | ✅ Surge Mac |
 
-**本配置里 RULE-SET 放在 `[Rule]` 段内**（Surge 兼容语法，Loon 原生支持），没有拆到 `[Remote Rule]` 面板——这样做的好处是和 Surge 版保持 1:1 可 diff，减少维护成本；代价是在 Loon 的「规则源」UI 里不会出现独立条目，要管理订阅更新仍可以，但无法逐个 RULE-SET 启用/禁用。如果你偏好 Loon 原生面板，可以自行把 `[Rule]` 段的 `RULE-SET,<URL>,<policy>` 行迁移到 `[Remote Rule]` 段，格式：
+**本配置从 v5.2.4-Loon.4 起把 288 条 RULE-SET 全部放在 `[Remote Rule]` 段内**（Loon 原生语法）：
+
 ```
-https://example.com/rule.list, policy=POLICY, tag=some-tag, enabled=true
+[Remote Rule]
+https://example.com/rule.list, policy=POLICY, tag=rule.list, enabled=true
 ```
+
+> **为什么不能用 Surge 风格的 `[Rule] RULE-SET,URL,policy`？**
+> Loon 的 `[Rule]` 段只接受内联规则（DOMAIN / IP-CIDR / GEOIP / FINAL 等），写了 Surge 风格的远程 RULE-SET
+> 会导致 Loon 在每一行都报"语法错误"弹窗。v5.2.3-Loon.1 → v5.2.4-Loon.3 都犯了这个错，直到 v5.2.4-Loon.4 才修。
+
+好处：在 Loon「规则」面板可以看到 288 条独立的订阅规则集条目，每条都能单独启用/禁用/查看命中数。
 
 ---
 
@@ -226,7 +234,7 @@ Parsec / Zoom / Pornhub / Wayback）：
 
 ## 九、验证
 
-1. Loon → **首页** → 应显示 `Loon Smart v5.2.4-Loon.2`，协议已启用。
+1. Loon → **首页** → 应显示 `Loon Smart v5.2.4-Loon.4`，协议已启用。
 2. **策略组** 面板应出现 37 组（9 区域 + 28 业务）。
 3. **过滤器** 面板应出现 9 个 Filter（GLOBAL_Filter / HK_Filter / TW_Filter / JPKR_Filter / APAC_Filter / US_Filter / EU_Filter / AM_Filter / AF_Filter）。
 4. 测试分流：

--- a/Loon/loon-smart.conf
+++ b/Loon/loon-smart.conf
@@ -1,7 +1,7 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Loon Smart v5.2.4-Loon.3 — Loon 版（从 Clash Party v5.2.4 迁移）
+#  Loon Smart v5.2.4-Loon.4 — Loon 版（从 Clash Party v5.2.4 迁移）
 #  Build: 2026-04-22 | Target: Loon iOS (App Store 付费正版)
-#  架构：9 区域 url-test 组（[Remote Filter] NameRegex）+ 28 业务 select 组 + 250+ RULE-SET
+#  架构：9 区域 url-test 组（[Remote Filter] NameRegex）+ 28 业务 select 组 + 288 [Remote Rule] 订阅规则集
 #  基线：Clash Party v5.2.4（唯一主线）
 #  变更历史：见 `Loon/CHANGELOG.md`
 # ══════════════════════════════════════════════════════════════════════════════
@@ -199,9 +199,20 @@ AF_Filter     = NameRegex, FilterKey = "(?i)(🇿🇦|🇪🇬|🇳🇬|🇰🇪
 🛑 广告拦截 = select,REJECT,DIRECT
 
 # ══════════════════════════════════════════════════════════════════════════════
-#  [Rule] — 规则引擎
+#  规则引擎 — [Remote Rule] + [Rule]
 #  ────────────────────────────────────────────────────────────────────────────
-#  规则顺序原则（原版 v5.2.2 防吞盾 + 优先级）
+#  v5.2.4-Loon.4 起 Loon 规则分两段存放：
+#
+#  [Remote Rule] — 订阅规则集（288 条，本段）
+#      URL, policy=<策略组>, tag=<显示名>, enabled=true
+#      ⚠️ 必须用 Loon 原生语法；不能写成 Surge 风格的 `RULE-SET,URL,policy`
+#      （放在 [Rule] 段里 Loon 会报"语法错误"弹窗）
+#
+#  [Rule] — 内联规则（下方）
+#      DOMAIN / DOMAIN-SUFFIX / DOMAIN-KEYWORD / IP-CIDR / DST-PORT / HOST /
+#      GEOIP / FINAL 等单行规则；两段一起参与路由决策
+#
+#  规则顺序原则（原版 v5.2.2 防吞盾 + 优先级，在两段 + 内部顺序中共同保证）
 #    1. 广告拦截/威胁情报（最前，强制 REJECT）
 #    2. 私有网段/本地服务（DIRECT）
 #    3. 防吞盾：Google 子服务精确规则（前置于 szkane-ai）
@@ -212,41 +223,374 @@ AF_Filter     = NameRegex, FilterKey = "(?i)(🇿🇦|🇪🇬|🇳🇬|🇰🇪
 #    5. GEOIP CN 兜底
 #    6. FINAL 漏网之鱼
 #
-#  规则源说明（v5.2.4-Loon.2 起）
-#    • bm7 = https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon
-#    • szkane = https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash
-#    • sukka = https://ruleset.skk.moe（Surge/Loon 兼容 .conf 与 .list）
-#    • hagezi = https://fastly.jsdelivr.net/gh/hagezi/dns-blocklists@main/share（Surge 格式）
-#    • anti-ad = https://anti-ad.net（Surge 格式）
+#  规则源说明
+#    • bm7     = https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon
+#    • szkane  = https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash
+#    • sukka   = https://ruleset.skk.moe（Surge/Loon 兼容 .conf 与 .list）
+#    • hagezi  = https://fastly.jsdelivr.net/gh/hagezi/dns-blocklists@main/share
+#    • anti-AD = https://fastly.jsdelivr.net/gh/privacy-protection-tools/anti-AD@master
 #
 #  Accademia/* Clash classical YAML 已全部移除（Loon 不支持 YAML RULE-SET）；
 #  等价覆盖由 bm7 / szkane / sukka 吸收，少量专属域名补在 [Rule] 段内（Monzo/RustDesk/Parsec/Zoom/Pornhub 等）。
 # ══════════════════════════════════════════════════════════════════════════════
 
+[Remote Rule]
+
+# ─── 阶段 1: 广告拦截与威胁情报 ───────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/privacy-protection-tools/anti-AD@master/anti-ad-surge.txt, policy=🛑 广告拦截, tag=anti-ad-surge.txt, enabled=true
+https://ruleset.skk.moe/List/non_ip/reject_phishing.conf, policy=🛑 广告拦截, tag=reject_phishing.conf, enabled=true
+https://fastly.jsdelivr.net/gh/hagezi/dns-blocklists@main/share/surge-tif-medium.txt, policy=🛑 广告拦截, tag=surge-tif-medium.txt, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Advertising/Advertising.list, policy=🛑 广告拦截, tag=Advertising.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AdvertisingMiTV/AdvertisingMiTV.list, policy=🛑 广告拦截, tag=AdvertisingMiTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AdobeActivation/AdobeActivation.list, policy=🛑 广告拦截, tag=AdobeActivation.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BlockHttpDNS/BlockHttpDNS.list, policy=🛑 广告拦截, tag=BlockHttpDNS.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Domob/Domob.list, policy=🛑 广告拦截, tag=Domob.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Hijacking/Hijacking.list, policy=🛑 广告拦截, tag=Hijacking.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/JiGuangTuiSong/JiGuangTuiSong.list, policy=🛑 广告拦截, tag=JiGuangTuiSong.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Marketing/Marketing.list, policy=🛑 广告拦截, tag=Marketing.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MIUIPrivacy/MIUIPrivacy.list, policy=🛑 广告拦截, tag=MIUIPrivacy.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Privacy/Privacy.list, policy=🛑 广告拦截, tag=Privacy.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/YouMengChuangXiang/YouMengChuangXiang.list, policy=🛑 广告拦截, tag=YouMengChuangXiang.list, enabled=true
+
+# ─── 阶段 2: 私有网段与本地服务 ───────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Lan/Lan.list, policy=DIRECT, tag=Lan.list, enabled=true
+
+# ─── 阶段 3: 防吞盾 — Google 子服务精准分流（前置于 szkane AI 宽规则） ───────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GoogleVoice/GoogleVoice.list, policy=💬 即时通讯, tag=GoogleVoice.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GoogleFCM/GoogleFCM.list, policy=📥 下载更新, tag=GoogleFCM.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GoogleSearch/GoogleSearch.list, policy=🔍 搜索引擎, tag=GoogleSearch.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GoogleDrive/GoogleDrive.list, policy=🔍 搜索引擎, tag=GoogleDrive.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GoogleEarth/GoogleEarth.list, policy=🔍 搜索引擎, tag=GoogleEarth.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Google/Google.list, policy=🔍 搜索引擎, tag=Google.list, enabled=true
+
+# ─── 阶段 4: AI 服务（Crypto 核心业务依赖，优先级高） ───────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/OpenAI/OpenAI.list, policy=🤖 AI 服务, tag=OpenAI.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Claude/Claude.list, policy=🤖 AI 服务, tag=Claude.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Gemini/Gemini.list, policy=🤖 AI 服务, tag=Gemini.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Copilot/Copilot.list, policy=🤖 AI 服务, tag=Copilot.list, enabled=true
+https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/AiDomain.list, policy=🤖 AI 服务, tag=AiDomain.list, enabled=true
+https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/CiciAi.list, policy=🤖 AI 服务, tag=CiciAi.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Civitai/Civitai.list, policy=🤖 AI 服务, tag=Civitai.list, enabled=true
+
+# ─── 阶段 5: 加密货币与量化交易 ───────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Binance/Binance.list, policy=💰 加密货币, tag=Binance.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Cryptocurrency/Cryptocurrency.list, policy=💰 加密货币, tag=Cryptocurrency.list, enabled=true
+https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Web3.list, policy=💰 加密货币, tag=Web3.list, enabled=true
+
+# ─── 阶段 6: 金融支付 ─────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PayPal/PayPal.list, policy=🏦 金融支付, tag=PayPal.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Stripe/Stripe.list, policy=🏦 金融支付, tag=Stripe.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/VISA/VISA.list, policy=🏦 金融支付, tag=VISA.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TigerFintech/TigerFintech.list, policy=🏦 金融支付, tag=TigerFintech.list, enabled=true
+
+# ─── 阶段 7: 邮件服务 ─────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Mail/Mail.list, policy=📧 邮件服务, tag=Mail.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Mailru/Mailru.list, policy=📧 邮件服务, tag=Mailru.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Protonmail/Protonmail.list, policy=📧 邮件服务, tag=Protonmail.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Spark/Spark.list, policy=📧 邮件服务, tag=Spark.list, enabled=true
+
+# ─── 阶段 8: 即时通讯 ─────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Telegram/Telegram.list, policy=💬 即时通讯, tag=Telegram.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Discord/Discord.list, policy=💬 即时通讯, tag=Discord.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Whatsapp/Whatsapp.list, policy=💬 即时通讯, tag=Whatsapp.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Line/Line.list, policy=💬 即时通讯, tag=Line.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/KakaoTalk/KakaoTalk.list, policy=💬 即时通讯, tag=KakaoTalk.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TelegramNL/TelegramNL.list, policy=💬 即时通讯, tag=TelegramNL.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TelegramSG/TelegramSG.list, policy=💬 即时通讯, tag=TelegramSG.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TelegramUS/TelegramUS.list, policy=💬 即时通讯, tag=TelegramUS.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Zalo/Zalo.list, policy=💬 即时通讯, tag=Zalo.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/iTalkBB/iTalkBB.list, policy=💬 即时通讯, tag=iTalkBB.list, enabled=true
+
+# ─── 阶段 9: 社交媒体 ─────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Twitter/Twitter.list, policy=📱 社交媒体, tag=Twitter.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TikTok/TikTok.list, policy=📱 社交媒体, tag=TikTok.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Reddit/Reddit.list, policy=📱 社交媒体, tag=Reddit.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Facebook/Facebook.list, policy=📱 社交媒体, tag=Facebook.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Instagram/Instagram.list, policy=📱 社交媒体, tag=Instagram.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Snap/Snap.list, policy=📱 社交媒体, tag=Snap.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Pinterest/Pinterest.list, policy=📱 社交媒体, tag=Pinterest.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LinkedIn/LinkedIn.list, policy=📱 社交媒体, tag=LinkedIn.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Tumblr/Tumblr.list, policy=📱 社交媒体, tag=Tumblr.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Clubhouse/Clubhouse.list, policy=📱 社交媒体, tag=Clubhouse.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ClubhouseIP/ClubhouseIP.list, policy=📱 社交媒体, tag=ClubhouseIP.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Pixiv/Pixiv.list, policy=📱 社交媒体, tag=Pixiv.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TruthSocial/TruthSocial.list, policy=📱 社交媒体, tag=TruthSocial.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/VK/VK.list, policy=📱 社交媒体, tag=VK.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Blued/Blued.list, policy=🏠 国内网站, tag=Blued.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Disqus/Disqus.list, policy=📱 社交媒体, tag=Disqus.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Imgur/Imgur.list, policy=📱 社交媒体, tag=Imgur.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Pixnet/Pixnet.list, policy=📱 社交媒体, tag=Pixnet.list, enabled=true
+
+# ─── 阶段 10: 会议协作 ────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Slack/Slack.list, policy=🧑‍💼 会议协作, tag=Slack.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Teams/Teams.list, policy=🧑‍💼 会议协作, tag=Teams.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Atlassian/Atlassian.list, policy=🧑‍💼 会议协作, tag=Atlassian.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Notion/Notion.list, policy=🧑‍💼 会议协作, tag=Notion.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TeamViewer/TeamViewer.list, policy=🧑‍💼 会议协作, tag=TeamViewer.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Zoho/Zoho.list, policy=🧑‍💼 会议协作, tag=Zoho.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Salesforce/Salesforce.list, policy=🧑‍💼 会议协作, tag=Salesforce.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Zendesk/Zendesk.list, policy=🧑‍💼 会议协作, tag=Zendesk.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Intercom/Intercom.list, policy=🧑‍💼 会议协作, tag=Intercom.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/RemoteDesktop/RemoteDesktop.list, policy=🧑‍💼 会议协作, tag=RemoteDesktop.list, enabled=true
+
+# ─── 阶段 11: 国内流媒体 ──────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BiliBili/BiliBili.list, policy=📺 国内流媒体, tag=BiliBili.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/iQIYI/iQIYI.list, policy=📺 国内流媒体, tag=iQIYI.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Youku/Youku.list, policy=📺 国内流媒体, tag=Youku.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TencentVideo/TencentVideo.list, policy=📺 国内流媒体, tag=TencentVideo.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DouYin/DouYin.list, policy=📺 国内流媒体, tag=DouYin.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ByteDance/ByteDance.list, policy=📺 国内流媒体, tag=ByteDance.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/KuaiShou/KuaiShou.list, policy=📺 国内流媒体, tag=KuaiShou.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Weibo/Weibo.list, policy=📺 国内流媒体, tag=Weibo.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/XiaoHongShu/XiaoHongShu.list, policy=📺 国内流媒体, tag=XiaoHongShu.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/NetEaseMusic/NetEaseMusic.list, policy=📺 国内流媒体, tag=NetEaseMusic.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/KugouKuwo/KugouKuwo.list, policy=📺 国内流媒体, tag=KugouKuwo.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Sohu/Sohu.list, policy=📺 国内流媒体, tag=Sohu.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AcFun/AcFun.list, policy=📺 国内流媒体, tag=AcFun.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Douyu/Douyu.list, policy=📺 国内流媒体, tag=Douyu.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HuYa/HuYa.list, policy=📺 国内流媒体, tag=HuYa.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Himalaya/Himalaya.list, policy=📺 国内流媒体, tag=Himalaya.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CCTV/CCTV.list, policy=📺 国内流媒体, tag=CCTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HunanTV/HunanTV.list, policy=📺 国内流媒体, tag=HunanTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PPTV/PPTV.list, policy=📺 国内流媒体, tag=PPTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Funshion/Funshion.list, policy=📺 国内流媒体, tag=Funshion.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LeTV/LeTV.list, policy=📺 国内流媒体, tag=LeTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TaiheMusic/TaiheMusic.list, policy=📺 国内流媒体, tag=TaiheMusic.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/KuKeMusic/KuKeMusic.list, policy=📺 国内流媒体, tag=KuKeMusic.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HibyMusic/HibyMusic.list, policy=📺 国内流媒体, tag=HibyMusic.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MiWu/MiWu.list, policy=📺 国内流媒体, tag=MiWu.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Migu/Migu.list, policy=📺 国内流媒体, tag=Migu.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/IPTVMainland/IPTVMainland.list, policy=📺 国内流媒体, tag=IPTVMainland.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/IPTVOther/IPTVOther.list, policy=📺 国内流媒体, tag=IPTVOther.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CIBN/CIBN.list, policy=📺 国内流媒体, tag=CIBN.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BesTV/BesTV.list, policy=📺 国内流媒体, tag=BesTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HuaShuTV/HuaShuTV.list, policy=📺 国内流媒体, tag=HuaShuTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SMG/SMG.list, policy=📺 国内流媒体, tag=SMG.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HWTV/HWTV.list, policy=📺 国内流媒体, tag=HWTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/NivodTV/NivodTV.list, policy=📺 国内流媒体, tag=NivodTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Olevod/Olevod.list, policy=📺 国内流媒体, tag=Olevod.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DanDanZan/DanDanZan.list, policy=📺 国内流媒体, tag=DanDanZan.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Dandanplay/Dandanplay.list, policy=📺 国内流媒体, tag=Dandanplay.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TianTianKanKan/TianTianKanKan.list, policy=📺 国内流媒体, tag=TianTianKanKan.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/YiZhiBo/YiZhiBo.list, policy=📺 国内流媒体, tag=YiZhiBo.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Ku6/Ku6.list, policy=📺 国内流媒体, tag=Ku6.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/56/56.list, policy=📺 国内流媒体, tag=56.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CETV/CETV.list, policy=📺 国内流媒体, tag=CETV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/YYeTs/YYeTs.list, policy=📺 国内流媒体, tag=YYeTs.list, enabled=true
+https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/BilibiliHMT.list, policy=🇭🇰 香港流媒体, tag=BilibiliHMT.list, enabled=true
+
+# ─── 阶段 12: 东南亚流媒体 ────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ViuTV/ViuTV.list, policy=📺 东南亚流媒体, tag=ViuTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BiliIntl/BiliIntl.list, policy=📺 东南亚流媒体, tag=BiliIntl.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AsianMedia/AsianMedia.list, policy=📺 东南亚流媒体, tag=AsianMedia.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/iQIYIIntl/iQIYIIntl.list, policy=📺 东南亚流媒体, tag=iQIYIIntl.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/JOOX/JOOX.list, policy=📺 东南亚流媒体, tag=JOOX.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MeWatch/MeWatch.list, policy=📺 东南亚流媒体, tag=MeWatch.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Viki/Viki.list, policy=📺 东南亚流媒体, tag=Viki.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/WeTV/WeTV.list, policy=📺 东南亚流媒体, tag=WeTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Zee/Zee.list, policy=📺 东南亚流媒体, tag=Zee.list, enabled=true
+
+# ─── 阶段 13: 美国流媒体 ──────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/YouTube/YouTube.list, policy=🇺🇸 美国流媒体, tag=YouTube.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Netflix/Netflix.list, policy=🇺🇸 美国流媒体, tag=Netflix.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Spotify/Spotify.list, policy=🇺🇸 美国流媒体, tag=Spotify.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Disney/Disney.list, policy=🇺🇸 美国流媒体, tag=Disney.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HBO/HBO.list, policy=🇺🇸 美国流媒体, tag=HBO.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PrimeVideo/PrimeVideo.list, policy=🇺🇸 美国流媒体, tag=PrimeVideo.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Hulu/Hulu.list, policy=🇺🇸 美国流媒体, tag=Hulu.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ParamountPlus/ParamountPlus.list, policy=🇺🇸 美国流媒体, tag=ParamountPlus.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Peacock/Peacock.list, policy=🇺🇸 美国流媒体, tag=Peacock.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Twitch/Twitch.list, policy=🇺🇸 美国流媒体, tag=Twitch.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Amazon/Amazon.list, policy=🇺🇸 美国流媒体, tag=Amazon.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CBS/CBS.list, policy=🇺🇸 美国流媒体, tag=CBS.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/NBC/NBC.list, policy=🇺🇸 美国流媒体, tag=NBC.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PBS/PBS.list, policy=🇺🇸 美国流媒体, tag=PBS.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ATTWatchTV/ATTWatchTV.list, policy=🇺🇸 美国流媒体, tag=ATTWatchTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Fox/Fox.list, policy=🇺🇸 美国流媒体, tag=Fox.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/FuboTV/FuboTV.list, policy=🇺🇸 美国流媒体, tag=FuboTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Sling/Sling.list, policy=🇺🇸 美国流媒体, tag=Sling.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SoundCloud/SoundCloud.list, policy=🇺🇸 美国流媒体, tag=SoundCloud.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Pandora/Pandora.list, policy=🇺🇸 美国流媒体, tag=Pandora.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PandoraTV/PandoraTV.list, policy=🇺🇸 美国流媒体, tag=PandoraTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TIDAL/TIDAL.list, policy=🇺🇸 美国流媒体, tag=TIDAL.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Vimeo/Vimeo.list, policy=🇺🇸 美国流媒体, tag=Vimeo.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Dailymotion/Dailymotion.list, policy=🇺🇸 美国流媒体, tag=Dailymotion.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Deezer/Deezer.list, policy=🇺🇸 美国流媒体, tag=Deezer.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DiscoveryPlus/DiscoveryPlus.list, policy=🇺🇸 美国流媒体, tag=DiscoveryPlus.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Overcast/Overcast.list, policy=🇺🇸 美国流媒体, tag=Overcast.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Americasvoice/Americasvoice.list, policy=🇺🇸 美国流媒体, tag=Americasvoice.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Cake/Cake.list, policy=🇺🇸 美国流媒体, tag=Cake.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Dood/Dood.list, policy=🇺🇸 美国流媒体, tag=Dood.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LastFM/LastFM.list, policy=🇺🇸 美国流媒体, tag=LastFM.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Emby/Emby.list, policy=🇺🇸 美国流媒体, tag=Emby.list, enabled=true
+https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/NetflixIP.list, policy=🇺🇸 美国流媒体, tag=NetflixIP.list, enabled=true
+
+# ─── 阶段 14: 香港流媒体 ──────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/myTVSUPER/myTVSUPER.list, policy=🇭🇰 香港流媒体, tag=myTVSUPER.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TVB/TVB.list, policy=🇭🇰 香港流媒体, tag=TVB.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/EncoreTVB/EncoreTVB.list, policy=🇭🇰 香港流媒体, tag=EncoreTVB.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/NowE/NowE.list, policy=🇭🇰 香港流媒体, tag=NowE.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/RTHK/RTHK.list, policy=🇭🇰 香港流媒体, tag=RTHK.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CableTV/CableTV.list, policy=🇭🇰 香港流媒体, tag=CableTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MOOV/MOOV.list, policy=🇭🇰 香港流媒体, tag=MOOV.list, enabled=true
+
+# ─── 阶段 15: 台湾流媒体 ──────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Bahamut/Bahamut.list, policy=🇹🇼 台湾流媒体, tag=Bahamut.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/KKTV/KKTV.list, policy=🇹🇼 台湾流媒体, tag=KKTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LiTV/LiTV.list, policy=🇹🇼 台湾流媒体, tag=LiTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/friDay/friDay.list, policy=🇹🇼 台湾流媒体, tag=friDay.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HamiVideo/HamiVideo.list, policy=🇹🇼 台湾流媒体, tag=HamiVideo.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LineTV/LineTV.list, policy=🇹🇼 台湾流媒体, tag=LineTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/VidolTV/VidolTV.list, policy=🇹🇼 台湾流媒体, tag=VidolTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TaiWanGood/TaiWanGood.list, policy=🇹🇼 台湾流媒体, tag=TaiWanGood.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CHT/CHT.list, policy=🇹🇼 台湾流媒体, tag=CHT.list, enabled=true
+
+# ─── 阶段 16: 日韩流媒体 ──────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Abema/Abema.list, policy=🇯🇵 日韩流媒体, tag=Abema.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DAZN/DAZN.list, policy=🇯🇵 日韩流媒体, tag=DAZN.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DMM/DMM.list, policy=🇯🇵 日韩流媒体, tag=DMM.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TVer/TVer.list, policy=🇯🇵 日韩流媒体, tag=TVer.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Niconico/Niconico.list, policy=🇯🇵 日韩流媒体, tag=Niconico.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Rakuten/Rakuten.list, policy=🇯🇵 日韩流媒体, tag=Rakuten.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Japonx/Japonx.list, policy=🇯🇵 日韩流媒体, tag=Japonx.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Nikkei/Nikkei.list, policy=🇯🇵 日韩流媒体, tag=Nikkei.list, enabled=true
+
+# ─── 阶段 17: 欧洲流媒体 ──────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BBC/BBC.list, policy=🇪🇺 欧洲流媒体, tag=BBC.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ITV/ITV.list, policy=🇪🇺 欧洲流媒体, tag=ITV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/All4/All4.list, policy=🇪🇺 欧洲流媒体, tag=All4.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/My5/My5.list, policy=🇪🇺 欧洲流媒体, tag=My5.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SkyGO/SkyGO.list, policy=🇪🇺 欧洲流媒体, tag=SkyGO.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BritboxUK/BritboxUK.list, policy=🇪🇺 欧洲流媒体, tag=BritboxUK.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LondonReal/LondonReal.list, policy=🇪🇺 欧洲流媒体, tag=LondonReal.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Qobuz/Qobuz.list, policy=🇪🇺 欧洲流媒体, tag=Qobuz.list, enabled=true
+https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/UK.list, policy=🇪🇺 欧洲流媒体, tag=UK.list, enabled=true
+
+# ─── 阶段 18: 国内游戏 ────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SteamCN/SteamCN.list, policy=🕹️ 国内游戏, tag=SteamCN.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/WanMeiShiJie/WanMeiShiJie.list, policy=🕹️ 国内游戏, tag=WanMeiShiJie.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/WanKaHuanJu/WanKaHuanJu.list, policy=🕹️ 国内游戏, tag=WanKaHuanJu.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Majsoul/Majsoul.list, policy=🕹️ 国内游戏, tag=Majsoul.list, enabled=true
+
+# ─── 阶段 19: 国外游戏 ────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Steam/Steam.list, policy=🎮 国外游戏, tag=Steam.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Epic/Epic.list, policy=🎮 国外游戏, tag=Epic.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PlayStation/PlayStation.list, policy=🎮 国外游戏, tag=PlayStation.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Nintendo/Nintendo.list, policy=🎮 国外游戏, tag=Nintendo.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Xbox/Xbox.list, policy=🎮 国外游戏, tag=Xbox.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/EA/EA.list, policy=🎮 国外游戏, tag=EA.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Blizzard/Blizzard.list, policy=🎮 国外游戏, tag=Blizzard.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Game/Game.list, policy=🎮 国外游戏, tag=Game.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Rockstar/Rockstar.list, policy=🎮 国外游戏, tag=Rockstar.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Riot/Riot.list, policy=🎮 国外游戏, tag=Riot.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Gog/Gog.list, policy=🎮 国外游戏, tag=Gog.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Supercell/Supercell.list, policy=🎮 国外游戏, tag=Supercell.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Garena/Garena.list, policy=🎮 国外游戏, tag=Garena.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HoYoverse/HoYoverse.list, policy=🎮 国外游戏, tag=HoYoverse.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/UBI/UBI.list, policy=🎮 国外游戏, tag=UBI.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/WildRift/WildRift.list, policy=🎮 国外游戏, tag=WildRift.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Sony/Sony.list, policy=🎮 国外游戏, tag=Sony.list, enabled=true
+
+# ─── 阶段 20: 搜索引擎 ────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Bing/Bing.list, policy=🔍 搜索引擎, tag=Bing.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Scholar/Scholar.list, policy=🔍 搜索引擎, tag=Scholar.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Yandex/Yandex.list, policy=🔍 搜索引擎, tag=Yandex.list, enabled=true
+
+# ─── 阶段 21: 开发者服务 ──────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GitHub/GitHub.list, policy=📟 开发者服务, tag=GitHub.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Docker/Docker.list, policy=📟 开发者服务, tag=Docker.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GitLab/GitLab.list, policy=📟 开发者服务, tag=GitLab.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Developer/Developer.list, policy=📟 开发者服务, tag=Developer.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Python/Python.list, policy=📟 开发者服务, tag=Python.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GitBook/GitBook.list, policy=📟 开发者服务, tag=GitBook.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Jfrog/Jfrog.list, policy=📟 开发者服务, tag=Jfrog.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SublimeText/SublimeText.list, policy=📟 开发者服务, tag=SublimeText.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Wordpress/Wordpress.list, policy=📟 开发者服务, tag=Wordpress.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/WIX/WIX.list, policy=📟 开发者服务, tag=WIX.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Cisco/Cisco.list, policy=📟 开发者服务, tag=Cisco.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/IBM/IBM.list, policy=📟 开发者服务, tag=IBM.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Oracle/Oracle.list, policy=📟 开发者服务, tag=Oracle.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Unity/Unity.list, policy=📟 开发者服务, tag=Unity.list, enabled=true
+https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Developer.list, policy=📟 开发者服务, tag=Developer.list-2, enabled=true
+
+# ─── 阶段 22: 微软服务 ────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/OneDrive/OneDrive.list, policy=Ⓜ️ 微软服务, tag=OneDrive.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Microsoft/Microsoft.list, policy=Ⓜ️ 微软服务, tag=Microsoft.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MicrosoftEdge/MicrosoftEdge.list, policy=Ⓜ️ 微软服务, tag=MicrosoftEdge.list, enabled=true
+
+# ─── 阶段 23: 苹果服务 ────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleMusic/AppleMusic.list, policy=🍎 苹果服务, tag=AppleMusic.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/iCloud/iCloud.list, policy=🍎 苹果服务, tag=iCloud.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Apple/Apple.list, policy=🍎 苹果服务, tag=Apple.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppStore/AppStore.list, policy=🍎 苹果服务, tag=AppStore.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleTV/AppleTV.list, policy=🍎 苹果服务, tag=AppleTV.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleNews/AppleNews.list, policy=🍎 苹果服务, tag=AppleNews.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleDev/AppleDev.list, policy=🍎 苹果服务, tag=AppleDev.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleProxy/AppleProxy.list, policy=🍎 苹果服务, tag=AppleProxy.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Siri/Siri.list, policy=🍎 苹果服务, tag=Siri.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TestFlight/TestFlight.list, policy=🍎 苹果服务, tag=TestFlight.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleFirmware/AppleFirmware.list, policy=🍎 苹果服务, tag=AppleFirmware.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/FindMy/FindMy.list, policy=🍎 苹果服务, tag=FindMy.list, enabled=true
+
+# ─── 阶段 24: 下载更新 ────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SystemOTA/SystemOTA.list, policy=📥 下载更新, tag=SystemOTA.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Download/Download.list, policy=📥 下载更新, tag=Download.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Ubuntu/Ubuntu.list, policy=📥 下载更新, tag=Ubuntu.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Mozilla/Mozilla.list, policy=📥 下载更新, tag=Mozilla.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Apkpure/Apkpure.list, policy=📥 下载更新, tag=Apkpure.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Android/Android.list, policy=📥 下载更新, tag=Android.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Intel/Intel.list, policy=📥 下载更新, tag=Intel.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Nvidia/Nvidia.list, policy=📥 下载更新, tag=Nvidia.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Dell/Dell.list, policy=📥 下载更新, tag=Dell.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HP/HP.list, policy=📥 下载更新, tag=HP.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Canon/Canon.list, policy=📥 下载更新, tag=Canon.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LG/LG.list, policy=📥 下载更新, tag=LG.list, enabled=true
+
+# ─── 阶段 25: 云与 CDN ────────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Cloudflare/Cloudflare.list, policy=☁️ 云与CDN, tag=Cloudflare.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Akamai/Akamai.list, policy=☁️ 云与CDN, tag=Akamai.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DigiCert/DigiCert.list, policy=☁️ 云与CDN, tag=DigiCert.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GlobalSign/GlobalSign.list, policy=☁️ 云与CDN, tag=GlobalSign.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Sectigo/Sectigo.list, policy=☁️ 云与CDN, tag=Sectigo.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BrightCove/BrightCove.list, policy=☁️ 云与CDN, tag=BrightCove.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Jwplayer/Jwplayer.list, policy=☁️ 云与CDN, tag=Jwplayer.list, enabled=true
+
+# ─── 阶段 26: BT/PT Tracker ───────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PrivateTracker/PrivateTracker.list, policy=🛰️ BT/PT Tracker, tag=PrivateTracker.list, enabled=true
+
+# ─── 阶段 28: 国内网站兜底 ────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ChinaMax/ChinaMax.list, policy=🏠 国内网站, tag=ChinaMax.list, enabled=true
+
+# ─── 阶段 29: 🚫 受限网站（GFW 封锁域名兜底，置于 INTL_SITE 之前） ────────────
+https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/ProxyGFWlist.list, policy=🚫 受限网站, tag=ProxyGFWlist.list, enabled=true
+
+# ─── 阶段 30: 国外网站兜底 ────────────────────────────────────────────────────
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CNN/CNN.list, policy=🌐 国外网站, tag=CNN.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/NYTimes/NYTimes.list, policy=🌐 国外网站, tag=NYTimes.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Bloomberg/Bloomberg.list, policy=🌐 国外网站, tag=Bloomberg.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/eBay/eBay.list, policy=🌐 国外网站, tag=eBay.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Nike/Nike.list, policy=🌐 国外网站, tag=Nike.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Adobe/Adobe.list, policy=🌐 国外网站, tag=Adobe.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Samsung/Samsung.list, policy=🌐 国外网站, tag=Samsung.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Tesla/Tesla.list, policy=🌐 国外网站, tag=Tesla.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Dropbox/Dropbox.list, policy=🌐 国外网站, tag=Dropbox.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MEGA/MEGA.list, policy=🌐 国外网站, tag=MEGA.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Wikipedia/Wikipedia.list, policy=🌐 国外网站, tag=Wikipedia.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Duolingo/Duolingo.list, policy=🌐 国外网站, tag=Duolingo.list, enabled=true
+https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Khan.list, policy=🌐 国外网站, tag=Khan.list, enabled=true
+https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Edutools.list, policy=🌐 国外网站, tag=Edutools.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Naver/Naver.list, policy=🌐 国外网站, tag=Naver.list, enabled=true
+https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/EHGallery/EHGallery.list, policy=🌐 国外网站, tag=EHGallery.list, enabled=true
+
 [Rule]
 # ─── 阶段 1: 广告拦截与威胁情报 ───────────────────────────────────────────────
 # anti-AD（privacy-protection-tools/anti-AD 官方源；anti-ad.net 无 CDN 且部分 ISP 会劫持返回 HTML，Loon 会当规则解析报语法错）
-RULE-SET,https://fastly.jsdelivr.net/gh/privacy-protection-tools/anti-AD@master/anti-ad-surge.txt,🛑 广告拦截
 # SukkaW 钓鱼域名拦截（13 万条；Loon 用 non_ip .conf，domainset 是 Surge 专属二级格式）
-RULE-SET,https://ruleset.skk.moe/List/non_ip/reject_phishing.conf,🛑 广告拦截
 # Hagezi TIF（威胁情报：malware/cryptojacking/C2/scam/spam）
-RULE-SET,https://fastly.jsdelivr.net/gh/hagezi/dns-blocklists@main/share/surge-tif-medium.txt,🛑 广告拦截
 # blackmatrix7 广告/隐私/营销追踪规则集（SR 原生）
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Advertising/Advertising.list,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AdvertisingMiTV/AdvertisingMiTV.list,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AdobeActivation/AdobeActivation.list,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BlockHttpDNS/BlockHttpDNS.list,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Domob/Domob.list,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Hijacking/Hijacking.list,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/JiGuangTuiSong/JiGuangTuiSong.list,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Marketing/Marketing.list,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MIUIPrivacy/MIUIPrivacy.list,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Privacy/Privacy.list,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/YouMengChuangXiang/YouMengChuangXiang.list,🛑 广告拦截
 
 # ─── 阶段 2: 私有网段与本地服务 ───────────────────────────────────────────────
 # 私有 IP（Surge 格式，SR 兼容）
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Lan/Lan.list,DIRECT
 # 常用 LAN 段兜底
 IP-CIDR,10.0.0.0/8,DIRECT,no-resolve
 IP-CIDR,172.16.0.0/12,DIRECT,no-resolve
@@ -286,7 +630,6 @@ DOMAIN-SUFFIX,googlemail.com,📧 邮件服务
 DOMAIN,mail.google.com,📧 邮件服务
 DOMAIN,inbox.google.com,📧 邮件服务
 # Google Voice
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GoogleVoice/GoogleVoice.list,💬 即时通讯
 # Google Meet
 DOMAIN-SUFFIX,meet.google.com,🧑‍💼 会议协作
 DOMAIN,meet.googleapis.com,🧑‍💼 会议协作
@@ -294,21 +637,10 @@ DOMAIN,meet.googleapis.com,🧑‍💼 会议协作
 DOMAIN-SUFFIX,dl.google.com,📥 下载更新
 DOMAIN-SUFFIX,play.googleapis.com,📥 下载更新
 DOMAIN-SUFFIX,android.clients.google.com,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GoogleFCM/GoogleFCM.list,📥 下载更新
 # Google 搜索（总兜底放在具体规则后）
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GoogleSearch/GoogleSearch.list,🔍 搜索引擎
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GoogleDrive/GoogleDrive.list,🔍 搜索引擎
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GoogleEarth/GoogleEarth.list,🔍 搜索引擎
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Google/Google.list,🔍 搜索引擎
 
 # ─── 阶段 4: AI 服务（Crypto 核心业务依赖，优先级高） ───────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/OpenAI/OpenAI.list,🤖 AI 服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Claude/Claude.list,🤖 AI 服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Gemini/Gemini.list,🤖 AI 服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Copilot/Copilot.list,🤖 AI 服务
 # szkane AI 综合（OpenAI/Claude/Grok/Perplexity/Gemini 合并）
-RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/AiDomain.list,🤖 AI 服务
-RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/CiciAi.list,🤖 AI 服务
 # 原版 FIX#13-P2: 微软 Delivery Optimization 遥测非 AI，前置拦截
 DOMAIN-SUFFIX,do.dsp.mp.microsoft.com,📥 下载更新
 # 常用 AI 域名兜底
@@ -346,7 +678,6 @@ DOMAIN-SUFFIX,deepseek.com,🏠 国内网站
 DOMAIN-SUFFIX,inflection.ai,🚫 受限网站
 DOMAIN-SUFFIX,pi.ai,🚫 受限网站
 # Civitai AI 模型社区
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Civitai/Civitai.list,🤖 AI 服务
 
 # ─── 阶段 5: 加密货币与量化交易 ───────────────────────────────────────────────
 # Binance
@@ -357,7 +688,6 @@ DOMAIN-SUFFIX,binance.cloud,💰 加密货币
 DOMAIN-SUFFIX,binance.me,💰 加密货币
 DOMAIN-SUFFIX,binance.org,💰 加密货币
 DOMAIN-SUFFIX,binancefuture.com,💰 加密货币
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Binance/Binance.list,💰 加密货币
 # TradingView / Coinglass / Hyperliquid
 DOMAIN-SUFFIX,tradingview.com,💰 加密货币
 DOMAIN-SUFFIX,tvcdn.com,💰 加密货币
@@ -367,13 +697,10 @@ DOMAIN-SUFFIX,hyperliquid-testnet.xyz,💰 加密货币
 DOMAIN-SUFFIX,eth.limo,💰 加密货币
 DOMAIN-SUFFIX,glitternode.ru,💰 加密货币
 # bm7 Cryptocurrency
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Cryptocurrency/Cryptocurrency.list,💰 加密货币
 # szkane Web3（DeFi/NFT/区块链 RPC）★量化交易核心
-RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Web3.list,💰 加密货币
 
 # ─── 阶段 6: 金融支付 ─────────────────────────────────────────────────────────
 # PayPal
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PayPal/PayPal.list,🏦 金融支付
 # Stripe
 DOMAIN-SUFFIX,stripe.com,🏦 金融支付
 DOMAIN-SUFFIX,stripe.network,🏦 金融支付
@@ -419,9 +746,6 @@ DOMAIN-SUFFIX,banksinarmas.com,🏦 金融支付
 DOMAIN-SUFFIX,idx.co.id,🏦 金融支付
 DOMAIN-SUFFIX,ksei.co.id,🏦 金融支付
 # bm7 支付规则集
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Stripe/Stripe.list,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/VISA/VISA.list,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TigerFintech/TigerFintech.list,🏦 金融支付
 # 虚拟金融（替代已移除的 Accademia VirtualFinance YAML）
 DOMAIN-SUFFIX,monzo.com,🏦 金融支付
 DOMAIN-SUFFIX,n26.com,🏦 金融支付
@@ -485,10 +809,6 @@ DOMAIN,mail.me.com,📧 邮件服务
 DOMAIN-SUFFIX,fastmail.com,📧 邮件服务
 DOMAIN-SUFFIX,fastmail.fm,📧 邮件服务
 # bm7 邮件规则集
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Mail/Mail.list,📧 邮件服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Mailru/Mailru.list,📧 邮件服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Protonmail/Protonmail.list,📧 邮件服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Spark/Spark.list,📧 邮件服务
 # 国内邮箱直连
 DOMAIN-SUFFIX,mail.qq.com,DIRECT
 DOMAIN-SUFFIX,mail.163.com,DIRECT
@@ -497,11 +817,6 @@ DOMAIN-SUFFIX,mail.sina.com.cn,DIRECT
 DOMAIN-SUFFIX,mail.aliyun.com,DIRECT
 
 # ─── 阶段 8: 即时通讯 ─────────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Telegram/Telegram.list,💬 即时通讯
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Discord/Discord.list,💬 即时通讯
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Whatsapp/Whatsapp.list,💬 即时通讯
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Line/Line.list,💬 即时通讯
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/KakaoTalk/KakaoTalk.list,💬 即时通讯
 # Skype / Signal / Viber / Element 等
 DOMAIN-SUFFIX,skype.com,💬 即时通讯
 DOMAIN-SUFFIX,skypeecs.net,💬 即时通讯
@@ -520,24 +835,11 @@ DOMAIN-SUFFIX,zalopay.vn,💬 即时通讯
 DOMAIN-SUFFIX,wire.com,💬 即时通讯
 DOMAIN-SUFFIX,threema.ch,💬 即时通讯
 # bm7 Telegram 区域 IP 段
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TelegramNL/TelegramNL.list,💬 即时通讯
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TelegramSG/TelegramSG.list,💬 即时通讯
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TelegramUS/TelegramUS.list,💬 即时通讯
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Zalo/Zalo.list,💬 即时通讯
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/iTalkBB/iTalkBB.list,💬 即时通讯
 DOMAIN-SUFFIX,icq.com,💬 即时通讯
 
 # ─── 阶段 9: 社交媒体 ─────────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Twitter/Twitter.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TikTok/TikTok.list,📱 社交媒体
 # lemon8 也是字节海外社交，跟 TikTok 同组
 DOMAIN-SUFFIX,lemon8-app.com,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Reddit/Reddit.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Facebook/Facebook.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Instagram/Instagram.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Snap/Snap.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Pinterest/Pinterest.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LinkedIn/LinkedIn.list,📱 社交媒体
 # 新兴社交平台
 DOMAIN-SUFFIX,mastodon.social,📱 社交媒体
 DOMAIN-SUFFIX,joinmastodon.org,📱 社交媒体
@@ -550,20 +852,8 @@ DOMAIN-SUFFIX,medium.com,📱 社交媒体
 DOMAIN-SUFFIX,flickr.com,📱 社交媒体
 DOMAIN-SUFFIX,clubhouse.com,📱 社交媒体
 # bm7 补充
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Tumblr/Tumblr.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Clubhouse/Clubhouse.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ClubhouseIP/ClubhouseIP.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Pixiv/Pixiv.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TruthSocial/TruthSocial.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/VK/VK.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Blued/Blued.list,🏠 国内网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Disqus/Disqus.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Imgur/Imgur.list,📱 社交媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Pixnet/Pixnet.list,📱 社交媒体
 
 # ─── 阶段 10: 会议协作 ────────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Slack/Slack.list,🧑‍💼 会议协作
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Teams/Teams.list,🧑‍💼 会议协作
 # Zoom（替代已移除的 ACL4SSR Zoom.yaml）
 DOMAIN-SUFFIX,zoom.us,🧑‍💼 会议协作
 DOMAIN-SUFFIX,zoom.com,🧑‍💼 会议协作
@@ -602,14 +892,6 @@ DOMAIN-SUFFIX,gotomeeting.com,🧑‍💼 会议协作
 DOMAIN-SUFFIX,logmein.com,🧑‍💼 会议协作
 DOMAIN-SUFFIX,goto.com,🧑‍💼 会议协作
 # bm7 会议协作规则集
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Atlassian/Atlassian.list,🧑‍💼 会议协作
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Notion/Notion.list,🧑‍💼 会议协作
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TeamViewer/TeamViewer.list,🧑‍💼 会议协作
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Zoho/Zoho.list,🧑‍💼 会议协作
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Salesforce/Salesforce.list,🧑‍💼 会议协作
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Zendesk/Zendesk.list,🧑‍💼 会议协作
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Intercom/Intercom.list,🧑‍💼 会议协作
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/RemoteDesktop/RemoteDesktop.list,🧑‍💼 会议协作
 # 国内协作工具直连
 DOMAIN-SUFFIX,feishu.cn,DIRECT
 DOMAIN-SUFFIX,dingtalk.com,DIRECT
@@ -618,7 +900,6 @@ DOMAIN-SUFFIX,welink.huaweicloud.com,DIRECT
 
 # ─── 阶段 11: 国内流媒体 ──────────────────────────────────────────────────────
 # 哔哩哔哩
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BiliBili/BiliBili.list,📺 国内流媒体
 # 爱奇艺
 DOMAIN-SUFFIX,iqiyi.com,📺 国内流媒体
 DOMAIN-SUFFIX,iqiyipic.com,📺 国内流媒体
@@ -660,53 +941,9 @@ DOMAIN-SUFFIX,weibo.com,📺 国内流媒体
 DOMAIN-SUFFIX,weibo.cn,📺 国内流媒体
 DOMAIN-SUFFIX,sinaimg.cn,📺 国内流媒体
 # bm7 国内流媒体规则集（大规模集合）
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/iQIYI/iQIYI.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Youku/Youku.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TencentVideo/TencentVideo.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DouYin/DouYin.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ByteDance/ByteDance.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/KuaiShou/KuaiShou.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Weibo/Weibo.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/XiaoHongShu/XiaoHongShu.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/NetEaseMusic/NetEaseMusic.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/KugouKuwo/KugouKuwo.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Sohu/Sohu.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AcFun/AcFun.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Douyu/Douyu.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HuYa/HuYa.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Himalaya/Himalaya.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CCTV/CCTV.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HunanTV/HunanTV.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PPTV/PPTV.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Funshion/Funshion.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LeTV/LeTV.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TaiheMusic/TaiheMusic.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/KuKeMusic/KuKeMusic.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HibyMusic/HibyMusic.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MiWu/MiWu.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Migu/Migu.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/IPTVMainland/IPTVMainland.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/IPTVOther/IPTVOther.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CIBN/CIBN.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BesTV/BesTV.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HuaShuTV/HuaShuTV.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SMG/SMG.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HWTV/HWTV.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/NivodTV/NivodTV.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Olevod/Olevod.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DanDanZan/DanDanZan.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Dandanplay/Dandanplay.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TianTianKanKan/TianTianKanKan.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/YiZhiBo/YiZhiBo.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Ku6/Ku6.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/56/56.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CETV/CETV.list,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/YYeTs/YYeTs.list,📺 国内流媒体
 # 港澳台 B 站需要港区代理解锁
-RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/BilibiliHMT.list,🇭🇰 香港流媒体
 
 # ─── 阶段 12: 东南亚流媒体 ────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ViuTV/ViuTV.list,📺 东南亚流媒体
 DOMAIN-SUFFIX,wetv.vip,📺 东南亚流媒体
 DOMAIN-SUFFIX,wetvinfo.com,📺 东南亚流媒体
 DOMAIN-SUFFIX,iq.com,📺 东南亚流媒体
@@ -719,7 +956,6 @@ DOMAIN-SUFFIX,genflix.co.id,📺 东南亚流媒体
 DOMAIN-SUFFIX,goplay.co.id,📺 东南亚流媒体
 DOMAIN-SUFFIX,maxstream.tv,📺 东南亚流媒体
 # B 站国际版
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BiliIntl/BiliIntl.list,📺 东南亚流媒体
 # 东南亚其它流媒体
 DOMAIN-SUFFIX,viki.com,📺 东南亚流媒体
 DOMAIN-SUFFIX,viki.io,📺 东南亚流媒体
@@ -729,32 +965,14 @@ DOMAIN-SUFFIX,mewatch.sg,📺 东南亚流媒体
 DOMAIN-SUFFIX,trueid.net,📺 东南亚流媒体
 DOMAIN-SUFFIX,dimsum.my,📺 东南亚流媒体
 # bm7 亚洲流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AsianMedia/AsianMedia.list,📺 东南亚流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/iQIYIIntl/iQIYIIntl.list,📺 东南亚流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/JOOX/JOOX.list,📺 东南亚流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MeWatch/MeWatch.list,📺 东南亚流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Viki/Viki.list,📺 东南亚流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/WeTV/WeTV.list,📺 东南亚流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Zee/Zee.list,📺 东南亚流媒体
 # Kwai 国际版（巴西/印尼主战场）
 
 # ─── 阶段 13: 美国流媒体 ──────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/YouTube/YouTube.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Netflix/Netflix.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Spotify/Spotify.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Disney/Disney.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HBO/HBO.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PrimeVideo/PrimeVideo.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Hulu/Hulu.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ParamountPlus/ParamountPlus.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Peacock/Peacock.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Twitch/Twitch.list,🇺🇸 美国流媒体
 # AWS 用户前端先归 Dev/CDN（v5.1.8 防吞）
 DOMAIN-SUFFIX,amazonaws.com,☁️ 云与CDN
 DOMAIN-SUFFIX,awsstatic.com,☁️ 云与CDN
 DOMAIN-SUFFIX,aws.amazon.com,📟 开发者服务
 DOMAIN-SUFFIX,elasticbeanstalk.com,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Amazon/Amazon.list,🇺🇸 美国流媒体
 # 其它美国流媒体
 DOMAIN-SUFFIX,crunchyroll.com,🇺🇸 美国流媒体
 DOMAIN-SUFFIX,vrv.co,🇺🇸 美国流媒体
@@ -772,29 +990,7 @@ DOMAIN-SUFFIX,tidal.com,🇺🇸 美国流媒体
 DOMAIN-SUFFIX,vimeo.com,🇺🇸 美国流媒体
 DOMAIN-SUFFIX,dailymotion.com,🇺🇸 美国流媒体
 # bm7 美国流媒体补充
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CBS/CBS.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/NBC/NBC.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PBS/PBS.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ATTWatchTV/ATTWatchTV.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Fox/Fox.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/FuboTV/FuboTV.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Sling/Sling.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SoundCloud/SoundCloud.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Pandora/Pandora.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PandoraTV/PandoraTV.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TIDAL/TIDAL.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Vimeo/Vimeo.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Dailymotion/Dailymotion.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Deezer/Deezer.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DiscoveryPlus/DiscoveryPlus.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Overcast/Overcast.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Americasvoice/Americasvoice.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Cake/Cake.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Dood/Dood.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LastFM/LastFM.list,🇺🇸 美国流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Emby/Emby.list,🇺🇸 美国流媒体
 # szkane Netflix IP 段补充
-RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/NetflixIP.list,🇺🇸 美国流媒体
 
 # ─── 阶段 14: 香港流媒体 ──────────────────────────────────────────────────────
 DOMAIN-SUFFIX,mytvsuper.com,🇭🇰 香港流媒体
@@ -809,17 +1005,8 @@ DOMAIN-SUFFIX,rthk.hk,🇭🇰 香港流媒体
 DOMAIN-SUFFIX,icable.com,🇭🇰 香港流媒体
 DOMAIN-SUFFIX,cabletv.com.hk,🇭🇰 香港流媒体
 DOMAIN-SUFFIX,hmvod.com.hk,🇭🇰 香港流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/myTVSUPER/myTVSUPER.list,🇭🇰 香港流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TVB/TVB.list,🇭🇰 香港流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/EncoreTVB/EncoreTVB.list,🇭🇰 香港流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/NowE/NowE.list,🇭🇰 香港流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/RTHK/RTHK.list,🇭🇰 香港流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CableTV/CableTV.list,🇭🇰 香港流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MOOV/MOOV.list,🇭🇰 香港流媒体
 
 # ─── 阶段 15: 台湾流媒体 ──────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Bahamut/Bahamut.list,🇹🇼 台湾流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/KKTV/KKTV.list,🇹🇼 台湾流媒体
 DOMAIN-SUFFIX,litv.tv,🇹🇼 台湾流媒体
 DOMAIN-SUFFIX,video.friday.tw,🇹🇼 台湾流媒体
 DOMAIN-SUFFIX,friday.tw,🇹🇼 台湾流媒体
@@ -830,17 +1017,8 @@ DOMAIN-SUFFIX,hamivideo.hinet.net,🇹🇼 台湾流媒体
 DOMAIN-SUFFIX,ofiii.com,🇹🇼 台湾流媒体
 DOMAIN-SUFFIX,pts.org.tw,🇹🇼 台湾流媒体
 DOMAIN-SUFFIX,4gtv.tv,🇹🇼 台湾流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LiTV/LiTV.list,🇹🇼 台湾流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/friDay/friDay.list,🇹🇼 台湾流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HamiVideo/HamiVideo.list,🇹🇼 台湾流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LineTV/LineTV.list,🇹🇼 台湾流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/VidolTV/VidolTV.list,🇹🇼 台湾流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TaiWanGood/TaiWanGood.list,🇹🇼 台湾流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CHT/CHT.list,🇹🇼 台湾流媒体
 
 # ─── 阶段 16: 日韩流媒体 ──────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Abema/Abema.list,🇯🇵 日韩流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DAZN/DAZN.list,🇯🇵 日韩流媒体
 DOMAIN-SUFFIX,tver.jp,🇯🇵 日韩流媒体
 DOMAIN-SUFFIX,unext.jp,🇯🇵 日韩流媒体
 DOMAIN-SUFFIX,video.unext.jp,🇯🇵 日韩流媒体
@@ -880,15 +1058,8 @@ DOMAIN-SUFFIX,navertv.naver.com,🇯🇵 日韩流媒体
 DOMAIN-SUFFIX,kakaotv.daum.net,🇯🇵 日韩流媒体
 DOMAIN-SUFFIX,navercorp.com,🇯🇵 日韩流媒体
 # bm7 补充
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DMM/DMM.list,🇯🇵 日韩流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TVer/TVer.list,🇯🇵 日韩流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Niconico/Niconico.list,🇯🇵 日韩流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Rakuten/Rakuten.list,🇯🇵 日韩流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Japonx/Japonx.list,🇯🇵 日韩流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Nikkei/Nikkei.list,🇯🇵 日韩流媒体
 
 # ─── 阶段 17: 欧洲流媒体 ──────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BBC/BBC.list,🇪🇺 欧洲流媒体
 # 英国
 DOMAIN-SUFFIX,itv.com,🇪🇺 欧洲流媒体
 DOMAIN-SUFFIX,itvstatic.com,🇪🇺 欧洲流媒体
@@ -923,14 +1094,6 @@ DOMAIN-SUFFIX,kinopoisk.ru,🇪🇺 欧洲流媒体
 DOMAIN-SUFFIX,okko.tv,🇪🇺 欧洲流媒体
 DOMAIN-SUFFIX,more.tv,🇪🇺 欧洲流媒体
 # bm7 欧洲流媒体补充
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ITV/ITV.list,🇪🇺 欧洲流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/All4/All4.list,🇪🇺 欧洲流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/My5/My5.list,🇪🇺 欧洲流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SkyGO/SkyGO.list,🇪🇺 欧洲流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BritboxUK/BritboxUK.list,🇪🇺 欧洲流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LondonReal/LondonReal.list,🇪🇺 欧洲流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Qobuz/Qobuz.list,🇪🇺 欧洲流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/UK.list,🇪🇺 欧洲流媒体
 
 
 # ─── 阶段 18: 国内游戏 ────────────────────────────────────────────────────────
@@ -962,20 +1125,8 @@ DOMAIN-SUFFIX,hypergryph.com,🕹️ 国内游戏
 DOMAIN-SUFFIX,gryphline.com,🕹️ 国内游戏
 DOMAIN-SUFFIX,lilith.com,🕹️ 国内游戏
 # bm7 国内游戏规则集
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SteamCN/SteamCN.list,🕹️ 国内游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/WanMeiShiJie/WanMeiShiJie.list,🕹️ 国内游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/WanKaHuanJu/WanKaHuanJu.list,🕹️ 国内游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Majsoul/Majsoul.list,🕹️ 国内游戏
 
 # ─── 阶段 19: 国外游戏 ────────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Steam/Steam.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Epic/Epic.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PlayStation/PlayStation.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Nintendo/Nintendo.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Xbox/Xbox.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/EA/EA.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Blizzard/Blizzard.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Game/Game.list,🎮 国外游戏
 DOMAIN-SUFFIX,ubisoft.com,🎮 国外游戏
 DOMAIN-SUFFIX,ubi.com,🎮 国外游戏
 DOMAIN-SUFFIX,riotgames.com,🎮 国外游戏
@@ -989,18 +1140,8 @@ DOMAIN-SUFFIX,supercell.com,🎮 国外游戏
 DOMAIN-SUFFIX,garena.com,🎮 国外游戏
 DOMAIN-SUFFIX,hoyoverse.com,🎮 国外游戏
 DOMAIN-SUFFIX,hoyolab.com,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Rockstar/Rockstar.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Riot/Riot.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Gog/Gog.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Supercell/Supercell.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Garena/Garena.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HoYoverse/HoYoverse.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/UBI/UBI.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/WildRift/WildRift.list,🎮 国外游戏
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Sony/Sony.list,🎮 国外游戏
 
 # ─── 阶段 20: 搜索引擎 ────────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Bing/Bing.list,🔍 搜索引擎
 DOMAIN-SUFFIX,yahoo.com,🔍 搜索引擎
 DOMAIN-SUFFIX,yahoo.co.jp,🔍 搜索引擎
 DOMAIN-SUFFIX,duckduckgo.com,🔍 搜索引擎
@@ -1012,13 +1153,8 @@ DOMAIN-SUFFIX,ecosia.org,🔍 搜索引擎
 DOMAIN-SUFFIX,startpage.com,🔍 搜索引擎
 DOMAIN-SUFFIX,you.com,🔍 搜索引擎
 DOMAIN-SUFFIX,search.naver.com,🔍 搜索引擎
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Scholar/Scholar.list,🔍 搜索引擎
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Yandex/Yandex.list,🔍 搜索引擎
 
 # ─── 阶段 21: 开发者服务 ──────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GitHub/GitHub.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Docker/Docker.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GitLab/GitLab.list,📟 开发者服务
 # 包管理器
 DOMAIN-SUFFIX,npmjs.com,📟 开发者服务
 DOMAIN-SUFFIX,npmjs.org,📟 开发者服务
@@ -1068,41 +1204,13 @@ DOMAIN-SUFFIX,hashicorp.com,📟 开发者服务
 DOMAIN-SUFFIX,terraform.io,📟 开发者服务
 DOMAIN-SUFFIX,vagrantup.com,📟 开发者服务
 # bm7 开发者规则集
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Developer/Developer.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Python/Python.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GitBook/GitBook.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Jfrog/Jfrog.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SublimeText/SublimeText.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Wordpress/Wordpress.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/WIX/WIX.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Cisco/Cisco.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/IBM/IBM.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Oracle/Oracle.list,📟 开发者服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Unity/Unity.list,📟 开发者服务
 # szkane Developer（Docker 镜像/HuggingFace 模型下载）
-RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Developer.list,📟 开发者服务
 
 # ─── 阶段 22: 微软服务 ────────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/OneDrive/OneDrive.list,Ⓜ️ 微软服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Microsoft/Microsoft.list,Ⓜ️ 微软服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MicrosoftEdge/MicrosoftEdge.list,Ⓜ️ 微软服务
 
 # ─── 阶段 23: 苹果服务 ────────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleMusic/AppleMusic.list,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/iCloud/iCloud.list,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Apple/Apple.list,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppStore/AppStore.list,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleTV/AppleTV.list,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleNews/AppleNews.list,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleDev/AppleDev.list,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleProxy/AppleProxy.list,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Siri/Siri.list,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/TestFlight/TestFlight.list,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/AppleFirmware/AppleFirmware.list,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/FindMy/FindMy.list,🍎 苹果服务
 
 # ─── 阶段 24: 下载更新 ────────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/SystemOTA/SystemOTA.list,📥 下载更新
 # Windows / Office 更新
 DOMAIN-SUFFIX,windowsupdate.com,📥 下载更新
 DOMAIN-SUFFIX,update.microsoft.com,📥 下载更新
@@ -1134,22 +1242,9 @@ DOMAIN-SUFFIX,ghcr.io,📥 下载更新
 DOMAIN-SUFFIX,quay.io,📥 下载更新
 DOMAIN-SUFFIX,registry.k8s.io,📥 下载更新
 # bm7 下载规则集
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Download/Download.list,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Ubuntu/Ubuntu.list,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Mozilla/Mozilla.list,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Apkpure/Apkpure.list,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Android/Android.list,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Intel/Intel.list,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Nvidia/Nvidia.list,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Dell/Dell.list,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/HP/HP.list,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Canon/Canon.list,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/LG/LG.list,📥 下载更新
 
 # ─── 阶段 25: 云与 CDN ────────────────────────────────────────────────────────
 # bm7 Cloudflare / Fastly / CloudFront IP 段（需要 no-resolve 避免解析消耗）
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Cloudflare/Cloudflare.list,☁️ 云与CDN
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Akamai/Akamai.list,☁️ 云与CDN
 # Akamai / EdgeKey
 DOMAIN-SUFFIX,akamai.net,☁️ 云与CDN
 DOMAIN-SUFFIX,akamaized.net,☁️ 云与CDN
@@ -1184,12 +1279,7 @@ DOMAIN-SUFFIX,ziffstatic.com,☁️ 云与CDN
 DOMAIN-SUFFIX,ucoz.ru,☁️ 云与CDN
 DOMAIN-SUFFIX,ucoz.net,☁️ 云与CDN
 # 证书服务 CA
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/DigiCert/DigiCert.list,☁️ 云与CDN
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/GlobalSign/GlobalSign.list,☁️ 云与CDN
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Sectigo/Sectigo.list,☁️ 云与CDN
 # 视频 CDN
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/BrightCove/BrightCove.list,☁️ 云与CDN
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Jwplayer/Jwplayer.list,☁️ 云与CDN
 # Let's Encrypt
 DOMAIN-SUFFIX,letsencrypt.org,☁️ 云与CDN
 DOMAIN-SUFFIX,lencr.org,☁️ 云与CDN
@@ -1202,7 +1292,6 @@ DOMAIN-SUFFIX,exodus.desync.com,🛰️ BT/PT Tracker
 DOMAIN-SUFFIX,tracker.openbittorrent.com,🛰️ BT/PT Tracker
 DOMAIN-SUFFIX,tracker.publicbt.com,🛰️ BT/PT Tracker
 DOMAIN-SUFFIX,tracker.dler.org,🛰️ BT/PT Tracker
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/PrivateTracker/PrivateTracker.list,🛰️ BT/PT Tracker
 
 # ─── 阶段 27: 印尼本地服务（电商/出行/外卖/电信/政府/新闻 → 国外网站） ────────
 DOMAIN-SUFFIX,tokopedia.com,🌐 国外网站
@@ -1257,34 +1346,16 @@ DOMAIN-SUFFIX,iwipwedabay.com,DIRECT
 # Aqara 国内 / 国际
 # HomeIP × 2 国（美/日）→ 国外网站
 # bm7 国内综合（ChinaMax / cn 等）
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/ChinaMax/ChinaMax.list,🏠 国内网站
 
 # ─── 阶段 29: 🚫 受限网站（GFW 封锁域名兜底，置于 INTL_SITE 之前） ────────────
 # 语义：GFW = 确认被中国封锁 / INTL_SITE = 普通国外域名
 # 中国：GFW 组选代理；INTL_SITE 保持默认可探测直连
 # 印尼：GFW 组选 DIRECT，INTL_SITE 也选 DIRECT
-RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/ProxyGFWlist.list,🚫 受限网站
 
 # ─── 阶段 30: 国外网站兜底 ────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/CNN/CNN.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/NYTimes/NYTimes.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Bloomberg/Bloomberg.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/eBay/eBay.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Nike/Nike.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Adobe/Adobe.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Samsung/Samsung.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Tesla/Tesla.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Dropbox/Dropbox.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/MEGA/MEGA.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Wikipedia/Wikipedia.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Duolingo/Duolingo.list,🌐 国外网站
 # szkane Education
-RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Khan.list,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Edutools.list,🌐 国外网站
 # Naver 宽域名兜底
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/Naver/Naver.list,🌐 国外网站
 # EHGallery（非流媒体服务）
-RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Loon/EHGallery/EHGallery.list,🌐 国外网站
 # 其它国外网站兜底
 DOMAIN-SUFFIX,archive.org,🌐 国外网站
 DOMAIN-SUFFIX,udemy.com,🌐 国外网站


### PR DESCRIPTION
## 根因（用户朋友捅破的关键）

v5.2.4-Loon.3 仍然弹"第 229 行语法错误"。用户朋友给出 Loon 正确写法：

```
https://.../Duckduckgo.list, policy=美国节点-兔子, tag=Duckduckgo.list, enabled=true
```

—— **这属于 `[Remote Rule]` 段**，而不是我们之前一直用的 `[Rule]` 段里的 Surge 风格 `RULE-SET,URL,policy`。

**Loon 的 `[Rule]` 段只接受内联规则**（DOMAIN / IP-CIDR / GEOIP / FINAL），远程订阅 RULE-SET 塞进 `[Rule]` Loon 会**逐行报语法错**，这就是 v5.2.3-Loon.1 以来所有错误弹窗的真正根因。

交叉核对 [fmz200/wool_scripts Loon.conf](https://raw.githubusercontent.com/fmz200/wool_scripts/main/Loon/config/Loon.conf)：它的 `[Rule]` 段干净只剩内联规则，所有订阅规则集都在 `[Remote Rule]`。

## 一次性修复

- **新增 `[Remote Rule]` 段**，位置 `[Proxy Group]` 与 `[Rule]` 之间
- **288 条 RULE-SET 全量迁移**，由 `tmp/migrate_loon.py` 脚本自动处理：
  - `RULE-SET,<URL>,<policy>` → `<URL>, policy=<policy>, tag=<file_basename>, enabled=true`
  - tag 自动从 URL 末段派生（如 `Advertising.list` / `anti-ad-surge.txt`）
  - 288 条 tag 全部唯一（`uniq -c` 验证）
- **`[Rule]` 段精简**到只剩 614 行内联规则（IP-CIDR / DST-PORT / DOMAIN / DOMAIN-SUFFIX / HOST / GEOIP / FINAL）
- **合并"规则引擎"头部注释**：新头部同时介绍 `[Remote Rule]` + `[Rule]` 两段职责 + 规则源清单 + 优先级原则
- 头部架构一句话：`... + 250+ RULE-SET` → `... + 288 [Remote Rule] 订阅规则集`

## 版本 + 文档

- `v5.2.4-Loon.3` → **`v5.2.4-Loon.4`**（Build 2026-04-22）
- `Loon/CHANGELOG.md`：新增 FIX#Loon-15-P0 + FIX#Loon-16-P0
- `Loon/README.md` §七：重写说明为什么不能用 `[Rule] RULE-SET,URL,policy`，以及 Loon 原生面板的好处（288 条订阅可以逐条查看命中数 / 启用禁用）

## 自检

```
[Remote Rule] entries:               288 (unique tags)
[Remote Filter] NameRegex filters:   9 (match 9 url-test groups 1:1)
Proxy groups (select + url-test):    37 (9 + 28)
RULE-SET in [Rule]:                  0
bypass-system / tun-excluded-routes /
ipv6-enabled / hijack-dns /
udp-policy-not-supported /
IP-CIDR6 / FINAL,...,dns-failed:     全部 0
段落顺序:                            [General] → [Proxy] → [Remote Filter]
                                     → [Proxy Group] → [Remote Rule] → [Rule]
                                     → [Host] → [URL Rewrite] → [MITM]
```

## Test plan

- [ ] 用户手机上重新订阅，Loon 启用**无**"第 229 行语法错误"弹窗
- [ ] 「规则」面板出现 288 条独立订阅规则集（每条可逐一启用/禁用/查看命中数）
- [ ] 首页版本号 `Loon Smart v5.2.4-Loon.4`

## 同步工作说明

本次同时对仓库其他 4 份独立产物做了深度审查（Surge / Shadowrocket / Quantumult X / SingBox / v2rayN），发现同类遗毒（72 条 Clash classical YAML RULE-SET、anti-ad.net 裸域名、Sukka `domainset` 路径）及 SingBox-full 的 sing-box 1.13 废弃 outbound。后续 PR 逐个修复：

| 产物 | 计划 |
|---|---|
| SingBox-full | `type:"block"` → `action:"reject"` + DNS schema 1.12+ 迁移 |
| Shadowrocket | 删 72 yaml + anti-ad + Sukka domainset → non_ip |
| Quantumult X | 删 71 yaml + anti-ad + domainset + version `v5.2.3-QX.1` → `v5.2.4-QX.1` |
| Surge | 删 72 yaml + anti-ad |
| v2rayN | geosite 类别核查（软问题，可选） |

https://claude.ai/code/session_016pAnSQpbR2mB55QrU2fnAH