### PR TITLE
fix(v2rayn): swap missing geosite:kakaotalk + version align (v5.2.5-v2n.2)

### DIFF
--- a/v2rayN/CHANGELOG.md
+++ b/v2rayN/CHANGELOG.md
@@ -7,6 +7,45 @@
 
 ---
 
+## v5.2.5-v2n.2 (2026-04-22) — geosite 类别兼容修复 + 版本对齐
+
+深度审查发现 `即时通讯` 规则里 `geosite:kakaotalk` 在 **v2fly/domain-list-community 里不存在**
+（仓库只有 `kakao` 类别，不带 `talk` 后缀；Loyalsoldier 扩展集同样没有）。规则加载后
+silent match 0 domains，KakaoTalk 流量会下沉到 geoip / FINAL，分流不符预期。
+
+### 改动
+
+- ★ FIX#v2n-01-P1：**`geosite:kakaotalk` → `geosite:kakao`**（v2fly 官方类别）+ 补三个显式 domain 兜底
+  - `domain:kakao.com` / `domain:kakaocorp.com` / `domain:kakaotalk.com`
+  - 其他 geosite 类别（`huggingface` / `anthropic` / `perplexity` / `copilot` / `gemini` / `bard` / `openai` 等 AI 新类别）
+    已逐一核对上游存在（v2fly 有 `huggingface.co/hf.co/hf.space` 等），保留
+- ★ FIX#v2n-02-P2：`_meta.version` `v5.2.3-v2n.1` → **`v5.2.5-v2n.2`**（主版本对齐 Clash Party JS `VERSION='v5.2.5'`）
+- ★ FIX#v2n-03-P2：`_meta.build` `2026-04-20` → `2026-04-22`；`_meta.baseline` `v5.2.4` → `v5.2.5`
+- ★ FIX#v2n-04-P2：`remarks` 顶层字段 `v5.2.3` → `v5.2.5`
+
+### 复核其他 audit 发现（保留，不改）
+
+- **`_meta` 顶层键**：v2rayN 保存时需要 `_meta` 做 UI 展示；Xray-core 的 JSON 解析器默认 `DisallowUnknownFields=false`，`_meta` 会被忽略。保留。
+- **`dns-out` outboundTag**：由 v2rayN 主配置补 outbound 定义（参考 `v2rayN/README.md`），本 routing 片段不包含 outbound 定义符合设计。保留。
+- **其他 98 个 geosite 类别**：已随机抽样确认 v2fly / Loyalsoldier 覆盖，未发现其他缺失。
+
+### 自检
+
+```
+python3 -c 'import json; d=json.load(open("v2rayN/v2rayn-smart-xray-routing.json")); print(d["_meta"]["version"])'
+→ v5.2.5-v2n.2 ✓
+rules 数量:                 29（不变）
+kakaotalk → kakao + domain: 已修 ✓
+_meta.version 以 v5. 开头:  ✓（CLAUDE.md §5 期望）
+```
+
+### 官方文档证据
+
+- [v2fly/domain-list-community data/kakao](https://github.com/v2fly/domain-list-community/tree/master/data)（存在）vs `data/kakaotalk`（404）
+- [v2fly/domain-list-community data/huggingface](https://raw.githubusercontent.com/v2fly/domain-list-community/master/data/huggingface) 存在（hf.co / hf.space / huggingface.co）
+
+---
+
 ## v5.2.3-v2n.1 (2026-04-20) — 初版
 
 - ★ 基于 Clash Party v5.2.3 提取关键业务域名，生成 Xray routing rule

--- a/v2rayN/README.md
+++ b/v2rayN/README.md
@@ -1,4 +1,6 @@
-# v2rayN 使用教程（对齐 Clash Party v5.2.3）
+# v2rayN 使用教程（对齐 Clash Party v5.2.5）
+
+> 路径 C（Xray 核）产物：`v2rayN/v2rayn-smart-xray-routing.json` v5.2.5-v2n.2（详见 `v2rayN/CHANGELOG.md`）。
 
 > 本目录提供 Windows 客户端 **v2rayN** 的接入说明。
 > v2rayN 本身不是内核，它是一个「多核心调度器」——可以切换到 **mihomo（推荐）/ sing-box / Xray** 三种核心。

--- a/v2rayN/v2rayn-smart-xray-routing.json
+++ b/v2rayN/v2rayn-smart-xray-routing.json
@@ -1,13 +1,13 @@
 {
   "_meta": {
     "name": "Smart-Config-Kit v2rayN Xray Routing",
-    "version": "v5.2.3-v2n.1",
-    "build": "2026-04-20",
-    "baseline": "Clash Party v5.2.4 (Clash Party/Clash Smart内核覆写脚本.js)",
+    "version": "v5.2.5-v2n.2",
+    "build": "2026-04-22",
+    "baseline": "Clash Party v5.2.5 (Clash Party/Clash Smart内核覆写脚本.js)",
     "note": "v2rayN + Xray-core 只支持 3 个出站 (proxy / direct / block)，无法还原 Clash Party 的 28 业务组 + 9 区域组。若要完整体验请在 v2rayN 里切到 mihomo 核心并导入 Clash Meta For Android/clash-smart-cmfa.yaml。",
     "changelog": "见 v2rayN/CHANGELOG.md"
   },
-  "remarks": "Smart-Config-Kit v5.2.3 (v2rayN + Xray)",
+  "remarks": "Smart-Config-Kit v5.2.5 (v2rayN + Xray)",
   "url": "",
   "customIcon": "",
   "sort": 0,
@@ -185,7 +185,10 @@
         "geosite:whatsapp",
         "geosite:line",
         "geosite:signal",
-        "geosite:kakaotalk"
+        "geosite:kakao",
+        "domain:kakao.com",
+        "domain:kakaocorp.com",
+        "domain:kakaotalk.com"
       ],
       "ip": [
         "geoip:telegram"


### PR DESCRIPTION
## 背景

「一次性修复优化」计划**收官 PR**（第 6 弹，软问题）。

审查发现 `v2rayn-smart-xray-routing.json` 的"即时通讯"规则里 `geosite:kakaotalk` 在 **v2fly/domain-list-community 里 404 不存在**（只有 `geosite:kakao`；Loyalsoldier 扩展集同样没有带 `talk` 后缀的变体）。规则加载不报错，但 silent match 0 domains，KakaoTalk 流量沉到 geoip/FINAL。

```bash
$ curl -s -w "HTTP:%{http_code}\n" https://raw.githubusercontent.com/v2fly/domain-list-community/master/data/kakaotalk
404: Not FoundHTTP:404

$ curl -s https://raw.githubusercontent.com/v2fly/domain-list-community/master/data/kakao | head -3
# Kakao Corp
daum.net
...
```

## 改动

```diff
[rule scki-015-im - 即时通讯]
   "geosite:signal",
-  "geosite:kakaotalk"
+  "geosite:kakao",
+  "domain:kakao.com",
+  "domain:kakaocorp.com",
+  "domain:kakaotalk.com"
```

元信息：
- `_meta.version`: `v5.2.3-v2n.1` → **`v5.2.5-v2n.2`**（对齐 Clash Party JS `VERSION='v5.2.5'`）
- `_meta.build`: `2026-04-20` → `2026-04-22`
- `_meta.baseline`: `v5.2.4` → `v5.2.5`
- `remarks`: `v5.2.3` → `v5.2.5`

## 保留项（审查复核后，无需改）

- **`_meta` 顶层键**：Xray-core JSON 解析默认 `DisallowUnknownFields=false`，会忽略未知键；v2rayN UI 保存/显示需要
- **`dns-out` outboundTag**：v2rayN 主配置补 outbound 定义（符合设计：本文件是 routing 片段）
- **其他 98 个 geosite 类别**：抽样确认（`huggingface`、`anthropic`、`perplexity`、`openai`、`gemini`、`copilot` 等新 AI 类别在 v2fly 全部存在），无缺失

## Test plan

- [ ] `python3 -c 'import json;json.load(open("v2rayN/v2rayn-smart-xray-routing.json"))'` — JSON 合法
- [ ] v2rayN 导入后"即时通讯"规则 + KakaoTalk 域名命中 proxy
- [ ] `_meta.version` 正确以 `v5.` 开头（CLAUDE.md §5 期望）

## 「一次性修复优化」最终战况

| 产物 | PR | 状态 |
|---|---|---|
| Loon（228 RULE-SET 迁移到 [Remote Rule] 段 + anti-AD） | #57 | ✅ merged |
| SingBox-full（sing-box 1.13 block outbound + DNS schema + 重建 base template） | #58 | ✅ merged |
| Shadowrocket（72 yaml + anti-AD + domainset→non_ip + 兜底） | #59 | ✅ merged |
| Quantumult X（71 yaml + anti-AD + domainset→non_ip + 版本对齐） | #60 | ✅ merged |
| Surge（72 yaml + anti-AD + 兜底 + 版本对齐） | #61 | ✅ merged |
| **v2rayN（kakaotalk→kakao + 版本对齐）** | **本 PR** | draft |

https://claude.ai/code/session_016pAnSQpbR2mB55QrU2fnAH