### PR TITLE
fix(singbox+v2rayn): 补齐港澳台 / 国际版 B 站分流

### DIFF
--- a/SingBox/CHANGELOG.md
+++ b/SingBox/CHANGELOG.md
@@ -5,6 +5,29 @@
 
 ---
 
+## v5.2.8-sing.2 (2026-04-23) — 修复港澳台 B 站（szkane-bilihmt）缺失
+
+- ★ FIX：Full 配置之前**静默丢失**了 `szkane-bilihmt`（港澳台哔哩哔哩）。
+  - 根因：`SingBox(sing-box)-generator.js` 的 `toSrsUrl()` 只识别 MetaCubeX `meta-rules-dat@meta/*.mrs` 和 DustinWin ads 两种 URL；szkane 的 `ClashRuleSet@main/Clash/Ruleset/BilibiliHMT.list` 不匹配 → provider 被 `filter(Boolean)` 丢弃 → `RULE-SET,szkane-bilihmt,🇭🇰 香港流媒体` 规则也被 `availableRuleSets` 过滤成 `null`。
+  - 结果：用户在 sing-box 上访问港澳台番剧域名（如 `p.bstarstatic.com` / `upos-bstar-*.akamaized.net`）会落到后续规则或 FINAL，不会路由到 🇭🇰 香港流媒体，可能触发港澳台 B 站 412 校验。
+- ★ 修法：在 `toSingRule()` 的 `RULE-SET` 分支里特判 `szkane-bilihmt`，用内联默认规则（`domain` × 5 / `domain_suffix` × 3 / `ip_cidr` × 13，共 21 条，与 szkane 上游一致）替代 remote rule_set 引用。
+  - sing-box 同一默认规则内 `domain` / `domain_suffix` / `ip_cidr` 默认 OR 组合（见 [sing-box Route Rule](https://sing-box.sagernet.org/configuration/route/rule/)）。
+- ★ Full 产物 `_meta.version` bump 到 `v5.2.8-sing.2`。
+
+### 自检摘要
+
+- `node SingBox/SingBox(sing-box)-generator.js` 重新生成后：
+  - `route.rules` = 624（比 sing.1 的 623 多 1 条，即恢复的 HMT 规则）
+  - 其中含有 `outbound: "🇭🇰 香港流媒体"` 且 `domain_suffix` 包含 `bilibili.com`/`bilibili.tv`/`acgvideo.com` 的 1 条内联规则
+  - `outbounds` selector/urltest 数仍为 47
+- JSON 合法性：`python3 -c 'import json;json.load(open("SingBox/SingBox(sing-box)-full.json"))'` 通过。
+
+### 官方文档证据
+
+- [sing-box Route Rule](https://sing-box.sagernet.org/configuration/route/rule/)：默认规则同类字段（`domain` / `domain_suffix` / `domain_keyword` / `ip_cidr` / `ip_is_private` 等）以 `||` 组合，跨类以 `&&` 组合——单条 inline 规则里混用 domain/ip_cidr 的 OR 语义正确。
+
+---
+
 ## v5.2.6-sing.5 (2026-04-23) — 删除 SingBox 非 Full 产物
 
 - ★ 删除旧的非 Full SingBox JSON 产物，本目录只保留 Full 配置。

--- a/SingBox/SingBox(sing-box)-full.json
+++ b/SingBox/SingBox(sing-box)-full.json
@@ -12,7 +12,7 @@
     },
     "_meta": {
       "name": "SingBox Smart Full",
-      "version": "v5.2.8-sing.1",
+      "version": "v5.2.8-sing.2",
       "build": "2026-04-23",
       "baseline": "Clash Party v5.2.8",
       "changelog": "见 SingBox/CHANGELOG.md"
@@ -3231,6 +3231,37 @@
         ],
         "action": "route",
         "outbound": "📺 国内流媒体"
+      },
+      {
+        "domain": [
+          "p-bstarstatic.akamaized.net",
+          "p.bstarstatic.com",
+          "upos-bstar-mirrorakam.akamaized.net",
+          "upos-bstar1-mirrorakam.akamaized.net",
+          "upos-hz-mirrorakam.akamaized.net"
+        ],
+        "domain_suffix": [
+          "acgvideo.com",
+          "bilibili.com",
+          "bilibili.tv"
+        ],
+        "ip_cidr": [
+          "45.43.32.234/32",
+          "103.151.150.0/23",
+          "119.29.29.29/32",
+          "128.1.62.200/32",
+          "128.1.62.201/32",
+          "150.116.92.250/32",
+          "164.52.33.178/32",
+          "164.52.33.182/32",
+          "164.52.76.18/32",
+          "203.107.1.33/32",
+          "203.107.1.34/32",
+          "203.107.1.65/32",
+          "203.107.1.66/32"
+        ],
+        "action": "route",
+        "outbound": "🇭🇰 香港流媒体"
       },
       {
         "domain_suffix": [

--- a/SingBox/SingBox(sing-box)-generator.js
+++ b/SingBox/SingBox(sing-box)-generator.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const vm = require('vm');
 
-const VERSION = 'v5.2.8-sing.1';
+const VERSION = 'v5.2.8-sing.2';
 const BUILD = '2026-04-23';
 const BASELINE = 'Clash Party v5.2.8';
 
@@ -312,12 +312,52 @@ function isRejectTarget(target) {
   return target === 'REJECT' || target === ADS_OUTBOUND;
 }
 
+// szkane/ClashRuleSet BilibiliHMT.list 为 Clash 私有 .list 文本，
+// MetaCubeX/meta-rules-dat 没有对应的 .srs，无法作为 sing-box remote rule_set 使用。
+// 将 21 条原始条目内联到一条默认规则里；sing-box 对同一分类下的
+// domain / domain_suffix / ip_cidr 默认按 OR 组合（见官方 route/rule 文档）。
+const SZKANE_BILIHMT_RULE = {
+  domain: [
+    'p-bstarstatic.akamaized.net',
+    'p.bstarstatic.com',
+    'upos-bstar-mirrorakam.akamaized.net',
+    'upos-bstar1-mirrorakam.akamaized.net',
+    'upos-hz-mirrorakam.akamaized.net'
+  ],
+  domain_suffix: [
+    'acgvideo.com',
+    'bilibili.com',
+    'bilibili.tv'
+  ],
+  ip_cidr: [
+    '45.43.32.234/32',
+    '103.151.150.0/23',
+    '119.29.29.29/32',
+    '128.1.62.200/32',
+    '128.1.62.201/32',
+    '150.116.92.250/32',
+    '164.52.33.178/32',
+    '164.52.33.182/32',
+    '164.52.76.18/32',
+    '203.107.1.33/32',
+    '203.107.1.34/32',
+    '203.107.1.65/32',
+    '203.107.1.66/32'
+  ]
+};
+
 function toSingRule(ruleText, availableRuleSets) {
   if (typeof ruleText !== 'string') return null;
   const parts = ruleText.split(',');
   const type = parts[0];
 
   if (type === 'RULE-SET') {
+    if (parts[1] === 'szkane-bilihmt') {
+      if (isRejectTarget(parts[2])) {
+        return { ...SZKANE_BILIHMT_RULE, action: 'reject' };
+      }
+      return { ...SZKANE_BILIHMT_RULE, action: 'route', outbound: parts[2] };
+    }
     if (!availableRuleSets.has(parts[1])) return null;
     if (isRejectTarget(parts[2])) return { rule_set: [parts[1]], action: 'reject' };
     return { rule_set: [parts[1]], action: 'route', outbound: parts[2] };

--- a/v2rayN/CHANGELOG.md
+++ b/v2rayN/CHANGELOG.md
@@ -7,6 +7,35 @@
 
 ---
 
+## v5.2.8-v2n.1 (2026-04-23) — 补齐港澳台 / 国际版 B 站分流，主线对齐 v5.2.8
+
+本轮补齐与 Clash Party v5.2.7 / v5.2.8 的主线同步欠账，以及港澳台 / 国际版 B 站在 Xray 路径的规则缺失。
+
+### 改动
+
+- ★ **FIX#v2n-07**：新增 `scki-019-hmt-media`（港澳台 B 站 → 代理）
+  - 基线 `Clash Party/ClashParty(mihomo-smart).js:1555` 将 `RULE-SET,szkane-bilihmt` 归入 `🇭🇰 香港流媒体`；Xray 三出站模型下降级为 `proxy`。
+  - szkane 的 `ClashRuleSet@main/Clash/Ruleset/BilibiliHMT.list` 是 Clash 私有 `.list`，xray 的 `geosite.dat` 不含对应分类，因此**内联**上游 21 条（5 DOMAIN / 3 DOMAIN-SUFFIX / 13 IP-CIDR）。
+  - **放置在 `scki-018-cn-media` 之前**：xray 与 mihomo 一样按数组顺序评估，`geosite:bilibili` 里包含 `bilibili.com` 后缀，若 HMT 排在 018 之后会先被 018 捕获命中直连 → 港澳台番剧 412。
+- ★ **FIX#v2n-08**：新增 `scki-019a-sea-media`（国际版 B 站 → 代理）
+  - 基线将 `RULE-SET,biliintl` 归入 `📺 东南亚流媒体`；v2rayN Xray 三出站下降级为 `proxy`。
+  - 用 `geosite:biliintl`（v2fly `geosite.dat` 标准分类）；若用户 geosite 不含该分类，会自然回落到 `scki-040-gfw` → proxy，语义不变。
+- ★ 主线对齐：`scki-000-meta` remarks 由 `v5.2.6-v2n.3` / `Baseline Clash Party v5.2.6` bump 到 `v5.2.8-v2n.1` / `Baseline Clash Party v5.2.8`（前两次 v5.2.7 / v5.2.8 主线 bump 未同步 v2rayN，一并补上）。
+
+### 官方文档证据
+
+- [v2rayN Wiki — 自定义路由规则](https://github.com/2dust/v2rayN/wiki/%E9%85%8D%E7%BD%AE%E6%95%99%E7%A8%8B-%E8%B7%AF%E7%94%B1)：自定义路由规则为数组，每项是一条 Xray 路由规则对象（顶层仍为数组保持不变）。
+- [Xray Routing — domain prefix](https://xtls.github.io/config/routing.html)：`geosite:*` / `domain:*` / 纯域名 / IP-CIDR 的匹配语义；路由按规则数组**顺序**评估，首条命中立即出站。
+
+### 自检
+
+- JSON 合法 ✓
+- 对象总数 32（启用 31 + 禁用 metadata 1）✓
+- `outboundTag` 集合仍为 `{proxy, direct, block}` ✓
+- 规则顺序：`scki-019-hmt-media` < `scki-018-cn-media` < `scki-019a-sea-media` ✓（python 断言通过）
+
+---
+
 ## v5.2.6-v2n.3 (2026-04-23) — 改为官方规则数组 + 移除悬空 dns-out
 
 本轮处理 P0 兼容性审查中 v2rayN Xray 路径的导入格式与 outboundTag 问题。

--- a/v2rayN/v2rayN(xray).json
+++ b/v2rayN/v2rayN(xray).json
@@ -2,7 +2,7 @@
     {
       "id": "scki-000-meta",
       "enabled": false,
-      "remarks": "Smart-Config-Kit v5.2.6-v2n.3 | Build 2026-04-23 | Baseline Clash Party v5.2.6 | changelog: v2rayN/CHANGELOG.md",
+      "remarks": "Smart-Config-Kit v5.2.8-v2n.1 | Build 2026-04-23 | Baseline Clash Party v5.2.8 | changelog: v2rayN/CHANGELOG.md",
       "outboundTag": "direct",
       "domain": [
         "domain:smart-config-kit.invalid"
@@ -240,6 +240,41 @@
       "network": "tcp,udp"
     },
     {
+      "id": "scki-019-hmt-media",
+      "enabled": true,
+      "remarks": "港澳台 B 站 (szkane BilibiliHMT: bstar/upos-bstar/bilibili.tv 等) → 代理；必须排在 scki-018-cn-media 之前，否则 geosite:bilibili 会先命中直连导致 412",
+      "outboundTag": "proxy",
+      "domain": [
+        "p-bstarstatic.akamaized.net",
+        "p.bstarstatic.com",
+        "upos-bstar-mirrorakam.akamaized.net",
+        "upos-bstar1-mirrorakam.akamaized.net",
+        "upos-hz-mirrorakam.akamaized.net",
+        "domain:acgvideo.com",
+        "domain:bilibili.com",
+        "domain:bilibili.tv"
+      ],
+      "ip": [
+        "45.43.32.234/32",
+        "103.151.150.0/23",
+        "119.29.29.29/32",
+        "128.1.62.200/32",
+        "128.1.62.201/32",
+        "150.116.92.250/32",
+        "164.52.33.178/32",
+        "164.52.33.182/32",
+        "164.52.76.18/32",
+        "203.107.1.33/32",
+        "203.107.1.34/32",
+        "203.107.1.65/32",
+        "203.107.1.66/32"
+      ],
+      "port": "",
+      "protocol": [],
+      "inboundTag": [],
+      "network": "tcp,udp"
+    },
+    {
       "id": "scki-018-cn-media",
       "enabled": true,
       "remarks": "国内流媒体 (B 站 / 爱奇艺 / 优酷 / 腾讯视频) → 直连",
@@ -251,6 +286,20 @@
         "geosite:tencentvideo",
         "geosite:mgtv",
         "geosite:douyin"
+      ],
+      "ip": [],
+      "port": "",
+      "protocol": [],
+      "inboundTag": [],
+      "network": "tcp,udp"
+    },
+    {
+      "id": "scki-019a-sea-media",
+      "enabled": true,
+      "remarks": "东南亚流媒体 (biliintl 国际版 B 站) → 代理；v2rayN Xray 只有 proxy/direct/block 三出站，STREAM_SEA 区域组在此降级为 proxy",
+      "outboundTag": "proxy",
+      "domain": [
+        "geosite:biliintl"
       ],
       "ip": [],
       "port": "",


### PR DESCRIPTION
## 背景

用户提问「`szkane-bilihmt` / `bilibili` / `biliintl` 是否分进了正确的代理组」。
对 10 份产物做了同构审计后发现：

| 产物 | bilibili (大陆) | szkane-bilihmt (港澳台) | biliintl (国际) |
|---|---|---|---|
| Clash Party / CMFA / OpenClash ×2 / SR / Surge / Loon / QX | ✅ 📺 国内流媒体 | ✅ 🇭🇰 香港流媒体 | ✅ 📺 东南亚流媒体 |
| **SingBox Full** | ✅ | **❌ 缺失** | ✅ |
| **v2rayN Xray** | ✅ direct | **❌ 缺失** | **❌ 缺失** |

本 PR 修这两处欠账。

## 改动

### 1. SingBox Full — `v5.2.8-sing.2`

**根因**：`SingBox/SingBox(sing-box)-generator.js` 的 `toSrsUrl()` 只识别 MetaCubeX `meta-rules-dat@meta/*.mrs` 和 DustinWin ads 两种 URL。szkane 的 `ClashRuleSet@main/Clash/Ruleset/BilibiliHMT.list` 不匹配 → provider 被 `filter(Boolean)` 静默丢弃 → 对应 `RULE-SET,szkane-bilihmt,🇭🇰 香港流媒体` 规则也被 `availableRuleSets` 过滤成 `null`。

**修法**：在 `toSingRule()` 的 `RULE-SET` 分支对 `szkane-bilihmt` 特判，用**内联默认规则**替代 remote rule_set 引用。上游 21 条（5 `DOMAIN` + 3 `DOMAIN-SUFFIX` + 13 `IP-CIDR`）写进一条 sing-box 规则——同类字段（`domain` / `domain_suffix` / `ip_cidr`）在一条默认规则内默认 OR 组合（[sing-box Route Rule](https://sing-box.sagernet.org/configuration/route/rule/)）。

### 2. v2rayN Xray — `v5.2.8-v2n.1`

- 新增 **`scki-019-hmt-media`**（港澳台 B 站 → proxy）
  - 放在 `scki-018-cn-media` **之前**：v2fly `geosite.dat` 的 `geosite:bilibili` 含 `bilibili.com` 后缀，若排在 018 之后会被先命中直连导致港澳台番剧 412。
  - 内联 szkane 的 21 条规则（domain + IP-CIDR）。
- 新增 **`scki-019a-sea-media`**（国际版 B 站 → proxy）
  - `geosite:biliintl`（v2fly 标准分类）。Xray 三出站模型下 `📺 东南亚流媒体` 降级为 `proxy`。
- 顺带主线对齐：`scki-000-meta` remarks 由 `v5.2.6-v2n.3 / Baseline v5.2.6` → `v5.2.8-v2n.1 / Baseline v5.2.8`（前两次主线 bump 未同步 v2rayN，一并补上）。

## 影响面

| 文件 | 改动 |
|---|---|
| `SingBox/SingBox(sing-box)-generator.js` | `VERSION` bump，`toSingRule()` 加 szkane-bilihmt 特判，新增 `SZKANE_BILIHMT_RULE` 常量 |
| `SingBox/SingBox(sing-box)-full.json` | 由 generator 重新生成；`route.rules` 623 → 624；新增 1 条 HMT inline 规则 |
| `SingBox/CHANGELOG.md` | 新增 `v5.2.8-sing.2` 段 |
| `v2rayN/v2rayN(xray).json` | 新增 2 条规则；对象总数 30 → 32；meta bump |
| `v2rayN/CHANGELOG.md` | 新增 `v5.2.8-v2n.1` 段 |

其他 8 份产物（Clash Party / CMFA / OpenClash ×2 / Shadowrocket / Surge / Loon / QX）基线上已经分流正确，无需改动——已在提问阶段完成同构审计。

## 自检（CLAUDE.md §5 + 额外）

- SingBox：`route.rules` = 624，含 1 条 `outbound: 🇭🇰 香港流媒体` + `domain_suffix` 包含 `bilibili.com`/`bilibili.tv`/`acgvideo.com` 的内联规则；`_meta.version = v5.2.8-sing.2`；outbounds selector/urltest = 47。
- v2rayN：32 条规则，`outboundTag` 集合 `{proxy, direct, block}`；顺序断言 `scki-019-hmt-media < scki-018-cn-media < scki-019a-sea-media` 通过；meta remarks 含 `v5.2.8-v2n.1` + `Baseline Clash Party v5.2.8`。
- JSON / YAML 合法性：SingBox Full、v2rayN、CMFA 均 parse 通过。
- OpenClash full override 探测：`rule-providers` / `rules` 顶层键各 1 个，providers=385，rules=975。

## 官方文档证据

- [sing-box Route Rule](https://sing-box.sagernet.org/configuration/route/rule/)：默认规则同类字段 `||` 组合，跨类 `&&` 组合——单条 inline 规则混用 domain/ip_cidr 的 OR 语义正确。
- [v2rayN 自定义路由规则](https://github.com/2dust/v2rayN/wiki/%E9%85%8D%E7%BD%AE%E6%95%99%E7%A8%8B-%E8%B7%AF%E7%94%B1)：顶层数组格式。
- [Xray Routing](https://xtls.github.io/config/routing.html)：`geosite:*` / `domain:*` / CIDR 语义；规则**按数组顺序**评估，首条命中即出站。

## Test plan

- [ ] sing-box 1.11+ 导入 Full，访问 `p.bstarstatic.com` / `api.global.bilibili.com`（bstar app）应路由到 🇭🇰 香港流媒体出站，不落 FINAL。
- [ ] sing-box 访问 `bstar.bilibili.tv` 应命中 biliintl rule_set → 📺 东南亚流媒体。
- [ ] sing-box 访问 `api.bilibili.com`（国内）应命中 `geosite-bilibili` → 📺 国内流媒体。
- [ ] v2rayN（Xray 核）导入 `v2rayN(xray).json`，港澳台番剧 domain / IP 应走 proxy（不 412）；国内 B 站仍走 direct。
- [ ] v2rayN 访问 bstar.bilibili.tv 应命中 `geosite:biliintl` → proxy。

https://claude.ai/code/session_01YLR8TfHY2uqhMyQSXL8sm7

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLR8TfHY2uqhMyQSXL8sm7)_