### PR TITLE
fix(mihomo): silence USER-AGENT / IP-CIDR parse warnings via mirrored providers (v5.2.7)

### DIFF
--- a/Clash Meta For Android/CHANGELOG.md
+++ b/Clash Meta For Android/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## v5.2.7-cmfa.1 (2026-04-23)
+
+- ★ **FIX#27-P1**：消除 mihomo 加载 3 个 classical rule-provider 的 parse warning（与 Clash Party v5.2.7 同步）
+  - 现象（用户报告）：CMFA 启动 / reload 日志反复打印
+    - `parse classical rule [USER-AGENT,TikTok*] error: unsupported rule type: USER-AGENT`
+    - `parse classical rule [USER-AGENT,BBCiPlayer*] error: unsupported rule type: USER-AGENT`
+    - `parse classical rule [IP-CIDR , 17.253.4.125] error: payloadRule error`
+  - 根因：upstream `szkane/ClashRuleSet` 的 `CiciAi.list` / `UK.list` 各含 1 行 USER-AGENT（mihomo `classical` provider 不识别，是 Surge / iOS 遗留语法）；upstream `Accademia/Additional_Rule_For_Clash` 的 `Grok.yaml` 含 1 行 `IP-CIDR         , 17.253.4.125`（多余空格 + 缺 CIDR 掩码）。
+  - 修复：把 `szkane-ciciai` / `szkane-uk` / `acc-grok` 的 URL 切到本仓库根目录新增的 `mirrors/` 子目录的清洗副本（仅删问题行，剩余规则字节级一致）。TikTok / BBC 域名分别已由 `geosite:tiktok` / `geosite:bbc` 提供 100% 覆盖；17.253.4.125 是 Apple `time.apple.com` anycast，与 Grok 路由无关。
+  - 跟随基线：Clash Party v5.2.7 → CMFA bump 到 `v5.2.7-cmfa.1`。
+
 ## docs (2026-04-23) — 追加 ClashMi 兼容说明（纯文档，YAML 未改动）
 
 - ★ **README §一 顶部"适用客户端"行**：追加 **[ClashMi](https://github.com/KaringX/clashmi)**（KaringX 跨平台 Flutter GUI，iOS/macOS/Android/Windows/Linux）。

--- a/Clash Meta For Android/CMFA(mihomo).yaml
+++ b/Clash Meta For Android/CMFA(mihomo).yaml
@@ -1,7 +1,8 @@
 # ================================================================
-# Clash Smart v5.2.6 - CMFA (Clash Meta for Android) 配置
+# Clash Smart v5.2.7-cmfa.1 - CMFA (Clash Meta for Android) 配置
+# Build: 2026-04-23
 # 架构：proxy-providers 订阅 + 9 url-test 区域组 + 28 业务策略组 + 373+ rule-providers
-# 基线：Clash Party v5.2.6（唯一主线）
+# 基线：Clash Party v5.2.7（唯一主线）
 # 变更历史：见 `Clash Meta For Android/CHANGELOG.md`
 # ================================================================
 # ★ 快速上手：
@@ -2636,11 +2637,15 @@ rule-providers:
     path: ./ruleset/szkane-ai.list
     interval: 89888
     proxy: '🚫 受限网站'
+  # v5.2.7 FIX#27-P1: upstream `Clash/Ruleset/CiciAi.list` 含 `USER-AGENT,TikTok*`，
+  # mihomo classical provider 不识别 USER-AGENT，每次 reload 触发
+  # `parse classical rule [USER-AGENT,TikTok*] error: unsupported rule type: USER-AGENT`。
+  # 改用本仓库 mirrors/ 的清洗副本（仅删该行；TikTok 域名已由 geosite:tiktok 覆盖）。
   szkane-ciciai:
     type: http
     behavior: classical
     format: text
-    url: 'https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/CiciAi.list'
+    url: 'https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/CiciAi.list'
     path: ./ruleset/szkane-ciciai.list
     interval: 89873
     proxy: '🚫 受限网站'
@@ -2676,11 +2681,15 @@ rule-providers:
     path: ./ruleset/szkane-edutools.list
     interval: 89948
     proxy: '🚫 受限网站'
+  # v5.2.7 FIX#27-P1: upstream `Clash/Ruleset/UK.list` 含 `USER-AGENT,BBCiPlayer*`，
+  # mihomo classical provider 不识别 USER-AGENT，每次 reload 触发
+  # `parse classical rule [USER-AGENT,BBCiPlayer*] error: unsupported rule type: USER-AGENT`。
+  # 改用本仓库 mirrors/ 的清洗副本（BBC 域名已由 geosite:bbc 覆盖）。
   szkane-uk:
     type: http
     behavior: classical
     format: text
-    url: 'https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/UK.list'
+    url: 'https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/UK.list'
     path: ./ruleset/szkane-uk.list
     interval: 89954
     proxy: '🚫 受限网站'
@@ -2731,10 +2740,14 @@ rule-providers:
     path: ./ruleset/acc-appleai.yaml
     interval: 90027
     proxy: '🚫 受限网站'
+  # v5.2.7 FIX#27-P1: upstream `Grok/Grok.yaml` 含 `IP-CIDR         , 17.253.4.125`
+  # （多余空格 + 缺 CIDR 掩码），mihomo 触发
+  # `parse classical rule [IP-CIDR , 17.253.4.125] error: payloadRule error`。
+  # 改用本仓库 mirrors/ 的清洗副本（仅删该行 + 规整空格）。
   acc-grok:
     type: http
     behavior: classical
-    url: 'https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Grok/Grok.yaml'
+    url: 'https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/Grok.yaml'
     path: ./ruleset/acc-grok.yaml
     interval: 90064
     proxy: '🚫 受限网站'

--- a/Clash Party/CHANGELOG.md
+++ b/Clash Party/CHANGELOG.md
@@ -7,6 +7,32 @@
 
 ---
 
+## v5.2.7 (2026-04-23)
+
+- ★ **FIX#27-P1**：消除 mihomo 加载 3 个 classical rule-provider 时的 parse warning
+  - 现象（用户报告）：mihomo 启动 / reload 日志反复打印
+    - `parse classical rule [USER-AGENT,TikTok*] error: unsupported rule type: USER-AGENT`
+    - `parse classical rule [USER-AGENT,BBCiPlayer*] error: unsupported rule type: USER-AGENT`
+    - `parse classical rule [IP-CIDR , 17.253.4.125] error: payloadRule error`
+  - 根因定位：
+    - `szkane-ciciai` → upstream `szkane/ClashRuleSet/Clash/Ruleset/CiciAi.list` 第 52 行 `USER-AGENT,TikTok*`（mihomo `classical` provider 不识别 USER-AGENT，是 Surge/iOS 遗留语法）
+    - `szkane-uk` → upstream `szkane/ClashRuleSet/Clash/Ruleset/UK.list` 第 5 行 `USER-AGENT,BBCiPlayer*`（同上）
+    - `acc-grok` → upstream `Accademia/Additional_Rule_For_Clash/Grok/Grok.yaml` 第 9 行 `IP-CIDR         , 17.253.4.125`（多余空格 + 缺 CIDR 掩码 → mihomo 解析失败）
+  - 修复方案：在仓库根目录新增 `mirrors/` 子目录托管这 3 份**仅删去问题行**的清洗副本，把 4 个 mihomo-family 产物的 URL 切到本仓库的 jsdelivr 镜像
+    - `mirrors/CiciAi.list`：去除 `USER-AGENT,TikTok*`（TikTok 域名已由 `metaDomain('tiktok','tiktok')` 提供 100% 覆盖）
+    - `mirrors/UK.list`：去除 `USER-AGENT,BBCiPlayer*`（BBC 域名已由 `metaDomain('bbc','bbc')` 提供 100% 覆盖）
+    - `mirrors/Grok.yaml`：去除 `IP-CIDR , 17.253.4.125`（该 IP 是 Apple `time.apple.com` 的 anycast 地址，与 Grok 路由无关）+ 规整 DOMAIN-SUFFIX 周围多余空格
+  - 同步范围（FIX#27 同构审计）：
+    - ✅ **Clash Party Smart JS**（本文件）：3 个 provider URL 切镜像，bump 到 `v5.2.7`
+    - ✅ **Clash Party Normal JS**（`ClashParty(mihomo).js`）：3 个 provider URL 切镜像，bump 到 `v5.2.7-normal.1`
+    - ✅ **CMFA YAML**（`Clash Meta For Android/CMFA(mihomo).yaml`）：3 个 provider URL 切镜像，bump 到 `v5.2.7-cmfa.1`
+    - ✅ **OpenClash Smart sh**（heredoc YAML）：3 个 provider URL 切镜像，bump 到 `v5.2.7-oc-full.1`
+    - ✅ **OpenClash Normal sh**（heredoc YAML）：3 个 provider URL 切镜像，bump 到 `v5.2.7-oc-normal.1`
+    - ⛔ **Shadowrocket / Surge / Loon / Quantumult X**：iOS 系产物的 RULE-SET 解析器**原生支持** `USER-AGENT`（Surge / Shadowrocket / Loon / QX 都把这条规则当一等公民），同样能容忍 `IP-CIDR  , 1.2.3.4` 这种空格变体；仍可继续直接拉 szkane / Accademia 的上游 URL，无须切镜像 —— 但若上游 yaml 里有 `IP-CIDR ,` 缺 mask（mihomo 报错的本因），iOS 端会把它解析成 `1.2.3.4/32`，行为等价。审计通过、不动。
+    - ⛔ **SingBox Full**：使用 sing-box 自身的 `route.rule_set`（binary `.srs` / source JSON），与 Clash classical 完全无关，零影响
+    - ⛔ **v2rayN Xray routing**：纯 Xray `routing.rules` 结构，不消费 Clash classical provider，零影响
+  - 兼容性：jsdelivr 对本仓库的拉取首次冷缓存 ~5 min；之后命中边缘缓存。镜像内容仅去掉问题行，剩余规则和 upstream 字节级一致。
+
 ## v5.2.6 (2026-04-22)
 
 - ★ **FIX#24-P0**：补齐 ISO alpha-3 国家代码，修复 `TWN/JPN/KOR/SGP` 命名节点归类失败

--- a/Clash Party/ClashParty(mihomo).js
+++ b/Clash Party/ClashParty(mihomo).js
@@ -1,7 +1,7 @@
 // Clash 普通内核覆写脚本 - SUB-STORE 多机场精细分流版（非 Smart 内核）
-// 版本：v5.2.6-normal.1 (2026-04-22)
+// 版本：v5.2.7-normal.1 (2026-04-23)
 // 架构：SUB-STORE 多机场融合 + 9 url-test 区域组 + 28 业务策略组 + 371+ rule-providers 100%+ 服务覆盖
-// 基线：Clash Party v5.2.6（与同目录 Clash Smart 内核覆写脚本.js 规则 100% 等价，仅 9 区域组从 smart 改为 url-test）
+// 基线：Clash Party v5.2.7（与同目录 ClashParty(mihomo-smart).js 规则 100% 等价，仅 9 区域组从 smart 改为 url-test）
 // 适用：Mihomo / Clash.Meta 稳定版内核、不支持 smart + LightGBM 的分支；也适用于想完全关闭 ML 评估的用户
 // 变更历史：见 `Clash Party/CHANGELOG.md`
 
@@ -9,7 +9,7 @@
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.2.6-normal.1'
+const VERSION = 'v5.2.7-normal.1'
 
 // ================================================================
 //  模块 A：节点过滤（沿用 v3.1）
@@ -630,9 +630,13 @@ function injectRuleProviders(config) {
       proxy: RP_PROXY
     }
     // ── szkane CiciAI（字节海外AI：Coze International/Luma AI，需新加坡节点）──
+    // v5.2.7 FIX#27-P1: upstream `Clash/Ruleset/CiciAi.list` 含 `USER-AGENT,TikTok*`，mihomo
+    //   classical provider 不识别 USER-AGENT 会触发 `parse classical rule [USER-AGENT,TikTok*]
+    //   error: unsupported rule type: USER-AGENT`。改用本仓库 mirrors/ 的清洗副本（仅删该行，
+    //   TikTok 域名已由 metaDomain('tiktok','tiktok') 覆盖）。
     config['rule-providers']['szkane-ciciai'] = {
       type: 'http', behavior: 'classical', format: 'text',
-      url: 'https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/CiciAi.list',
+      url: 'https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/CiciAi.list',
       path: './ruleset/szkane-CiciAi.list',
       interval: nextInterval(),
       proxy: RP_PROXY
@@ -670,9 +674,13 @@ function injectRuleProviders(config) {
       proxy: RP_PROXY
     }
     // ── szkane UK Apps ──
+    // v5.2.7 FIX#27-P1: upstream `Clash/Ruleset/UK.list` 含 `USER-AGENT,BBCiPlayer*`，
+    //   mihomo classical provider 不识别 USER-AGENT 会触发
+    //   `parse classical rule [USER-AGENT,BBCiPlayer*] error: unsupported rule type: USER-AGENT`。
+    //   改用本仓库 mirrors/ 的清洗副本（BBC 域名已由 metaDomain('bbc','bbc') 覆盖）。
     config['rule-providers']['szkane-uk'] = {
       type: 'http', behavior: 'classical', format: 'text',
-      url: 'https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/UK.list',
+      url: 'https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/UK.list',
       path: './ruleset/szkane-UK.list',
       interval: nextInterval(),
       proxy: RP_PROXY
@@ -750,9 +758,13 @@ function injectRuleProviders(config) {
       interval: nextInterval(),
       proxy: RP_PROXY
     }
+    // v5.2.7 FIX#27-P1: upstream `Grok/Grok.yaml` 含 `IP-CIDR         , 17.253.4.125`
+    //   （多余空格 + 缺 CIDR 掩码）会触发
+    //   `parse classical rule [IP-CIDR , 17.253.4.125] error: payloadRule error`。
+    //   改用本仓库 mirrors/ 的清洗副本（仅删该行 + 规整空格）。
     config['rule-providers']['acc-grok'] = {
       type: 'http', behavior: 'classical',
-      url: 'https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Grok/Grok.yaml',
+      url: 'https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/Grok.yaml',
       path: './ruleset/acc-Grok.yaml',
       interval: nextInterval(),
       proxy: RP_PROXY

--- a/Clash Party/ClashParty(mihomo-smart).js
+++ b/Clash Party/ClashParty(mihomo-smart).js
@@ -1,5 +1,5 @@
 // Clash Smart 内核覆写脚本 - SUB-STORE 多机场精细分流版
-// 版本：v5.2.6 (2026-04-22)
+// 版本：v5.2.7 (2026-04-23)
 // 架构：SUB-STORE 多机场融合 + 9 Smart 区域组 + 28 业务策略组 + 371+ rule-providers 100%+ 服务覆盖
 // 变更历史：见 `Clash Party/CHANGELOG.md`
 
@@ -7,7 +7,7 @@
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.2.6'
+const VERSION = 'v5.2.7'
 
 // ================================================================
 //  模块 A：节点过滤（沿用 v3.1）
@@ -628,9 +628,13 @@ function injectRuleProviders(config) {
       proxy: RP_PROXY
     }
     // ── szkane CiciAI（字节海外AI：Coze International/Luma AI，需新加坡节点）──
+    // v5.2.7 FIX#27-P1: upstream `Clash/Ruleset/CiciAi.list` 含 `USER-AGENT,TikTok*`，mihomo
+    //   classical provider 不识别 USER-AGENT 会触发 `parse classical rule [USER-AGENT,TikTok*]
+    //   error: unsupported rule type: USER-AGENT`。改用本仓库 mirrors/ 的清洗副本（仅删该行，
+    //   TikTok 域名已由 metaDomain('tiktok','tiktok') 覆盖）。
     config['rule-providers']['szkane-ciciai'] = {
       type: 'http', behavior: 'classical', format: 'text',
-      url: 'https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/CiciAi.list',
+      url: 'https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/CiciAi.list',
       path: './ruleset/szkane-CiciAi.list',
       interval: nextInterval(),
       proxy: RP_PROXY
@@ -668,9 +672,13 @@ function injectRuleProviders(config) {
       proxy: RP_PROXY
     }
     // ── szkane UK Apps ──
+    // v5.2.7 FIX#27-P1: upstream `Clash/Ruleset/UK.list` 含 `USER-AGENT,BBCiPlayer*`，
+    //   mihomo classical provider 不识别 USER-AGENT 会触发
+    //   `parse classical rule [USER-AGENT,BBCiPlayer*] error: unsupported rule type: USER-AGENT`。
+    //   改用本仓库 mirrors/ 的清洗副本（BBC 域名已由 metaDomain('bbc','bbc') 覆盖）。
     config['rule-providers']['szkane-uk'] = {
       type: 'http', behavior: 'classical', format: 'text',
-      url: 'https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/UK.list',
+      url: 'https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/UK.list',
       path: './ruleset/szkane-UK.list',
       interval: nextInterval(),
       proxy: RP_PROXY
@@ -748,9 +756,13 @@ function injectRuleProviders(config) {
       interval: nextInterval(),
       proxy: RP_PROXY
     }
+    // v5.2.7 FIX#27-P1: upstream `Grok/Grok.yaml` 含 `IP-CIDR         , 17.253.4.125`
+    //   （多余空格 + 缺 CIDR 掩码）会触发
+    //   `parse classical rule [IP-CIDR , 17.253.4.125] error: payloadRule error`。
+    //   改用本仓库 mirrors/ 的清洗副本（仅删该行 + 规整空格）。
     config['rule-providers']['acc-grok'] = {
       type: 'http', behavior: 'classical',
-      url: 'https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Grok/Grok.yaml',
+      url: 'https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/Grok.yaml',
       path: './ruleset/acc-Grok.yaml',
       interval: nextInterval(),
       proxy: RP_PROXY

--- a/OpenClash/CHANGELOG.md
+++ b/OpenClash/CHANGELOG.md
@@ -9,6 +9,17 @@
 
 ## Normal（`OpenClash(mihomo).sh`，非 Smart 内核 / url-test 版）
 
+### v5.2.7-oc-normal.1 (2026-04-23)
+
+- ★ **FIX#27-P1**（与 Clash Party v5.2.7 同步）：消除 mihomo 加载 3 个 classical rule-provider 的 parse warning
+  - 现象：OpenClash → mihomo 启动 / reload 日志反复打印
+    - `parse classical rule [USER-AGENT,TikTok*] error: unsupported rule type: USER-AGENT`
+    - `parse classical rule [USER-AGENT,BBCiPlayer*] error: unsupported rule type: USER-AGENT`
+    - `parse classical rule [IP-CIDR , 17.253.4.125] error: payloadRule error`
+  - 根因：upstream `szkane/ClashRuleSet` 的 `CiciAi.list` / `UK.list` 各有 1 行 USER-AGENT（mihomo 不识别）；upstream `Accademia/...` 的 `Grok.yaml` 有 1 行 `IP-CIDR         , 17.253.4.125`（多余空格 + 缺 mask）
+  - 修复：把 `szkane-ciciai` / `szkane-uk` / `acc-grok` 的 URL 切到本仓库 `mirrors/` 子目录的清洗副本（仅删问题行，剩余规则字节级一致）
+  - 跟随基线：Clash Party v5.2.7 → Normal bump 到 `v5.2.7-oc-normal.1`
+
 ### v5.2.6-oc-normal.1 (2026-04-22)
 
 - ★ **FIX#24-P0**（同构 bug 补齐）：Ruby `REGIONS` 哈希补 `KOR` 字面量
@@ -64,6 +75,13 @@
 ---
 
 ## Full（`OpenClash(mihomo-smart).sh`）
+
+### v5.2.7-oc-full.1 (2026-04-23)
+
+- ★ **FIX#27-P1**（与 Clash Party v5.2.7 同步）：消除 mihomo 加载 3 个 classical rule-provider 的 parse warning
+  - 现象 / 根因：同 Normal 版 v5.2.7-oc-normal.1 —— upstream `CiciAi.list` / `UK.list` 各 1 行 `USER-AGENT,*`、`Grok.yaml` 1 行 `IP-CIDR         , 17.253.4.125`（多余空格 + 缺 mask）
+  - 修复：把 `szkane-ciciai` / `szkane-uk` / `acc-grok` 的 URL 切到本仓库 `mirrors/` 子目录的清洗副本
+  - 跟随基线：Clash Party v5.2.7 → Full bump 到 `v5.2.7-oc-full.1`
 
 ### v5.2.6-oc-full.1 (2026-04-22)
 

--- a/OpenClash/OpenClash(mihomo).sh
+++ b/OpenClash/OpenClash(mihomo).sh
@@ -2,7 +2,7 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash v5.2.6-oc-normal.1 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
+# Clash v5.2.7-oc-normal.1 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
 # ============================================================================
 # 定位：与同目录 OpenClash(mihomo-smart).sh 规则 100% 等价的「非 Smart 内核」版本。
 #       两者唯一区别：9 个区域组从 type: smart（uselightgbm）换成 type: url-test。
@@ -17,14 +17,14 @@
 #   • ~977 条 rules
 #   • DNS fake-ip + 嗅探（HTTP/TLS/QUIC）+ nameserver-policy 救援
 #   • Ruby 阶段做：节点过滤 / 区域分类 / url-test 组生成 / TLS 指纹注入
-# 基线：Clash Party v5.2.5（唯一主线）── 任何规则/组/DNS 改动必须先改 Clash Party JS，
+# 基线：Clash Party v5.2.7（唯一主线）── 任何规则/组/DNS 改动必须先改 Clash Party JS，
 #       再同步到此文件。参见仓库根目录 CLAUDE.md / AGENTS.md。
 # 变更历史：见 `OpenClash/CHANGELOG.md`（Normal 部分）。
 # ============================================================================
 
 
 
-VERSION_TAG="v5.2.6-oc-normal.1"
+VERSION_TAG="v5.2.7-oc-normal.1"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -2365,11 +2365,14 @@ rule-providers:
     path: "./ruleset/szkane-AiDomain.list"
     interval: 89808
     proxy: "\U0001F6AB 受限网站"
+  # v5.2.7 FIX#27-P1: upstream CiciAi.list 含 USER-AGENT,TikTok* (mihomo classical 触发
+  # `parse classical rule [USER-AGENT,TikTok*] error: unsupported rule type: USER-AGENT`)
+  # 改用本仓库 mirrors/ 清洗副本；TikTok 域名已由 geosite:tiktok 覆盖。
   szkane-ciciai:
     type: http
     behavior: classical
     format: text
-    url: https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/CiciAi.list
+    url: https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/CiciAi.list
     path: "./ruleset/szkane-CiciAi.list"
     interval: 89844
     proxy: "\U0001F6AB 受限网站"
@@ -2405,11 +2408,14 @@ rule-providers:
     path: "./ruleset/szkane-Edutools.list"
     interval: 89927
     proxy: "\U0001F6AB 受限网站"
+  # v5.2.7 FIX#27-P1: upstream UK.list 含 USER-AGENT,BBCiPlayer* (mihomo classical 触发
+  # `parse classical rule [USER-AGENT,BBCiPlayer*] error: unsupported rule type: USER-AGENT`)
+  # 改用本仓库 mirrors/ 清洗副本；BBC 域名已由 geosite:bbc 覆盖。
   szkane-uk:
     type: http
     behavior: classical
     format: text
-    url: https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/UK.list
+    url: https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/UK.list
     path: "./ruleset/szkane-UK.list"
     interval: 89896
     proxy: "\U0001F6AB 受限网站"
@@ -2460,10 +2466,13 @@ rule-providers:
     path: "./ruleset/acc-AppleAI.yaml"
     interval: 90028
     proxy: "\U0001F6AB 受限网站"
+  # v5.2.7 FIX#27-P1: upstream Grok.yaml 含 `IP-CIDR         , 17.253.4.125`
+  # (多余空格 + 缺 CIDR 掩码 → `parse classical rule [IP-CIDR , 17.253.4.125] error: payloadRule error`)
+  # 改用本仓库 mirrors/ 清洗副本（仅删该行 + 规整空格）。
   acc-grok:
     type: http
     behavior: classical
-    url: https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Grok/Grok.yaml
+    url: https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/Grok.yaml
     path: "./ruleset/acc-Grok.yaml"
     interval: 90049
     proxy: "\U0001F6AB 受限网站"
@@ -4046,7 +4055,7 @@ cat > "$RUBY_SCRIPT" << 'RUBY_EOF'
 require 'yaml'
 require 'digest'
 
-VERSION = "v5.2.6-oc-normal.1"
+VERSION = "v5.2.7-oc-normal.1"
 
 STATUS_LOG = "/tmp/clash_normal_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }

--- a/OpenClash/OpenClash(mihomo-smart).sh
+++ b/OpenClash/OpenClash(mihomo-smart).sh
@@ -2,7 +2,7 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash Smart v5.2.6-oc-full.1 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
+# Clash Smart v5.2.7-oc-full.1 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
 # ============================================================================
 # 定位：对齐 Clash Party v5.2.4 JS 主线的 OpenClash 全量版本。
 #       与同目录 OpenClash(mihomo).sh（Normal）互补：
@@ -15,14 +15,14 @@
 #   • ~977 条 rules
 #   • DNS fake-ip + 嗅探（HTTP/TLS/QUIC）+ nameserver-policy 救援
 #   • Ruby 阶段做：节点过滤 / 区域分类 / Smart 组生成 / TLS 指纹注入
-# 基线：Clash Party v5.2.4（唯一主线）── 任何规则/组/DNS 改动必须先改 Clash Party JS，
+# 基线：Clash Party v5.2.7（唯一主线）── 任何规则/组/DNS 改动必须先改 Clash Party JS，
 #       再同步到此文件。参见仓库根目录 CLAUDE.md / AGENTS.md。
 # 变更历史：见 `OpenClash/CHANGELOG.md`（Full 部分）。
 # ============================================================================
 
 
 
-VERSION_TAG="v5.2.6-oc-full.1"
+VERSION_TAG="v5.2.7-oc-full.1"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -2363,11 +2363,14 @@ rule-providers:
     path: "./ruleset/szkane-AiDomain.list"
     interval: 89808
     proxy: "\U0001F6AB 受限网站"
+  # v5.2.7 FIX#27-P1: upstream CiciAi.list 含 USER-AGENT,TikTok* (mihomo classical 触发
+  # `parse classical rule [USER-AGENT,TikTok*] error: unsupported rule type: USER-AGENT`)
+  # 改用本仓库 mirrors/ 清洗副本；TikTok 域名已由 geosite:tiktok 覆盖。
   szkane-ciciai:
     type: http
     behavior: classical
     format: text
-    url: https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/CiciAi.list
+    url: https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/CiciAi.list
     path: "./ruleset/szkane-CiciAi.list"
     interval: 89844
     proxy: "\U0001F6AB 受限网站"
@@ -2403,11 +2406,14 @@ rule-providers:
     path: "./ruleset/szkane-Edutools.list"
     interval: 89927
     proxy: "\U0001F6AB 受限网站"
+  # v5.2.7 FIX#27-P1: upstream UK.list 含 USER-AGENT,BBCiPlayer* (mihomo classical 触发
+  # `parse classical rule [USER-AGENT,BBCiPlayer*] error: unsupported rule type: USER-AGENT`)
+  # 改用本仓库 mirrors/ 清洗副本；BBC 域名已由 geosite:bbc 覆盖。
   szkane-uk:
     type: http
     behavior: classical
     format: text
-    url: https://fastly.jsdelivr.net/gh/szkane/ClashRuleSet@main/Clash/Ruleset/UK.list
+    url: https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/UK.list
     path: "./ruleset/szkane-UK.list"
     interval: 89896
     proxy: "\U0001F6AB 受限网站"
@@ -2458,10 +2464,13 @@ rule-providers:
     path: "./ruleset/acc-AppleAI.yaml"
     interval: 90028
     proxy: "\U0001F6AB 受限网站"
+  # v5.2.7 FIX#27-P1: upstream Grok.yaml 含 `IP-CIDR         , 17.253.4.125`
+  # (多余空格 + 缺 CIDR 掩码 → `parse classical rule [IP-CIDR , 17.253.4.125] error: payloadRule error`)
+  # 改用本仓库 mirrors/ 清洗副本（仅删该行 + 规整空格）。
   acc-grok:
     type: http
     behavior: classical
-    url: https://fastly.jsdelivr.net/gh/Accademia/Additional_Rule_For_Clash@main/Grok/Grok.yaml
+    url: https://fastly.jsdelivr.net/gh/IvanSolis1989/Smart-Config-Kit@main/mirrors/Grok.yaml
     path: "./ruleset/acc-Grok.yaml"
     interval: 90049
     proxy: "\U0001F6AB 受限网站"
@@ -4044,7 +4053,7 @@ cat > "$RUBY_SCRIPT" << 'RUBY_EOF'
 require 'yaml'
 require 'digest'
 
-VERSION = "v5.2.6-oc-full.1"
+VERSION = "v5.2.7-oc-full.1"
 
 STATUS_LOG = "/tmp/clash_smart_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }

--- a/mirrors/CiciAi.list
+++ b/mirrors/CiciAi.list
@@ -1,0 +1,84 @@
+# Mirror of: https://github.com/szkane/ClashRuleSet/blob/main/Clash/Ruleset/CiciAi.list
+# Cleanup: dropped `USER-AGENT,TikTok*` — mihomo `classical` provider does not support
+# USER-AGENT rules (Surge / iOS leftover) and emits
+#   `parse classical rule [USER-AGENT,TikTok*] error: unsupported rule type: USER-AGENT`.
+# TikTok domain coverage is already provided by MetaCubeX geosite:tiktok (metaDomain('tiktok')).
+# CiciAI
+PROCESS-NAME,Cici
+PROCESS-NAME,Cici Helper (Renderer)
+PROCESS-NAME,Cici Helper
+DOMAIN-KEYWORD,ciciai
+DOMAIN-KEYWORD,dola
+DOMAIN-KEYWORD,byteoversea
+DOMAIN-SUFFIX,cici.com
+DOMAIN-SUFFIX,dola.com
+DOMAIN-SUFFIX,ciciai.com
+DOMAIN-SUFFIX,vcs-sg.byteoversea.com
+DOMAIN-SUFFIX,vmweb-va.ciciai.com
+DOMAIN-SUFFIX,mcs-va.ciciai.com
+DOMAIN-SUFFIX,lf-rc1.yhgfb-static.com
+DOMAIN-SUFFIX,itobsnssdk.com
+DOMAIN-SUFFIX,ciciaicdn.com
+DOMAIN-SUFFIX,abtestvm-sg.bytedance.com
+DOMAIN-SUFFIX,starling-oversea.byteoversea.com
+DOMAIN-SUFFIX,sf16-tcc-tos-sg.byteoversea.com
+DOMAIN-SUFFIX,bytedapm.com
+DOMAIN-SUFFIX,byteintl.net
+IP-CIDR,23.41.4.0/22,no-resolve
+
+
+#trae  + MarsCode Oversea version
+PROCESS-NAME,Trae Helper
+PROCESS-NAME,Trae Helper (Plugin)
+PROCESS-NAME,ai
+PROCESS-NAME,ai-agent
+PROCESS-NAME,ai-completion
+DOMAIN-SUFFIX,trae.ai
+DOMAIN-SUFFIX,bytednsdoc.com
+DOMAIN-SUFFIX,mchost.guru
+
+DOMAIN-SUFFIX,marscode.com
+DOMAIN-SUFFIX,zijieapi.com
+DOMAIN-SUFFIX,api.marscode.com
+DOMAIN-SUFFIX,api-sg-central.marscode.com
+DOMAIN-SUFFIX,mon-va.byteoversea.com
+DOMAIN-SUFFIX,sgali-mcs.byteoversea.com
+DOMAIN-SUFFIX,maliva-mcs.byteoversea.com
+DOMAIN-SUFFIX,mcs.zijieapi.com
+DOMAIN-SUFFIX,mon.zijieapi.com
+DOMAIN-SUFFIX,lf-cdn.marscode.com
+DOMAIN-SUFFIX,abtestvm.bytedance.com
+
+
+
+
+# TikTok
+PROCESS-NAME,TikTok
+DOMAIN-KEYWORD,tiktokcdn
+DOMAIN-SUFFIX,byteoversea.com
+DOMAIN-SUFFIX,ibytedtos.com
+DOMAIN-SUFFIX,ipstatp.com
+DOMAIN-SUFFIX,muscdn.com
+DOMAIN-SUFFIX,musical.ly
+DOMAIN-SUFFIX,tik-tokapi.com
+DOMAIN-SUFFIX,tiktok.com
+DOMAIN-SUFFIX,tiktokcdn.com
+DOMAIN-SUFFIX,tiktokv.com
+DOMAIN-SUFFIX,tiktokcdn-us.com
+
+# capcut
+PROCESS-NAME,CapCut
+DOMAIN-SUFFIX,ulikecam.com
+DOMAIN-SUFFIX,capcut.com
+DOMAIN-SUFFIX,capcutapi.com
+
+
+# lemon8
+PROCESS-NAME,Lemon8
+DOMAIN-KEYWORD,lemon8
+DOMAIN-SUFFIX,lemon8cdn.com
+DOMAIN-SUFFIX,lemon8-app.com
+DOMAIN-SUFFIX,ttwstatic.com
+DOMAIN-SUFFIX,ibyteimg.com
+DOMAIN-SUFFIX,snapkit.com
+DOMAIN-SUFFIX,pangle.io

--- a/mirrors/Grok.yaml
+++ b/mirrors/Grok.yaml
@@ -1,0 +1,9 @@
+# Mirror of: https://github.com/Accademia/Additional_Rule_For_Clash/blob/main/Grok/Grok.yaml
+# Cleanup: dropped malformed `IP-CIDR         , 17.253.4.125` (extra whitespace + missing CIDR mask)
+# triggering `parse classical rule [IP-CIDR , 17.253.4.125] error: payloadRule error` in mihomo.
+# Also normalized whitespace around commas in DOMAIN-SUFFIX entries.
+payload:
+  - DOMAIN-SUFFIX,x.ai
+  - DOMAIN-SUFFIX,grok.com
+  - DOMAIN-SUFFIX,featureassets.org
+  - DOMAIN-SUFFIX,xai.chronosphere.io

--- a/mirrors/UK.list
+++ b/mirrors/UK.list
@@ -1,0 +1,30 @@
+# Mirror of: https://github.com/szkane/ClashRuleSet/blob/main/Clash/Ruleset/UK.list
+# Cleanup: dropped `USER-AGENT,BBCiPlayer*` — mihomo `classical` provider does not
+# support USER-AGENT rules and emits
+#   `parse classical rule [USER-AGENT,BBCiPlayer*] error: unsupported rule type: USER-AGENT`.
+# BBC iPlayer domain coverage is already provided by MetaCubeX geosite:bbc (metaDomain('bbc')).
+DOMAIN-SUFFIX,uk
+DOMAIN-SUFFIX,co.uk
+
+# BBCiPlayer
+DOMAIN-KEYWORD,bbcfmt
+DOMAIN-KEYWORD,uk-live
+DOMAIN,aod-dash-uk-live.akamaized.net
+DOMAIN,aod-hls-uk-live.akamaized.net
+DOMAIN,vod-dash-uk-live.akamaized.net
+DOMAIN,vod-thumb-uk-live.akamaized.net
+DOMAIN-SUFFIX,bbc.co
+DOMAIN-SUFFIX,bbc.co.uk
+DOMAIN-SUFFIX,bbc.com
+DOMAIN-SUFFIX,bbc.net.uk
+DOMAIN-SUFFIX,bbcfmt.hs.llnwd.net
+DOMAIN-SUFFIX,bbci.co
+DOMAIN-SUFFIX,bbci.co.uk
+DOMAIN-SUFFIX,bidi.net.uk
+
+# BITESIZE
+DOMAIN-SUFFIX,emp.bbc.co.uk
+DOMAIN-SUFFIX,emp.bbci.co.uk
+DOMAIN-SUFFIX,uk-script.dotmetrics.net
+DOMAIN-SUFFIX,rm-script.dotmetrics.net
+DOMAIN-SUFFIX,dotmetrics.net


### PR DESCRIPTION
## Summary

mihomo (Clash Party / CMFA / OpenClash) currently spams these on every reload:

```
parse classical rule [USER-AGENT,TikTok*]    error: unsupported rule type: USER-AGENT
parse classical rule [USER-AGENT,BBCiPlayer*] error: unsupported rule type: USER-AGENT
parse classical rule [IP-CIDR , 17.253.4.125] error: payloadRule error
```

### Root cause

| Provider | Upstream file | Bad line |
|---|---|---|
| `szkane-ciciai` | `szkane/ClashRuleSet/Clash/Ruleset/CiciAi.list` L52 | `USER-AGENT,TikTok*` |
| `szkane-uk`     | `szkane/ClashRuleSet/Clash/Ruleset/UK.list` L5 | `USER-AGENT,BBCiPlayer*` |
| `acc-grok`      | `Accademia/Additional_Rule_For_Clash/Grok/Grok.yaml` L9 | `IP-CIDR         , 17.253.4.125` (extra spaces + missing CIDR mask) |

mihomo's `classical` provider rejects `USER-AGENT` (Surge / iOS-only) and bails on the malformed `IP-CIDR`. Functionally harmless (mihomo skips and continues) but each reload prints these errors.

### Fix

New `mirrors/` directory at repo root hosts byte-for-byte copies of the three upstream files **with only the offending lines removed**. The five mihomo-family products now point at jsdelivr-cached versions of those mirrors:

- `mirrors/CiciAi.list` — drops `USER-AGENT,TikTok*` (TikTok domains already 100% covered by `geosite:tiktok`)
- `mirrors/UK.list` — drops `USER-AGENT,BBCiPlayer*` (BBC domains already 100% covered by `geosite:bbc`)
- `mirrors/Grok.yaml` — drops `IP-CIDR , 17.253.4.125` (it's an Apple `time.apple.com` anycast IP, unrelated to Grok routing) + normalizes spacing around commas

### Sibling-audit (CLAUDE.md §1.5)

| Product | Loads CiciAi/UK/Grok? | USER-AGENT support? | Action |
|---|---|---|---|
| Clash Party Smart JS | yes | mihomo: NO | **fixed** → `v5.2.7` |
| Clash Party Normal JS | yes | mihomo: NO | **fixed** → `v5.2.7-normal.1` |
| CMFA YAML | yes | mihomo: NO | **fixed** → `v5.2.7-cmfa.1` |
| OpenClash Smart sh | yes | mihomo: NO | **fixed** → `v5.2.7-oc-full.1` |
| OpenClash Normal sh | yes | mihomo: NO | **fixed** → `v5.2.7-oc-normal.1` |
| Surge.conf | CiciAi+UK | Surge: **native** | not affected, no change |
| Loon.conf | CiciAi+UK | Loon: **native** | not affected, no change |
| Shadowrocket.conf | CiciAi+UK | SR: **native** | not affected, no change |
| QuantumultX.conf | CiciAi+UK | QX: **native** (`host-user-agent`) | not affected, no change |
| SingBox JSON | n/a | uses `route.rule_set` (.srs binary) | not affected |
| v2rayN Xray | n/a | uses Xray `routing.rules` | not affected |
| Passwall2 | n/a | uses `shunt_rules.lua` syntax | not affected |

### Self-check

```
$ python3 -c 'import yaml;d=yaml.safe_load(open("Clash Meta For Android/CMFA(mihomo).yaml"));...'
YAML loaded OK; rule-providers count: 387 rules: 961 proxy-groups: 37

$ ruby -ryaml -e '...' /tmp/oc_full_override_probe.yaml
OC full override yaml: providers=385 rules=975

$ ruby -ryaml -e '...' /tmp/oc_normal_override_probe.yaml
OC normal override yaml: providers=385 rules=975

$ python3 -c 'import yaml;g=yaml.safe_load(open("mirrors/Grok.yaml"));...'
Grok.yaml payload: 4 rules = ['DOMAIN-SUFFIX,x.ai', 'DOMAIN-SUFFIX,grok.com', 'DOMAIN-SUFFIX,featureassets.org', 'DOMAIN-SUFFIX,xai.chronosphere.io']
```

All 5 mihomo-family products contain exactly 3 occurrences of the new `IvanSolis1989/Smart-Config-Kit@main/mirrors/` URL pattern (15 hits total) and 0 occurrences of the original upstream URLs for these three providers.

### Caveats

- jsdelivr first-fetch warm-up is ~5 min after merge; cold cache resolves automatically
- Any future upstream additions to CiciAi.list / UK.list / Grok.yaml won't be picked up automatically — needs manual mirror refresh (acceptable trade-off for clean logs; mirror diff is small)

## Test plan

- [ ] Apply Clash Party `v5.2.7` JS via Sub-Store override; reload mihomo; tail logs — confirm zero `USER-AGENT` / `payloadRule` errors
- [ ] Same for CMFA `v5.2.7-cmfa.1`
- [ ] Same for OpenClash Normal & Smart `v5.2.7-oc-{normal,full}.1`
- [ ] Verify `RULE-SET,szkane-ciciai`, `RULE-SET,szkane-uk`, `RULE-SET,acc-grok` still resolve as expected (rules count unchanged, just minus the unsupported lines)

https://claude.ai/code/session_01AZVNZU5i6Bk99ZJnntpdwf

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZVNZU5i6Bk99ZJnntpdwf)_