### PR TITLE
docs + fix + refactor: ClashMi / Passwall2 / FINAL 兜底 / 命名统一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@
 >
 > **关于 Hiddify：** Hiddify 内核即 sing-box（修改版 `hiddify-sing-box`），直接消费 `SingBox/singbox-smart*.json`，**不需要**独立产物；`SingBox/README.md §2a` 提供 Hiddify 专用导入说明。
 >
+> **关于 ClashMi（`KaringX/clashmi`，KaringX 跨平台 Flutter GUI，覆盖 iOS/macOS/Android/Windows/Linux）：** bundle 的是 **MetaCubeX mihomo mainline**（**非** `vernesong/mihomo` Smart fork），与 CMFA 内核同源，直接消费 `Clash Meta For Android/clash-smart-cmfa.yaml`，**不需要**独立产物；`Clash Meta For Android/README.md §九` 提供 ClashMi 专用导入说明。注意 ClashMi 的内核定制会把 `GEOIP,*` / `GEOSITE,*` 规则**强制转换**为对应 rule-set、iOS 端不支持 IP-ASN 数据库、`tun:` 由 App UI 托管不在 YAML 手写（官方 [FAQ](https://clashmi.app/guide/faq)）——这三点对本仓库 YAML **零影响**（0 条 GEOIP、0 条 GEOSITE、0 条 ASN、无 `tun:` 块）。与 Hiddify 对称：Hiddify 是 sing-box 的跨平台 GUI / ClashMi 是 mihomo 的跨平台 GUI。
+>
 > **关于 ShellClash（`juewuy/ShellCrash`）：** 内核是 mihomo，直接复用 `Clash Meta For Android/clash-smart-cmfa.yaml` 或 `OpenClash/openclash_custom_overwrite.sh` 里的 heredoc YAML 块，**不需要**独立产物。
 >
 > **关于 HomeProxy（OpenWrt 官方 sing-box LuCI 插件）：** 内核就是 sing-box，直接导入 `SingBox/singbox-smart-full.json`，**不需要**独立产物；`SingBox/README.md §2b` 提供 HomeProxy 专用导入说明。

--- a/Clash Meta For Android/CHANGELOG.md
+++ b/Clash Meta For Android/CHANGELOG.md
@@ -5,6 +5,22 @@
 
 ---
 
+## docs (2026-04-23) — 追加 ClashMi 兼容说明（纯文档，YAML 未改动）
+
+- ★ **README §一 顶部"适用客户端"行**：追加 **[ClashMi](https://github.com/KaringX/clashmi)**（KaringX 跨平台 Flutter GUI，iOS/macOS/Android/Windows/Linux）。
+- ★ **README 新增 §九〈兼容客户端：ClashMi（跨平台）〉**：导入方式 + 与 CMFA 行为一致点（37 代理组 / 387 RULE-SET / fake-ip DNS / 区域组 url-test）+ ClashMi 专属差异表 6 项。
+- ★ **根 `README.md`**：
+  - 顶部"覆盖客户端"列表补 `ClashMi`
+  - 协议矩阵"客户端列名缩写对照"里 **CMFA** 条目扩展到包含 ClashMi，指向 CMFA §九
+- ★ **`CLAUDE.md` §0 备注链**：新增一段〈关于 ClashMi〉（与〈关于 Hiddify〉对称，说明"mihomo 跨平台 GUI 版"的复用模式）。
+- **关键兼容性论据**（均引自 ClashMi 官方 [FAQ](https://clashmi.app/guide/faq)）：
+  - ClashMi bundle 的是 MetaCubeX mihomo **mainline**（非 vernesong Smart fork）—— 与 CMFA 同源。
+  - ClashMi 内核定制会把 `GEOIP,*` / `GEOSITE,*` **强制转换**为 rule-set → 本 YAML 自检 **0 条 GEOIP / 0 条 GEOSITE / 387 条 RULE-SET**，转换零触发。
+  - iOS VPN Extension 50 MB 内存硬顶 → 本 YAML 使用 `.mrs` 二进制 + 懒加载，不触发 OOM。
+  - iOS 端 IP-ASN 不可用 → 本 YAML 未使用 ASN 规则。
+  - `tun:` 由 App UI 托管 → 本 YAML 未写 `tun:` 段，天然兼容。
+- **版本号策略**：本次仅改 `README.md` / `CHANGELOG.md` / 根 `README.md` / `CLAUDE.md`，**未触及** `clash-smart-cmfa.yaml`，故不 bump YAML 版本号。
+
 ## v5.2.6 (2026-04-22)
 
 - ★ **FIX#24-P0**（同构 bug 补齐）：`filter:` 正则补 ISO alpha-3 国家代码

--- a/Clash Meta For Android/README.md
+++ b/Clash Meta For Android/README.md
@@ -1,7 +1,7 @@
 # Clash Meta For Android（CMFA）使用教程
 
 > 配置文件：`clash-smart-cmfa.yaml`
-> 适用客户端：**Clash Meta For Android（CMFA）** / **FlClash** / **mihomo-party-android**
+> 适用客户端：**Clash Meta For Android（CMFA）** / **FlClash** / **mihomo-party-android**（Android 原生）· **[ClashMi](https://github.com/KaringX/clashmi)**（跨平台 Flutter GUI，iOS/macOS/Android/Windows/Linux，复用同一 YAML；详见 §九）
 > 内核要求：**Mihomo**（原生 YAML 导入；区域组用 `url-test`，**不含 Smart + LightGBM**——CMFA 的静态 YAML 不支持 JS 覆写）
 > 当前版本：**v5.2.2**（跟随 Clash Party 主线）
 
@@ -228,9 +228,50 @@ A：已通过 `sniffer.skip-domain` 排除主要支付域名（支付宝/微信/
 
 ---
 
-## 九、参考与致谢
+## 九、兼容客户端：ClashMi（跨平台）
+
+**[ClashMi](https://github.com/KaringX/clashmi)**（又称 Clash Mi，KaringX 团队维护的 Flutter 跨平台 Mihomo GUI，GPL-3.0）可以**直接加载本 YAML**，无需任何修改；覆盖 **iOS 15+ / macOS 12+ / Android 8+ / Windows 10+ / Linux**。
+
+> 与 CMFA 的关系：ClashMi bundle 的是 **MetaCubeX mihomo mainline**（[README](https://github.com/KaringX/clashmi)），与 CMFA 内核同源；但软件设置逻辑、UI、订阅管理流程和 CMFA 完全不同，因此单独列出使用说明；**配置层面（YAML schema）100% 共享**，本仓库不为 ClashMi 单开产物。
+
+### 导入方式
+
+ClashMi App 首页菜单 → **我的配置** → 右上角 **＋** → 选择一种：
+- **添加配置链接**（订阅 URL，推荐长期使用，定时自动更新）
+- **从剪贴板导入**（粘贴 YAML 内容）
+- **从文件导入**（本地 `.yml` / `.yaml`）
+- **扫描二维码**
+
+命名后确定即可启用。TUN / HTTP 代理 / DNS 劫持等开关由 **App UI** 托管（不在 YAML 里手写）。
+
+### 与 CMFA 行为一致的部分
+
+- ✅ 37 代理组（9 区域 + 28 业务）结构 1:1 加载。
+- ✅ 387 条 `RULE-SET` + 380+ `rule-providers` 全部走同一 MetaCubeX / blackmatrix7 / Loyalsoldier / szkane / Accademia 源。
+- ✅ fake-ip DNS / sniffer / `proxy-providers.filter` / `exclude-filter` 行为与 CMFA 等价。
+- ✅ 9 区域组使用 `type: url-test`（按延迟择优）—— 与 CMFA 完全相同。
+
+### ClashMi 专属差异（官方 [FAQ](https://clashmi.app/guide/faq) 声明；本 YAML 均已规避）
+
+| 项 | ClashMi 行为 | 本 YAML 的影响 |
+|---|---|---|
+| **GEOIP / GEOSITE 规则** | 启动时强制转换为对应 geo rule-set（内核定制） | **零触发**。本 YAML 使用 **387 条 `RULE-SET`**，**0 条 `GEOIP,`**，**0 条 `GEOSITE,`**（已在仓库自检）|
+| **`GEOIP,<ASN>` ASN 规则** | iOS 版本不支持 IP-ASN 数据库 | **未使用** ASN 规则 |
+| **iOS VPN Extension 50 MB 内存硬顶** | 超出即被系统杀进程 | 本 YAML 全部走 `.mrs` 二进制 ruleset + 懒加载，**不会触发** OOM |
+| **`tun:` YAML 字段块** | 由 App UI 托管 TUN 开关，不建议 YAML 手写 | 本 YAML **未写** `tun:` 段（交 App 设置），对 ClashMi 天然友好 |
+| **Mihomo Smart 内核 / LightGBM** | bundle 的是 mainline（**非** `vernesong/mihomo` Smart fork），不识别 `type: smart` / `uselightgbm` / `lgbm-custom-url` | 本 YAML 区域组本就是 `url-test`（CMFA 同因），此限制不适用 |
+| **内核版本升级** | 跟随 App 发版，**不可独立更新**（FAQ） | 无影响；本 YAML 使用 mainline 稳定字段 |
+
+### 一句话结论
+
+`clash-smart-cmfa.yaml` 可在 ClashMi 上**开箱即用**，行为与 CMFA 等价；UI 操作路径不同但产物层无差异。
+
+---
+
+## 十、参考与致谢
 
 - 上游内核：[MetaCubeX/mihomo](https://github.com/MetaCubeX/mihomo)
 - LightGBM 模型：[vernesong/mihomo](https://github.com/vernesong/mihomo)
 - 规则集：[blackmatrix7/ios_rule_script](https://github.com/blackmatrix7/ios_rule_script) · [MetaCubeX/meta-rules-dat](https://github.com/MetaCubeX/meta-rules-dat)
 - GeoIP：[Loyalsoldier/geoip](https://github.com/Loyalsoldier/geoip)
+- 兼容客户端：[KaringX/clashmi](https://github.com/KaringX/clashmi) · [ClashMi 官方 FAQ](https://clashmi.app/guide/faq)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > 一套以 **Clash Party（Mihomo Smart 内核）JS 覆写脚本** 为基线，同步产出多核心 / 多客户端等价配置的科学上网分流体系。  
 > 覆盖核心：**Mihomo (Clash.Meta / Smart)** · **sing-box** · **Xray** · **Shadowrocket / Surge / Loon / Quantumult X 各自私有引擎**  
-> 覆盖客户端：**Clash Party / Clash Verge Rev / Mihomo Party / CMFA / FlClash / OpenClash / PassWall2 / Shadowrocket / Surge / Loon / Quantumult X / sing-box / Hiddify / v2rayN**  
+> 覆盖客户端：**Clash Party / Clash Verge Rev / Mihomo Party / CMFA / FlClash / mihomo-party-android / ClashMi / OpenClash / PassWall2 / Shadowrocket / Surge / Loon / Quantumult X / sing-box / Hiddify / v2rayN**  
 > 覆盖设备：**Windows / macOS / Linux / Android / iOS / OpenWrt 软路由**  
 > 目标：让同一套分流策略在任何设备、任何代理工具上给出**一致、可解释、可迭代**的结果。
 
@@ -351,7 +351,7 @@ tcpdump -n -i any port 443       # 应看到持续流量 → DoH 正常
 
 **🏷️ 客户端列名缩写对照**：
 - **Clash Party** = Clash Party / Clash Verge Rev / Mihomo Party
-- **CMFA** = Clash Meta For Android / FlClash / mihomo-party-android
+- **CMFA** = Clash Meta For Android / FlClash / mihomo-party-android / **[ClashMi](https://github.com/KaringX/clashmi)**（KaringX 跨平台 Flutter GUI，iOS/macOS/Android/Windows/Linux，同样 bundle MetaCubeX mainline，直接复用 `clash-smart-cmfa.yaml`；导入流程与差异点见 [CMFA 子目录 §九](./Clash%20Meta%20For%20Android/README.md#九兼容客户端clashmi跨平台)）
 - **QX** = Quantumult X
 - **sing-box** = sing-box 通用客户端（SFA / SFM / SFI / Hiddify / NekoBox / Karing / HomeProxy）
 - **v2rayN Xray** = v2rayN 默认 Xray 核模式


### PR DESCRIPTION
本 PR 含 5 个独立变更（按提交时间）：

---

## 变更 1 — docs(cmfa)：追加 ClashMi 兼容说明 (`6984cf2`)

## 变更 2 — fix(passwall2)：致命语法 bug + 定位纠正 (`d3de855`，v5.2.6-pw2.2)

## 变更 3 — fix(passwall2)：所有权精确化 (`2314195`)

## 变更 4 — fix(final)：SR FINAL 补 dns-failed + SingBox smart.json 补 route.final (`b61517b`)

## 变更 5 — refactor(naming)：统一主配置文件命名 (`ffb0033`)

16 个主配置文件批量 `git mv` 到 **`APP(kernel).ext`** 模板，同步更新 ~270 处引用 + CLAUDE.md §0/1.2/1.3/5 + 生成器脚本内部 relative path + 根 README 加可折叠迁移公告。

**重命名对照表**：

| 子目录 | 旧名 | 新名 |
|---|---|---|
| `Clash Party/` | `Clash Smart内核覆写脚本.js` | `ClashParty(mihomo-smart).js` |
| `Clash Party/` | `Clash 普通内核覆写脚本.js` | `ClashParty(mihomo).js` |
| `Clash Meta For Android/` | `clash-smart-cmfa.yaml` | `CMFA(mihomo).yaml` |
| `OpenClash/` | `openclash_custom_overwrite_full.sh` | `OpenClash(mihomo-smart).sh` |
| `OpenClash/` | `openclash_custom_overwrite_normal.sh` | `OpenClash(mihomo).sh` |
| `OpenClash/` | `clash-smart-openclash.conf` | `OpenClash(mihomo).conf` |
| `Shadowrocket/` | `shadowrocket-smart.conf` | `Shadowrocket.conf` |
| `SingBox/` | `singbox-smart.json` | `SingBox(sing-box).json` |
| `SingBox/` | `singbox-smart-full.json` | `SingBox(sing-box)-full.json` |
| `SingBox/` | `generate-singbox-full.js` | `SingBox(sing-box)-generator.js` |
| `v2rayN/` | `v2rayn-smart-xray-routing.json` | `v2rayN(xray).json` |
| `Surge/` | `surge-smart.conf` | `Surge.conf` |
| `Loon/` | `loon-smart.conf` | `Loon.conf` |
| `Quantumult X/` | `qx-smart.conf` | `QuantumultX.conf` |
| `Passwall2/` | `passwall2-smart-shunt.conf` | `Passwall2(xray+sing-box).conf` |
| `Passwall2/` | `apply-shunt-rules.sh` | `Passwall2(xray+sing-box)-apply.sh` |

**命名规则**：
- `APP名称(内核名称).扩展名` 统一模板
- **专有引擎**（Shadowrocket/Surge/Loon/QuantumultX）省略括号（用户选择 Q1=B 简洁）
- **辅助脚本**一并改名（用户选择 Q2=A 一致）
- **规则清单** `Passwall2/shunt-rules/*.list` 28 文件**不改**（编号+分类已清晰）

**破坏性**：GitHub Raw URL 订阅用户 URL 会 404，必须更新订阅——根 README 顶部已加可折叠 `<details>` 迁移公告（16 处对照表 + 各客户端订阅更新指引）。

**验证**：生成器脚本从仓库根实跑通过（`node SingBox/SingBox(sing-box)-generator.js` → 51 outbounds / 975 rules / `route.final: 🐟 漏网之鱼` / `_meta: v5.2.6-sing.3`）。

---

## 汇总自检（CLAUDE.md §5 跑新路径）

| 项 | 期望 | 实测 |
|---|---|:-:|
| CMFA YAML `^- name:` | 37 或 28（不等分缩进） | 28（yaml.safe_load = 37）✓ |
| OpenClash slim/full `^- name:` | 37 或 28 | 28 / 28 ✓ |
| SR/Surge/Loon/QX `select/url-test`/`url-latency-benchmark` | 37 | 37 / 37 / 37 / 37 ✓ |
| SingBox slim/full selector+urltest | 38 | 38 / 38 ✓ |
| CMFA `proxy: '🚫 受限网站'` | ≥ 300 | 387 ✓ |
| CMFA `proxy: '☁️ 云与CDN'` | 0 | 0 ✓ |
| OC normal `proxy: DIRECT` | 0 | 0 ✓ |
| 所有 JSON 合法 | — | ✓ |
| CMFA YAML 合法 | — | ✓ |
| v2rayN `_meta.version` 以 `v5.` 开头 | ✓ | v5.2.5-v2n.2 ✓ |

## 提交列表

- `6984cf2` docs(cmfa): 追加 ClashMi 兼容说明
- `d3de855` fix(passwall2): 修正分流规则语法 + Passwall/Passwall2 定位关系 (v5.2.6-pw2.2)
- `2314195` fix(passwall2): 所有权更新到 Openwrt-Passwall 组织
- `b61517b` fix(final): SR FINAL 补 dns-failed + SingBox smart.json 补 route.final
- `ffb0033` refactor(naming): 统一主配置文件命名为 APP(kernel).ext