### PR TITLE
fix(shadowrocket): drop 72 Clash yaml rule-sets + anti-AD CDN + Sukka path (v5.2.5-SR.3)

### DIFF
--- a/Shadowrocket/CHANGELOG.md
+++ b/Shadowrocket/CHANGELOG.md
@@ -5,6 +5,45 @@
 
 ---
 
+## v5.2.5-SR.3 (2026-04-22) — 移除 72 条 Clash YAML 规则集 + anti-AD/Sukka 兼容修复
+
+深度审查发现仓库 iOS 三兄弟（Loon / Shadowrocket / Quantumult X）共享同一批"Clash Party v5.2.4 基线遗毒"：
+- 72 条 Accademia Clash classical `.yaml` RULE-SET（SR 的"auto-detect yaml"只有非官方文档声称，保守视作 Loon 已验证失效同款）
+- `anti-ad.net/surge.txt` 裸域名（Loon v5.2.4-Loon.3 已确认部分国内 ISP 会劫持返回 HTML）
+- Sukka `List/domainset/*.conf`（Surge 专属二级路径，Loon 不认，SR 官方同样没保证）
+
+本次按 Loon v5.2.4-Loon.2 / .3 已验证的修复模板同步应用：
+
+### 改动
+
+- ★ FIX#SR-01-P1：**删除 72 条 Clash classical `.yaml` RULE-SET**（71 Accademia + 1 ACL4SSR Zoom.yaml），SR 可能沉默加载为 0 条
+- ★ FIX#SR-02-P0：`anti-ad.net/surge.txt` → `fastly.jsdelivr.net/gh/privacy-protection-tools/anti-AD@master/anti-ad-surge.txt`
+- ★ FIX#SR-03-P0：Sukka `List/domainset/reject_phishing.conf` → `List/non_ip/reject_phishing.conf`
+- ★ FIX#SR-04-P1：72 条 yaml 删除后的关键域名补 DOMAIN-SUFFIX 兜底：
+  - 🏦 金融支付：Monzo / N26 / Chime + 24 国际银行（Chase / BofA / HSBC / Barclays / DBS / MUFG / RBC / ANZ 等）
+  - 🧑‍💼 会议协作：Zoom × 5 / RustDesk / Parsec × 3
+  - 🌐 国外网站：Wayback Machine / Pornhub × 3
+
+### 元信息
+
+- 版本：`v5.2.2-SR.2` → **`v5.2.5-SR.3`**（主版本对齐 Clash Party JS `VERSION = 'v5.2.5'`）
+- Build：2026-04-20 → 2026-04-22
+- 架构一句话：`250+ RULE-SET` → `~290 RULE-SET`
+- 清理 15 行孤立的 `# Accademia xxx` 注释头（原 yaml 段已删）
+
+### 已接受的回归损失（与 Loon 一致）
+
+Accademia `FakeLocation × 10`（国内 APP IP 伪装）、`GeoRouting × 17 区域`、`eMuleServer`、`HomeIP`、各国银行细粒度 YAML —— 没有 `.list` 等价源；关键域名已补 DOMAIN-SUFFIX 兜底。完整覆盖请换 CMFA / OpenClash / SingBox。
+
+### 自检
+
+- 代理组 37 个 ✓
+- `.yaml,` RULE-SET 残留：0 条 ✓
+- `anti-ad.net` 残留：0 次 ✓
+- `skk.moe/List/domainset/`：0 次；`List/non_ip/`：1 次 ✓
+
+---
+
 ## v5.2.2-SR.2 (2026-04-20)
 
 与 Clash Party 业务组严格对齐：
@@ -34,5 +73,5 @@ DNS 段重构，映射用户 Clash DNS 配置：
 - 删除 Smart fingerprint 注入（SR 不暴露 TLS 指纹控制）
 - GEOSITE 全部替换为 RULE-SET（SR 不原生支持 GEOSITE）
 - Meta `.mrs` 二进制格式全部替换为 blackmatrix7 Shadowrocket `.list`
-- Accademia 部分 YAML classical 保留（SR 按内容识别，可解析）
+- Accademia 部分 YAML classical 保留（SR 按内容识别，可解析）— v5.2.5-SR.3 起全部删除，改用 `.list` 等价源 + DOMAIN-SUFFIX 兜底
 - rule-provider 的周期刷新改由 SR 的「自动更新配置」统一管理

--- a/Shadowrocket/README.md
+++ b/Shadowrocket/README.md
@@ -1,9 +1,9 @@
 # Shadowrocket（小火箭）使用教程
 
 > 配置文件：`shadowrocket-smart.conf`
-> 版本：**v5.2.2-SR.2**（Build 2026-04-20，从 Clash Party v5.2.2 迁移重构）
+> 版本：**v5.2.5-SR.3**（Build 2026-04-22，删除 72 条 Clash yaml 规则集 + anti-AD/Sukka 兼容修复，详见 `Shadowrocket/CHANGELOG.md`）
 > 目标：**Shadowrocket iOS（App Store 正版）** / macOS 通用
-> 架构：9 区域组（`url-test` + `policy-regex-filter` 按节点名自动分类）+ 28 业务策略组 + 250+ rule-set
+> 架构：9 区域组（`url-test` + `policy-regex-filter` 按节点名自动分类）+ 28 业务策略组 + ~290 rule-set
 
 ---
 

--- a/Shadowrocket/shadowrocket-smart.conf
+++ b/Shadowrocket/shadowrocket-smart.conf
@@ -1,8 +1,8 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Shadowrocket Smart v5.2.2-SR.2 — 小火箭版（从 Clash Party v5.2.4 迁移重构）
-#  Build: 2026-04-20 | Target: Shadowrocket iOS (App Store 正版) | macOS 通用
-#  架构：9 区域 url-test 组（policy-regex-filter）+ 28 业务策略组 + 250+ RULE-SET
-#  基线：Clash Party v5.2.4（唯一主线）
+#  Shadowrocket Smart v5.2.5-SR.3 — 小火箭版（从 Clash Party v5.2.5 迁移重构）
+#  Build: 2026-04-22 | Target: Shadowrocket iOS (App Store 正版) | macOS 通用
+#  架构：9 区域 url-test 组（policy-regex-filter）+ 28 业务策略组 + ~290 RULE-SET
+#  基线：Clash Party v5.2.5（唯一主线）
 #  变更历史：见 `Shadowrocket/CHANGELOG.md`
 # ══════════════════════════════════════════════════════════════════════════════
 
@@ -253,16 +253,11 @@ icmp-auto-reply = true
 [Rule]
 # ─── 阶段 1: 广告拦截与威胁情报 ───────────────────────────────────────────────
 # anti-AD（DustinWin 同源 privacy-protection-tools/anti-AD）
-RULE-SET,https://anti-ad.net/surge.txt,🛑 广告拦截
+RULE-SET,https://fastly.jsdelivr.net/gh/privacy-protection-tools/anti-AD@master/anti-ad-surge.txt,🛑 广告拦截
 # SukkaW 钓鱼域名拦截（13 万条）
-RULE-SET,https://ruleset.skk.moe/List/domainset/reject_phishing.conf,🛑 广告拦截
+RULE-SET,https://ruleset.skk.moe/List/non_ip/reject_phishing.conf,🛑 广告拦截
 # Hagezi TIF（威胁情报：malware/cryptojacking/C2/scam/spam）
 RULE-SET,https://fastly.jsdelivr.net/gh/hagezi/dns-blocklists@main/share/surge-tif-medium.txt,🛑 广告拦截
-# Accademia 安全补充（劫持/HTTP DNS/隐私修复/不支持VPN）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/HijackingPlus/HijackingPlus.yaml,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/BlockHttpDNSPlus/BlockHttpDNSPlus.yaml,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/PreRepairEasyPrivacy/PreRepairEasyPrivacy.yaml,🛑 广告拦截
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/UnsupportVPN/UnsupportVPN.yaml,🛑 广告拦截
 # blackmatrix7 广告/隐私/营销追踪规则集（SR 原生）
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Advertising/Advertising.list,🛑 广告拦截
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/AdvertisingMiTV/AdvertisingMiTV.list,🛑 广告拦截
@@ -340,13 +335,8 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 # szkane AI 综合（OpenAI/Claude/Grok/Perplexity/Gemini 合并）
 RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/AiDomain.list,🤖 AI 服务
 RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/CiciAi.list,🤖 AI 服务
-# Accademia AI 补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/AppleAI/AppleAI.yaml,🤖 AI 服务
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Grok/Grok.yaml,🤖 AI 服务
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Gemini/Gemini.yaml,🤖 AI 服务
 # 原版 FIX#13-P2: 微软 Delivery Optimization 遥测非 AI，前置拦截
 DOMAIN-SUFFIX,do.dsp.mp.microsoft.com,📥 下载更新
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Copilot/Copilot.yaml,🤖 AI 服务
 # 常用 AI 域名兜底
 DOMAIN-SUFFIX,perplexity.ai,🤖 AI 服务
 DOMAIN-SUFFIX,mistral.ai,🤖 AI 服务
@@ -458,21 +448,39 @@ DOMAIN-SUFFIX,ksei.co.id,🏦 金融支付
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Stripe/Stripe.list,🏦 金融支付
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/VISA/VISA.list,🏦 金融支付
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/TigerFintech/TigerFintech.list,🏦 金融支付
-# Accademia 银行 × 10 国 + 虚拟金融 × 4（原 rule-provider 拆分为子规则集）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankUS.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankUK.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankHK.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankSG.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankJP.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankAU.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankCA.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankDE.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankNL.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Bank/BankFR.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Paypal.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Wise.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Monzo.yaml,🏦 金融支付
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/VirtualFinance/Revolut.yaml,🏦 金融支付
+# 虚拟金融兜底（替代已移除的 Accademia VirtualFinance YAML）
+DOMAIN-SUFFIX,monzo.com,🏦 金融支付
+DOMAIN-SUFFIX,n26.com,🏦 金融支付
+DOMAIN-SUFFIX,chime.com,🏦 金融支付
+# 主要国际银行兜底（替代已移除的 Accademia Bank × 10 国家级 YAML；欲全量覆盖请换 CMFA/OpenClash/SingBox）
+DOMAIN-SUFFIX,chase.com,🏦 金融支付
+DOMAIN-SUFFIX,bankofamerica.com,🏦 金融支付
+DOMAIN-SUFFIX,wellsfargo.com,🏦 金融支付
+DOMAIN-SUFFIX,citi.com,🏦 金融支付
+DOMAIN-SUFFIX,citibank.com,🏦 金融支付
+DOMAIN-SUFFIX,hsbc.com,🏦 金融支付
+DOMAIN-SUFFIX,hsbc.com.hk,🏦 金融支付
+DOMAIN-SUFFIX,barclays.co.uk,🏦 金融支付
+DOMAIN-SUFFIX,lloydsbank.com,🏦 金融支付
+DOMAIN-SUFFIX,santander.com,🏦 金融支付
+DOMAIN-SUFFIX,db.com,🏦 金融支付
+DOMAIN-SUFFIX,deutsche-bank.de,🏦 金融支付
+DOMAIN-SUFFIX,ing.nl,🏦 金融支付
+DOMAIN-SUFFIX,bnpparibas.com,🏦 金融支付
+DOMAIN-SUFFIX,sgmarkets.com,🏦 金融支付
+DOMAIN-SUFFIX,ocbc.com,🏦 金融支付
+DOMAIN-SUFFIX,uobgroup.com,🏦 金融支付
+DOMAIN-SUFFIX,dbs.com,🏦 金融支付
+DOMAIN-SUFFIX,dbs.com.sg,🏦 金融支付
+DOMAIN-SUFFIX,mufg.jp,🏦 金融支付
+DOMAIN-SUFFIX,smbc.co.jp,🏦 金融支付
+DOMAIN-SUFFIX,mizuhobank.com,🏦 金融支付
+DOMAIN-SUFFIX,rbc.com,🏦 金融支付
+DOMAIN-SUFFIX,td.com,🏦 金融支付
+DOMAIN-SUFFIX,scotiabank.com,🏦 金融支付
+DOMAIN-SUFFIX,cba.com.au,🏦 金融支付
+DOMAIN-SUFFIX,anz.com,🏦 金融支付
+DOMAIN-SUFFIX,westpac.com.au,🏦 金融支付
 
 # ─── 阶段 7: 邮件服务 ─────────────────────────────────────────────────────────
 # 微软服务域名前置（防止吞入邮件组）
@@ -543,8 +551,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/TelegramUS/TelegramUS.list,💬 即时通讯
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Zalo/Zalo.list,💬 即时通讯
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/iTalkBB/iTalkBB.list,💬 即时通讯
-# Accademia Signal 补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Signal/Signal.yaml,💬 即时通讯
 DOMAIN-SUFFIX,icq.com,💬 即时通讯
 
 # ─── 阶段 9: 社交媒体 ─────────────────────────────────────────────────────────
@@ -582,9 +588,19 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Pixnet/Pixnet.list,📱 社交媒体
 
 # ─── 阶段 10: 会议协作 ────────────────────────────────────────────────────────
-RULE-SET,https://fastly.jsdelivr.net/gh/ACL4SSR/ACL4SSR@master/Clash/Providers/Ruleset/Zoom.yaml,🧑‍💼 会议协作
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Slack/Slack.list,🧑‍💼 会议协作
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Teams/Teams.list,🧑‍💼 会议协作
+# Zoom（替代已移除的 ACL4SSR Zoom.yaml）
+DOMAIN-SUFFIX,zoom.us,🧑‍💼 会议协作
+DOMAIN-SUFFIX,zoom.com,🧑‍💼 会议协作
+DOMAIN-SUFFIX,zoomgov.com,🧑‍💼 会议协作
+DOMAIN-SUFFIX,zoomcdn.com,🧑‍💼 会议协作
+DOMAIN-SUFFIX,zoomdev.us,🧑‍💼 会议协作
+# RustDesk / Parsec（替代已移除的 Accademia RustDesk/Parsec YAML）
+DOMAIN-SUFFIX,rustdesk.com,🧑‍💼 会议协作
+DOMAIN-SUFFIX,parsec.app,🧑‍💼 会议协作
+DOMAIN-SUFFIX,parsecgaming.com,🧑‍💼 会议协作
+DOMAIN-SUFFIX,parsecusercontent.com,🧑‍💼 会议协作
 # Webex / Notion / Figma / Atlassian 等协作工具
 DOMAIN-SUFFIX,webex.com,🧑‍💼 会议协作
 DOMAIN-SUFFIX,wbx2.com,🧑‍💼 会议协作
@@ -620,9 +636,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Zendesk/Zendesk.list,🧑‍💼 会议协作
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Intercom/Intercom.list,🧑‍💼 会议协作
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/RemoteDesktop/RemoteDesktop.list,🧑‍💼 会议协作
-# Accademia 远程桌面补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/RustDesk/RustDesk.yaml,🧑‍💼 会议协作
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Parsec/Parsec.yaml,🧑‍💼 会议协作
 # 国内协作工具直连
 DOMAIN-SUFFIX,feishu.cn,DIRECT
 DOMAIN-SUFFIX,dingtalk.com,DIRECT
@@ -715,21 +728,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/56/56.list,📺 国内流媒体
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/CETV/CETV.list,📺 国内流媒体
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/YYeTs/YYeTs.list,📺 国内流媒体
-# Accademia 国内云盘/媒体补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Alipan/Alipan.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/BaiduNetDisk/BaiduNetDisk.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/WeiYun/WeiYun.yaml,📺 国内流媒体
-# Accademia FakeLocation × 10 平台（国内 APP IP 归属地伪装）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationBiliBili.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationDouYin.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationKuaiShou.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationXiaoHongShu.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationXiGua.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationWeiBo.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationZhiHu.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationTieBa.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationDouBan.yaml,📺 国内流媒体
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/FakeLocation/FakeLocationXianYu.yaml,📺 国内流媒体
 # 港澳台 B 站需要港区代理解锁
 RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/BilibiliHMT.list,🇭🇰 香港流媒体
 
@@ -765,7 +763,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/WeTV/WeTV.list,📺 东南亚流媒体
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Zee/Zee.list,📺 东南亚流媒体
 # Kwai 国际版（巴西/印尼主战场）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Kwai/Kwai.yaml,📺 东南亚流媒体
 
 # ─── 阶段 13: 美国流媒体 ──────────────────────────────────────────────────────
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/YouTube/YouTube.list,🇺🇸 美国流媒体
@@ -1115,8 +1112,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/D
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/OneDrive/OneDrive.list,Ⓜ️ 微软服务
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Microsoft/Microsoft.list,Ⓜ️ 微软服务
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/MicrosoftEdge/MicrosoftEdge.list,Ⓜ️ 微软服务
-# Accademia 微软 APP 补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/MicrosoftAPPs/MicrosoftAPPs.yaml,Ⓜ️ 微软服务
 
 # ─── 阶段 23: 苹果服务 ────────────────────────────────────────────────────────
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/AppleMusic/AppleMusic.list,🍎 苹果服务
@@ -1131,9 +1126,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/TestFlight/TestFlight.list,🍎 苹果服务
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/AppleFirmware/AppleFirmware.list,🍎 苹果服务
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/FindMy/FindMy.list,🍎 苹果服务
-# Accademia 苹果补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/AppleNews/AppleNews.yaml,🍎 苹果服务
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Apple/Apple.yaml,🍎 苹果服务
 
 # ─── 阶段 24: 下载更新 ────────────────────────────────────────────────────────
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/SystemOTA/SystemOTA.list,📥 下载更新
@@ -1179,8 +1171,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/HP/HP.list,📥 下载更新
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Canon/Canon.list,📥 下载更新
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/LG/LG.list,📥 下载更新
-# Accademia Mac App 升级（Homebrew/Sparkle 源）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/MacAppUpgrade/MacAppUpgrade.yaml,📥 下载更新
 
 # ─── 阶段 25: 云与 CDN ────────────────────────────────────────────────────────
 # bm7 Cloudflare / Fastly / CloudFront IP 段（需要 no-resolve 避免解析消耗）
@@ -1226,8 +1216,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 # 视频 CDN
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/BrightCove/BrightCove.list,☁️ 云与CDN
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Jwplayer/Jwplayer.list,☁️ 云与CDN
-# Accademia CDN 补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Fastly/Fastly.yaml,☁️ 云与CDN
 # Let's Encrypt
 DOMAIN-SUFFIX,letsencrypt.org,☁️ 云与CDN
 DOMAIN-SUFFIX,lencr.org,☁️ 云与CDN
@@ -1241,8 +1229,6 @@ DOMAIN-SUFFIX,tracker.openbittorrent.com,🛰️ BT/PT Tracker
 DOMAIN-SUFFIX,tracker.publicbt.com,🛰️ BT/PT Tracker
 DOMAIN-SUFFIX,tracker.dler.org,🛰️ BT/PT Tracker
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/PrivateTracker/PrivateTracker.list,🛰️ BT/PT Tracker
-# Accademia eMule 服务器
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/eMuleServer/eMuleServer.yaml,🛰️ BT/PT Tracker
 
 # ─── 阶段 27: 印尼本地服务（电商/出行/外卖/电信/政府/新闻 → 国外网站） ────────
 DOMAIN-SUFFIX,tokopedia.com,🌐 国外网站
@@ -1294,16 +1280,8 @@ DOMAIN-SUFFIX,zxtdjy.com,🏠 国内网站
 # Chiphell 论坛直连（原版 FIX）
 DOMAIN-SUFFIX,chiphell.com,DIRECT
 DOMAIN-SUFFIX,iwipwedabay.com,DIRECT
-# Accademia 国内兜底
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeositeCN/GeositeCN.yaml,🏠 国内网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/ChinaMax/ChinaMax.yaml,🏠 国内网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/China/China.yaml,🏠 国内网站
 # Aqara 国内 / 国际
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Aqara/AqaraCN.yaml,🏠 国内网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Aqara/AqaraGlobal.yaml,🌐 国外网站
 # HomeIP × 2 国（美/日）→ 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/HomeIP/HomeIPUS.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/HomeIP/HomeIPJP.yaml,🌐 国外网站
 # bm7 国内综合（ChinaMax / cn 等）
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/ChinaMax/ChinaMax.list,🏠 国内网站
 
@@ -1326,9 +1304,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/MEGA/MEGA.list,🌐 国外网站
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Wikipedia/Wikipedia.list,🌐 国外网站
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Duolingo/Duolingo.list,🌐 国外网站
-# Accademia 国外网站补充
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/WaybackMachine/WaybackMachine.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Pornhub/Pornhub.yaml,🌐 国外网站
 # szkane Education
 RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Khan.list,🌐 国外网站
 RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/Edutools.list,🌐 国外网站
@@ -1336,24 +1311,6 @@ RULE-SET,https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/E
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Naver/Naver.list,🌐 国外网站
 # EHGallery（非流媒体服务）
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/EHGallery/EHGallery.list,🌐 国外网站
-# Accademia GeoRouting × 17 区域（中国 → CN_SITE，其它 → INTL_SITE）
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_China_ccTLD_Domain.yaml,🏠 国内网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_East_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_EastSouth_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_South_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_Central_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Asia_West_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_America_North_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_America_South_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Europe_West_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Europe_East_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Oceania_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Antarctica_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_North_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_South_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_West_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_East_ccTLD_Domain.yaml,🌐 国外网站
-RULE-SET,https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/GeoRouting_For_Domain/GeoRouting_Africa_Central_ccTLD_Domain.yaml,🌐 国外网站
 # 其它国外网站兜底
 DOMAIN-SUFFIX,archive.org,🌐 国外网站
 DOMAIN-SUFFIX,udemy.com,🌐 国外网站
@@ -1366,6 +1323,11 @@ DOMAIN-SUFFIX,guardianapis.com,🌐 国外网站
 DOMAIN-SUFFIX,box.com,🌐 国外网站
 DOMAIN-SUFFIX,boxcdn.net,🌐 国外网站
 DOMAIN-SUFFIX,noip.com,🌐 国外网站
+# Wayback Machine / Pornhub（替代已移除的 Accademia 国外网站 YAML）
+DOMAIN-SUFFIX,web.archive.org,🌐 国外网站
+DOMAIN-SUFFIX,pornhub.com,🌐 国外网站
+DOMAIN-SUFFIX,phncdn.com,🌐 国外网站
+DOMAIN-SUFFIX,phprcdn.com,🌐 国外网站
 
 # ─── 阶段 31: GEOIP 精准标签路由 + CN 兜底 ────────────────────────────────────
 # 注：SR 原生 GEOIP 仅支持国家码匹配，不支持 cloudflare/telegram 等标签


### PR DESCRIPTION
## 背景

与 Loon v5.2.4-Loon.2 / .3 同根同源。SR 配置里有三类高风险"v5.2.4 基线遗毒"，Loon 在过去 48 小时已经踩过一遍：

1. **72 条 Accademia Clash classical `.yaml` RULE-SET** —— SR 的"auto-detect yaml"只有非官方第三方 doc 声称，官方 SR manual 明确 RULE-SET 期望 `.list`/`.conf` 纯文本（Surge 同源）。Loon 已实锤这批 yaml 沉默失效。
2. **`anti-ad.net/surge.txt` 裸域名** —— 无 CDN，部分国内 ISP DNS 劫持返回 HTML captive 页，SR 当规则解析 → 沉默断裂或语法报错。
3. **Sukka `List/domainset/*.conf`** —— Surge 专属二级路径；Loon 不识别，SR 官方 doc 没保证兼容；Sukka 自己推荐 iOS 平台用 `non_ip/`。

按 Loon v5.2.4-Loon.2 / .3 已验证模板同步应用。

## 改动

| 修复 | 详情 |
|---|---|
| 删除 72 条 `.yaml` RULE-SET | `sed -i '/^RULE-SET,.*\.yaml,/d'`；同时删 15 行孤立的 `# Accademia xxx` section 注释 |
| anti-ad.net → jsDelivr | `RULE-SET,https://fastly.jsdelivr.net/gh/privacy-protection-tools/anti-AD@master/anti-ad-surge.txt,🛑 广告拦截` |
| Sukka `domainset/` → `non_ip/` | `skk.moe/List/non_ip/reject_phishing.conf` |
| DOMAIN-SUFFIX 兜底补 | 🏦 Monzo / N26 / Chime + 24 国际银行；🧑‍💼 Zoom × 5 / RustDesk / Parsec × 3；🌐 Wayback / Pornhub × 3 |
| 版本对齐 | `v5.2.2-SR.2` → **`v5.2.5-SR.3`**（主版本对齐 Clash Party JS `VERSION='v5.2.5'`） |
| Build 日期 | `2026-04-20` → `2026-04-22` |
| 头部架构 | `250+ RULE-SET` → `~290 RULE-SET` |

## 自检

```
proxy groups (37):        37 ✓
yaml RULE-SET (0):         0 ✓
anti-ad.net (0):           0 ✓
skk.moe domainset (0):     0 ✓
skk.moe non_ip (1):        1 ✓
dead emoji refs:           0 ✓
stale # Accademia 注释:    0 ✓
lines:                  1372（原 1410，净 -38）
```

## 已接受的回归损失

与 Loon v5.2.4-Loon.2 相同；没有 `.list` 等价源的 Accademia 专属 YAML 不再在 SR 上使用：
`Bank × 10 国家级细粒度` / `FakeLocation × 10` / `GeoRouting × 17 区域` / `eMuleServer` / `HomeIP`。
关键域名已补 DOMAIN-SUFFIX。完整覆盖请换 CMFA / OpenClash / SingBox。

## Test plan

- [ ] 手机 Shadowrocket 导入新配置，启用无"语法错误"弹窗
- [ ] 「规则」面板无 yaml 来源；jsDelivr CDN 拉 anti-AD 成功
- [ ] 首页版本号 `v5.2.5-SR.3`

## 同期 PR

这是「一次性修复优化」的第 3 弹：

| 产物 | PR | 状态 |
|---|---|---|
| Loon | #57 | ✅ merged |
| SingBox-full | #58 | draft |
| **Shadowrocket** | **本 PR** | draft |
| Quantumult X | 下一个 | 待 |
| Surge | 下一个 | 待 |
| v2rayN | 可选 | 待评估 |

https://claude.ai/code/session_016pAnSQpbR2mB55QrU2fnAH