### PR TITLE
fix(regions): 🌏 亚太 补 HK/TW/JP/KR · 🌎 美洲 补 US (FIX#28-P0)

### DIFF
--- a/Clash Meta For Android/CHANGELOG.md
+++ b/Clash Meta For Android/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 ---
 
+## v5.2.8-cmfa.3 (2026-04-23)
+
+- ★ **FIX#28-P0**（节点分类同构 bug 补齐）：🌏 亚太节点 filter 补 HK/TW/JP/KR 子串
+  - 现象：CMFA 侧用户订阅的香港/台湾/日韩节点进不了 🌏 亚太节点组。
+  - 根因：L486 亚太 filter 只匹配 `新加坡|Singapore|SGP|马来西亚|...|🇸🇬|🇲🇾|...`，未包含 HK/TW/JP/KR 任何标识 → mihomo 按 Go RE2 子串匹配时，港台日韩节点全部落空。与 Clash Party JS 主线语义不一致（`apacNodes = c.HK.concat(c.TW, c.CN, c.JP, c.KR, c.SG, c.APAC_OTHER)`）。
+  - 修复：
+    - L486 🌏 亚太节点 filter 头部补 `香港|HongKong|Hong\s*Kong|HKG|🇭🇰|台湾|台灣|Taiwan|Taipei|TPE|TWN|🇹🇼|日本|东京|大阪|Japan|Tokyo|Osaka|NRT|KIX|JPN|🇯🇵|韩国|首尔|Korea|Seoul|ICN|KOR|🇰🇷`（与香港/台湾/日韩节点 filter 关键词一致，避免裸 `HK`/`TW`/`JP`/`KR` 误命中 HKD / TWD 等非节点字符串）
+    - L495 🏡 亚太家宽 filter 同步扩展（两侧 lookahead/lookbehind 的子区域关键词都加）
+  - 💡 美洲节点（L540）已包含 `美国|United\s*States|USA|LAX|...|🇺🇸`，不需要改；欧洲/非洲亦已正确覆盖所属国家。
+  - 同构 bug 审计（CLAUDE.md §1.5 强制）：OpenClash Ruby Normal / Full 命中同构 bug，本 PR 一并修复（见 `OpenClash/CHANGELOG.md` v5.2.8-oc-normal.3 / v5.2.8-oc-full.3）。Clash Party JS / Normal JS / Shadowrocket / Surge / Loon / QX 核对均已有正确覆盖；SingBox / v2rayN 无运行时分类（N/A）。
+  - 跟随基线：Clash Party v5.2.8 → CMFA bump 到 `v5.2.8-cmfa.3`。
+
 ## v5.2.7-cmfa.1 (2026-04-23)
 
 - ★ **FIX#27-P1**：消除 mihomo 加载 3 个 classical rule-provider 的 parse warning（与 Clash Party v5.2.7 同步）

--- a/Clash Meta For Android/CMFA(mihomo).yaml
+++ b/Clash Meta For Android/CMFA(mihomo).yaml
@@ -1,5 +1,5 @@
 # ================================================================
-# Clash Smart v5.2.8-cmfa.2 - CMFA (Clash Meta for Android) 配置
+# Clash Smart v5.2.8-cmfa.3 - CMFA (Clash Meta for Android) 配置
 # Build: 2026-04-23
 # 架构：proxy-providers 订阅 + 18 url-test 区域组（9 全部 + 9 家宽）+ 28 业务策略组 + 373+ rule-providers
 # 基线：Clash Party v5.2.8（唯一主线）
@@ -483,7 +483,8 @@ proxy-groups:
   name: '🌏 亚太节点'
   use:
   - Subscribe
-  filter: '(?i)(新加坡|Singapore|SGP|马来西亚|Malaysia|印度尼西亚|印尼|Indonesia|泰国|Thailand|越南|Vietnam|菲律宾|Philippines|印度|India|澳大利亚|Australia|新西兰|New\s*Zealand|土耳其|Turkey|以色列|Israel|阿联酋|UAE|迪拜|Dubai|🇸🇬|🇲🇾|🇮🇩|🇹🇭|🇻🇳|🇵🇭|🇮🇳|🇦🇺)'
+  # v5.2.8-cmfa.3 FIX#28-P0: 🌏 亚太节点 应包含 HK/TW/JP/KR（原 filter 只匹配 SG/MY/ID/TH/... 导致港台日韩节点被排除；对齐 Clash Party 主线 apacNodes = HK+TW+CN+JP+KR+SG+APAC_OTHER）
+  filter: '(?i)(香港|HongKong|Hong\s*Kong|HKG|🇭🇰|台湾|台灣|Taiwan|Taipei|TPE|TWN|🇹🇼|日本|东京|大阪|Japan|Tokyo|Osaka|NRT|KIX|JPN|🇯🇵|韩国|首尔|Korea|Seoul|ICN|KOR|🇰🇷|新加坡|Singapore|SGP|马来西亚|Malaysia|印度尼西亚|印尼|Indonesia|泰国|Thailand|越南|Vietnam|菲律宾|Philippines|印度|India|澳大利亚|Australia|新西兰|New\s*Zealand|土耳其|Turkey|以色列|Israel|阿联酋|UAE|迪拜|Dubai|🇸🇬|🇲🇾|🇮🇩|🇹🇭|🇻🇳|🇵🇭|🇮🇳|🇦🇺)'
 - type: url-test
   url: 'https://www.gstatic.com/generate_204'
   interval: 120
@@ -492,7 +493,8 @@ proxy-groups:
   name: '🏡 亚太家宽'
   use:
   - Subscribe
-  filter: '(?i)((新加坡|Singapore|SGP|马来西亚|Malaysia|印度尼西亚|印尼|Indonesia|泰国|Thailand|越南|Vietnam|菲律宾|Philippines|印度|India|澳大利亚|Australia|新西兰|New\s*Zealand|土耳其|Turkey|以色列|Israel|阿联酋|UAE|迪拜|Dubai|🇸🇬|🇲🇾|🇮🇩|🇹🇭|🇻🇳|🇵🇭|🇮🇳|🇦🇺).*(resi(dential)?|home[-_ ]?ip|home[-_ ]?broadband|broadband|isp|家宽|家庭宽带|家庭住宅|住宅宽带|住宅|宽带)|(resi(dential)?|home[-_ ]?ip|home[-_ ]?broadband|broadband|isp|家宽|家庭宽带|家庭住宅|住宅宽带|住宅|宽带).*(新加坡|Singapore|SGP|马来西亚|Malaysia|印度尼西亚|印尼|Indonesia|泰国|Thailand|越南|Vietnam|菲律宾|Philippines|印度|India|澳大利亚|Australia|新西兰|New\s*Zealand|土耳其|Turkey|以色列|Israel|阿联酋|UAE|迪拜|Dubai|🇸🇬|🇲🇾|🇮🇩|🇹🇭|🇻🇳|🇵🇭|🇮🇳|🇦🇺))'
+  # v5.2.8-cmfa.3 FIX#28-P0: 🏡 亚太家宽 同步扩展（对齐 🌏 亚太节点），补 HK/TW/JP/KR 子串
+  filter: '(?i)((香港|HongKong|Hong\s*Kong|HKG|🇭🇰|台湾|台灣|Taiwan|Taipei|TPE|TWN|🇹🇼|日本|东京|大阪|Japan|Tokyo|Osaka|NRT|KIX|JPN|🇯🇵|韩国|首尔|Korea|Seoul|ICN|KOR|🇰🇷|新加坡|Singapore|SGP|马来西亚|Malaysia|印度尼西亚|印尼|Indonesia|泰国|Thailand|越南|Vietnam|菲律宾|Philippines|印度|India|澳大利亚|Australia|新西兰|New\s*Zealand|土耳其|Turkey|以色列|Israel|阿联酋|UAE|迪拜|Dubai|🇸🇬|🇲🇾|🇮🇩|🇹🇭|🇻🇳|🇵🇭|🇮🇳|🇦🇺).*(resi(dential)?|home[-_ ]?ip|home[-_ ]?broadband|broadband|isp|家宽|家庭宽带|家庭住宅|住宅宽带|住宅|宽带)|(resi(dential)?|home[-_ ]?ip|home[-_ ]?broadband|broadband|isp|家宽|家庭宽带|家庭住宅|住宅宽带|住宅|宽带).*(香港|HongKong|Hong\s*Kong|HKG|🇭🇰|台湾|台灣|Taiwan|Taipei|TPE|TWN|🇹🇼|日本|东京|大阪|Japan|Tokyo|Osaka|NRT|KIX|JPN|🇯🇵|韩国|首尔|Korea|Seoul|ICN|KOR|🇰🇷|新加坡|Singapore|SGP|马来西亚|Malaysia|印度尼西亚|印尼|Indonesia|泰国|Thailand|越南|Vietnam|菲律宾|Philippines|印度|India|澳大利亚|Australia|新西兰|New\s*Zealand|土耳其|Turkey|以色列|Israel|阿联酋|UAE|迪拜|Dubai|🇸🇬|🇲🇾|🇮🇩|🇹🇭|🇻🇳|🇵🇭|🇮🇳|🇦🇺))'
 - type: url-test
   url: 'https://www.gstatic.com/generate_204'
   interval: 120

--- a/OpenClash/CHANGELOG.md
+++ b/OpenClash/CHANGELOG.md
@@ -9,6 +9,17 @@
 
 ## Normal（`OpenClash(mihomo).sh`，非 Smart 内核 / url-test 版）
 
+### v5.2.8-oc-normal.3 (2026-04-23)
+
+- ★ **FIX#28-P0**（节点分类多归属）：🌏 亚太节点组缺 HK/TW/JP/KR、🌎 美洲节点组缺 US
+  - 现象（用户报告）：OpenClash 亚太组里看不到香港/台湾/日韩节点；美洲组里看不到美国节点。
+  - 根因：Ruby 分类循环用 `GROUP_MAP.each { ... break }`，每个节点的 region code 只会命中 `GROUP_MAP` 里第一个包含它的条目 → HK 永远停在 `"HK" => ["HK"]`、US 永远停在 `"US" => ["US"]`，永远走不到 `"APAC"` / `"AM"` 条目。而 Clash Party JS 主线语义是 `apacNodes = c.HK.concat(c.TW, c.CN, c.JP, c.KR, c.SG, c.APAC_OTHER)` / `americasNodes = c.US.concat(c.AM)`，子区域与所属大洲**同时归属**。
+  - 修复（L4275 ~ L4332）：
+    - `GROUP_MAP["APAC"]` 扩充为 `["HK", "TW", "JP", "KR", "SG", "IN", "TH", "VN", "MY", "ID", "PH", "AU", "NZ", "TR", "AE"]`
+    - `GROUP_MAP["AM"]` 扩充为 `["US", "CA", "MX", "BR", "AR"]`
+    - 分类循环去掉 `break` —— 同一节点可同时进入子区域组（香港/台湾/日韩/美国）与所属大洲组（亚太/美洲）
+  - 同构 bug 审计（CLAUDE.md §1.5 强制）：Ruby 双脚本 + CMFA YAML 均命中同构 bug，本 PR 一并修复（OpenClash Normal / OpenClash Full / CMFA）。Clash Party JS / Clash Party Normal JS / Shadowrocket / Surge / Loon / QX 经核对均已有正确覆盖，无需改动；SingBox / v2rayN 无运行时节点分类（N/A）。
+
 ### v5.2.7-oc-normal.1 (2026-04-23)
 
 - ★ **FIX#27-P1**（与 Clash Party v5.2.7 同步）：消除 mihomo 加载 3 个 classical rule-provider 的 parse warning
@@ -75,6 +86,13 @@
 ---
 
 ## Full（`OpenClash(mihomo-smart).sh`）
+
+### v5.2.8-oc-full.3 (2026-04-23)
+
+- ★ **FIX#28-P0**（节点分类多归属，与 Normal 同步）：
+  - 现象 / 根因 / 修复同 `v5.2.8-oc-normal.3`（L4273 ~ L4325 对应位置）。
+  - `GROUP_MAP["APAC"]` 扩展到 HK+TW+JP+KR+SG+其它亚太国家，`GROUP_MAP["AM"]` 扩展到 US+CA+MX+BR+AR，循环移除 `break`。
+  - 同构 bug 审计：见 Normal v5.2.8-oc-normal.3 条目。
 
 ### v5.2.7-oc-full.1 (2026-04-23)
 

--- a/OpenClash/OpenClash(mihomo).sh
+++ b/OpenClash/OpenClash(mihomo).sh
@@ -2,7 +2,7 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash v5.2.8-oc-normal.2 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
+# Clash v5.2.8-oc-normal.3 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
 # ============================================================================
 # 定位：与同目录 OpenClash(mihomo-smart).sh 规则 100% 等价的「非 Smart 内核」版本。
 #       两者唯一区别：18 个区域组（9 全部 + 9 家宽）从 type: smart（uselightgbm）换成 type: url-test。
@@ -24,7 +24,7 @@
 
 
 
-VERSION_TAG="v5.2.8-oc-normal.2"
+VERSION_TAG="v5.2.8-oc-normal.3"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -4195,7 +4195,7 @@ cat > "$RUBY_SCRIPT" << 'RUBY_EOF'
 require 'yaml'
 require 'digest'
 
-VERSION = "v5.2.8-oc-normal.2"
+VERSION = "v5.2.8-oc-normal.3"
 
 STATUS_LOG = "/tmp/clash_normal_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }
@@ -4272,15 +4272,22 @@ REGIONS = {
   "AE"  => /阿联酋|AE\b|UAE|Dubai|🇦🇪/i,
 }
 
+# v5.2.8-oc-normal.3 FIX#28-P0: GROUP_MAP 展平同源 bug
+#   原实现每个 code 只落入 GROUP_MAP 的首个命中条目（下方 each/break），导致：
+#     • HK/TW/JP/KR 只进香港/台湾/日韩子组，永远进不了 🌏 亚太节点
+#     • US 只进美国子组，永远进不了 🌎 美洲节点
+#   Clash Party JS 主线语义：区域大组 = 子区域并集（apacNodes = HK+TW+CN+JP+KR+SG+APAC_OTHER；
+#   americasNodes = US+AM）。修复：APAC 扩充至涵盖 HK/TW/JP/KR + 原 APAC_OTHER 集；AM 扩充至
+#   包含 US；分类循环移除 break，同一节点可同时进入子区域组与所属大洲组。
 GROUP_MAP = {
   "HK"     => ["HK"],
   "TW"     => ["TW"],
   "JP_KR"  => ["JP", "KR"],
   "US"     => ["US"],
   "EU"     => ["UK", "DE", "FR", "NL", "CH", "RU"],
-  "AM"     => ["CA", "MX", "BR", "AR"],
+  "AM"     => ["US", "CA", "MX", "BR", "AR"],
   "AF"     => ["ZA", "EG", "NG"],
-  "APAC"   => ["SG", "IN", "TH", "VN", "MY", "ID", "PH", "AU", "NZ"],
+  "APAC"   => ["HK", "TW", "JP", "KR", "SG", "IN", "TH", "VN", "MY", "ID", "PH", "AU", "NZ", "TR", "AE"],
 }
 GROUP_NAMES = {
   "HK"    => "🇭🇰 香港节点",
@@ -4319,11 +4326,11 @@ filtered_proxies.each do |p|
   code = classify.call(name)
   next if code.nil?
 
+  # v5.2.8-oc-normal.3 FIX#28-P0: 去掉 break，单节点可并入多个区域组（子区域 + 所属大洲）
   GROUP_MAP.each do |gkey, codes|
     if codes.include?(code)
       buckets[gkey] << name
       home_buckets[gkey] << name if is_home
-      break
     end
   end
 end

--- a/OpenClash/OpenClash(mihomo-smart).sh
+++ b/OpenClash/OpenClash(mihomo-smart).sh
@@ -2,7 +2,7 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash Smart v5.2.8-oc-full.2 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
+# Clash Smart v5.2.8-oc-full.3 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
 # ============================================================================
 # 定位：对齐 Clash Party v5.2.8 JS 主线的 OpenClash 全量版本。
 #       与同目录 OpenClash(mihomo).sh（Normal）互补：
@@ -22,7 +22,7 @@
 
 
 
-VERSION_TAG="v5.2.8-oc-full.2"
+VERSION_TAG="v5.2.8-oc-full.3"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -4193,7 +4193,7 @@ cat > "$RUBY_SCRIPT" << 'RUBY_EOF'
 require 'yaml'
 require 'digest'
 
-VERSION = "v5.2.8-oc-full.2"
+VERSION = "v5.2.8-oc-full.3"
 
 STATUS_LOG = "/tmp/clash_smart_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }
@@ -4270,15 +4270,22 @@ REGIONS = {
   "AE"  => /阿联酋|AE\b|UAE|Dubai|🇦🇪/i,
 }
 
+# v5.2.8-oc-full.3 FIX#28-P0: GROUP_MAP 展平同源 bug
+#   原实现每个 code 只落入 GROUP_MAP 的首个命中条目（下方 each/break），导致：
+#     • HK/TW/JP/KR 只进香港/台湾/日韩子组，永远进不了 🌏 亚太节点
+#     • US 只进美国子组，永远进不了 🌎 美洲节点
+#   Clash Party JS 主线语义：区域大组 = 子区域并集（apacNodes = HK+TW+CN+JP+KR+SG+APAC_OTHER；
+#   americasNodes = US+AM）。修复：APAC 扩充至涵盖 HK/TW/JP/KR + 原 APAC_OTHER 集；AM 扩充至
+#   包含 US；分类循环移除 break，同一节点可同时进入子区域组与所属大洲组。
 GROUP_MAP = {
   "HK"     => ["HK"],
   "TW"     => ["TW"],
   "JP_KR"  => ["JP", "KR"],
   "US"     => ["US"],
   "EU"     => ["UK", "DE", "FR", "NL", "CH", "RU"],
-  "AM"     => ["CA", "MX", "BR", "AR"],
+  "AM"     => ["US", "CA", "MX", "BR", "AR"],
   "AF"     => ["ZA", "EG", "NG"],
-  "APAC"   => ["SG", "IN", "TH", "VN", "MY", "ID", "PH", "AU", "NZ"],
+  "APAC"   => ["HK", "TW", "JP", "KR", "SG", "IN", "TH", "VN", "MY", "ID", "PH", "AU", "NZ", "TR", "AE"],
 }
 GROUP_NAMES = {
   "HK"    => "🇭🇰 香港节点",
@@ -4316,11 +4323,11 @@ filtered_proxies.each do |p|
 
   code = classify.call(name)
   next if code.nil?
+  # v5.2.8-oc-full.3 FIX#28-P0: 去掉 break，单节点可并入多个区域组（子区域 + 所属大洲）
   GROUP_MAP.each do |gkey, codes|
     if codes.include?(code)
       buckets[gkey] << name
       home_buckets[gkey] << name if is_home
-      break
     end
   end
 end


### PR DESCRIPTION
## 问题

用户报告：OpenClash 里 🌏 亚太节点组不包含 HK/TW/JP/KR 节点，🌎 美洲节点组不包含 US 节点。

**根因（OpenClash Ruby）**：分类循环 `GROUP_MAP.each { ... break }` 每个 region code 只落入首个命中条目 —— HK 永远停在 `"HK" => ["HK"]`，US 永远停在 `"US" => ["US"]`，永远走不到 `"APAC"` / `"AM"`。

**对照 Clash Party JS 主线语义**：
```js
var apacNodes     = c.HK.concat(c.TW, c.CN, c.JP, c.KR, c.SG, c.APAC_OTHER)
var americasNodes = c.US.concat(c.AM)
```
子区域节点**同时归属**所属大洲 —— OpenClash Ruby / CMFA YAML 偏离了这条语义。

## 同构 bug 审计（CLAUDE.md §1.5 强制）

| 产物 | 运行时分类位置 | 亚太 | 美洲 | 处理 |
|---|---|:-:|:-:|---|
| Clash Party Smart JS | `apacNodes = c.HK.concat(...)` | ✓ | ✓ | 基线，无需改 |
| Clash Party Normal JS | 同上 | ✓ | ✓ | 基线，无需改 |
| **OpenClash Normal** | Ruby `GROUP_MAP` + break | ❌ | ❌ | **本 PR 修复** |
| **OpenClash Full** | Ruby `GROUP_MAP` + break | ❌ | ❌ | **本 PR 修复** |
| **CMFA YAML** | mihomo `filter:` 正则 | ❌ | ✓ | **本 PR 修复（仅亚太）** |
| Shadowrocket | `policy-regex-filter` | ✓ | ✓ | 已正确覆盖 |
| Surge | `policy-regex-filter` | ✓ | ✓ | 已正确覆盖 |
| Loon | `NameRegex FilterKey` | ✓ | ✓ | 已正确覆盖 |
| Quantumult X | `server-tag-regex` | ✓ | ✓ | 已正确覆盖 |
| SingBox Full | 静态 outbound 列表 | N/A | N/A | 无运行时分类 |
| v2rayN Xray | 路由规则无节点分类 | N/A | N/A | 无运行时分类 |

## 修复

### OpenClash Normal + Full (Ruby)
- `GROUP_MAP["APAC"]` 扩展到 `["HK", "TW", "JP", "KR", "SG", "IN", "TH", "VN", "MY", "ID", "PH", "AU", "NZ", "TR", "AE"]`
- `GROUP_MAP["AM"]` 扩展到 `["US", "CA", "MX", "BR", "AR"]`
- 分类循环移除 `break` —— 同一节点可同时归入子区域组与所属大洲组

### CMFA YAML
- 🌏 亚太节点 filter 头部补 `香港|HongKong|Hong\s*Kong|HKG|🇭🇰|台湾|台灣|Taiwan|Taipei|TPE|TWN|🇹🇼|日本|东京|大阪|Japan|Tokyo|Osaka|NRT|KIX|JPN|🇯🇵|韩国|首尔|Korea|Seoul|ICN|KOR|🇰🇷`
- 🏡 亚太家宽 filter 同步扩展（两侧 lookbehind/lookahead 都加）
- 避免裸 `HK`/`TW`/`JP`/`KR` 以防 HKD/TWD 等误命中（与 🇭🇰 香港节点 / 🇹🇼 台湾节点 / 🇯🇵 日韩节点 filter 的关键词策略一致）

### 版本号同步（CLAUDE.md §1.3）
- CMFA: `v5.2.8-cmfa.2` → **`v5.2.8-cmfa.3`**
- OpenClash Normal: `v5.2.8-oc-normal.2` → **`v5.2.8-oc-normal.3`**
- OpenClash Full: `v5.2.8-oc-full.2` → **`v5.2.8-oc-full.3`**

## 自检

- [x] `ruby -c` 两份提取的 Ruby heredoc 都 `Syntax OK`
- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` CMFA YAML 合法
- [x] CMFA YAML `proxy-groups` 总数仍为 46（18 区域 + 28 业务，无增删）
- [x] CMFA 🌏 亚太 filter 里 `香港/HongKong/HKG/🇭🇰/台湾/Taiwan/TWN/🇹🇼/日本/Japan/JPN/🇯🇵/韩国/Korea/KOR/🇰🇷` 全部命中
- [x] OpenClash Ruby `GROUP_MAP` APAC 含 `["HK", "TW", "JP", "KR", ...]`、AM 含 `["US", ...]`
- [x] 分类循环已移除 `break`（两份脚本都验证）
- [x] Ruby 模拟跑：HK 节点同时进入 HK + APAC 组；US 节点同时进入 US + AM 组

## Test plan

- [ ] 在 OpenClash Normal 路由器上 reload 一份含 HK/US 节点的订阅，确认 🌏 亚太节点 列表里能看到香港节点、🌎 美洲节点列表里能看到美国节点
- [ ] OpenClash Full（Smart/LightGBM 版）同样验证
- [ ] CMFA 导入 YAML 后，在 App 的代理组页面展开 🌏 亚太节点 / 🏡 亚太家宽，确认港台日韩节点都在列

https://claude.ai/code/session_01PLxUAfLyCbCAKHSsyGzCmE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLxUAfLyCbCAKHSsyGzCmE)_