### PR TITLE
docs(readme): DNS 图去掉 subgraph 外框，字号放大到 18px

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,42 +263,37 @@ Clash Party / CMFA / OpenClash 都采用同一套分层方案（详见 `Clash Pa
 config:
   flowchart:
     htmlLabels: true
-    wrappingWidth: 800
+    wrappingWidth: 1000
+    nodeSpacing: 50
+    rankSpacing: 60
+  themeVariables:
+    fontSize: 18px
 ---
 flowchart TB
-    Start(["🚀&nbsp;客户端启动"])
+    Start(["<b>🚀 客户端启动</b>"])
 
-    subgraph S1 ["① default-nameserver · 明文 UDP · 仅用于 bootstrap"]
-      B["<b>223.5.5.5</b>&nbsp;·&nbsp;<b>119.29.29.29</b>&nbsp;·&nbsp;<b>1.1.1.1</b>&nbsp;·&nbsp;<b>8.8.8.8</b><br/>作用：启动时解析下方 DoH 服务的域名（dns.alidns.com 等）<br/>只查 4 个 IP，不参与任何业务查询&nbsp;→&nbsp;零暴露面"]
-    end
+    L1["<b>① default-nameserver</b> &nbsp;·&nbsp; 明文 UDP &nbsp;·&nbsp; 仅用于 bootstrap<br/><br/><b>223.5.5.5 &nbsp;·&nbsp; 119.29.29.29 &nbsp;·&nbsp; 1.1.1.1 &nbsp;·&nbsp; 8.8.8.8</b><br/>启动时解析下方 DoH 服务的域名（dns.alidns.com 等）<br/>只查 4 个 IP，不参与任何业务查询 &nbsp;→&nbsp; 零暴露面"]
 
-    Start --> B
-    B ==>|"bootstrap 成功后，所有业务查询全走加密 DoH"| Gate
+    Gate{{"<b>🔀 按域名性质分三路查询</b>"}}
 
-    Gate{{"🔀&nbsp;按域名性质分三路查询"}}
+    L2["<b>② nameserver</b> &nbsp;·&nbsp; 国内域名主通道 &nbsp;·&nbsp; DoH<br/><br/><b>AliDNS</b> &nbsp; https://223.5.5.5/dns-query<br/><b>DNSPod</b> &nbsp; https://doh.pub/dns-query<br/>大陆站点 / 国内 CDN 用国内权威 DoH &nbsp;→&nbsp; 不被 ISP 记录"]
 
-    subgraph S2 ["② nameserver · 国内域名主通道 · DoH"]
-      N["<b>AliDNS</b>&nbsp;&nbsp;https://223.5.5.5/dns-query<br/><b>DNSPod</b>&nbsp;https://doh.pub/dns-query<br/>作用：大陆站点&nbsp;/&nbsp;国内 CDN 用国内权威 DoH&nbsp;→&nbsp;不被 ISP 记录"]
-    end
+    L3["<b>③ proxy-server-nameserver</b> &nbsp;·&nbsp; 机场节点域名解析 &nbsp;·&nbsp; DoH<br/><br/><b>Cloudflare</b> &nbsp; https://1.1.1.1/dns-query<br/><b>Google</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://8.8.8.8/dns-query<br/><b>AliDNS</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://223.5.5.5/dns-query<br/><b>DNSPod</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://doh.pub/dns-query<br/>解析 node.xxx-airport.com 走加密 DoH<br/>→&nbsp; 节点域名与 IP 都不暴露给 ISP，也不被 DNS 污染"]
 
-    subgraph S3 ["③ proxy-server-nameserver · 机场节点域名解析 · DoH"]
-      P["<b>Cloudflare</b>&nbsp;https://1.1.1.1/dns-query<br/><b>Google</b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;https://8.8.8.8/dns-query<br/><b>AliDNS</b>&nbsp;&nbsp;&nbsp;&nbsp;https://223.5.5.5/dns-query<br/><b>DNSPod</b>&nbsp;&nbsp;&nbsp;&nbsp;https://doh.pub/dns-query<br/>作用：解析&nbsp;node.xxx-airport.com&nbsp;走海外/加密 DoH<br/>→&nbsp;节点域名与 IP 都不暴露给 ISP，也不被 DNS 污染"]
-    end
+    L4["<b>④ fallback</b> &nbsp;·&nbsp; 海外域名回退通道 &nbsp;·&nbsp; DoH + GeoIP 解毒<br/><br/><b>Cloudflare</b> &nbsp; https://1.1.1.1/dns-query<br/><b>Google</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://8.8.8.8/dns-query<br/><b>fallback-filter.geoip-code: CN</b><br/>海外域名若查出 CN 段 IP（说明被污染）<br/>→&nbsp; 自动切 fallback 重查，避开 GFW 注入的假 IP"]
 
-    subgraph S4 ["④ fallback · 海外域名回退通道 · DoH + GeoIP 解毒"]
-      F["<b>Cloudflare</b>&nbsp;https://1.1.1.1/dns-query<br/><b>Google</b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;https://8.8.8.8/dns-query<br/><b>fallback-filter.geoip-code: CN</b><br/>作用：海外域名若查出 CN 段 IP（说明被污染），<br/>自动切 fallback 重查&nbsp;→&nbsp;避开 GFW 注入的假 IP"]
-    end
+    Start --> L1
+    L1 ==>|"<b>bootstrap 成功后，所有业务查询全走加密 DoH</b>"| Gate
+    Gate -->|"国内域名 / 国内 CDN"| L2
+    Gate -->|"机场节点域名"| L3
+    Gate -->|"海外域名"| L4
 
-    Gate -->|"国内域名 / 国内 CDN"| N
-    Gate -->|"机场节点域名"| P
-    Gate -->|"海外域名"| F
-
-    style Start fill:#FFE9E9,stroke:#C0392B,stroke-width:2px,color:#000
-    style B fill:#F5F5F5,stroke:#888,stroke-width:1px,color:#000
-    style Gate fill:#FFF6E9,stroke:#F39C12,stroke-width:2px,color:#000
-    style N fill:#EEF9F1,stroke:#27AE60,stroke-width:2px,color:#000
-    style P fill:#EAF4FF,stroke:#4A90E2,stroke-width:2px,color:#000
-    style F fill:#F3F0FF,stroke:#8E44AD,stroke-width:2px,color:#000
+    style Start fill:#FFE9E9,stroke:#C0392B,stroke-width:3px,color:#000
+    style L1 fill:#F5F5F5,stroke:#555,stroke-width:2px,color:#000
+    style Gate fill:#FFF6E9,stroke:#F39C12,stroke-width:3px,color:#000
+    style L2 fill:#EEF9F1,stroke:#27AE60,stroke-width:2px,color:#000
+    style L3 fill:#EAF4FF,stroke:#4A90E2,stroke-width:2px,color:#000
+    style L4 fill:#F3F0FF,stroke:#8E44AD,stroke-width:2px,color:#000
 ```
 
 ### 为什么这套分工能同时解决 5 个威胁


### PR DESCRIPTION
- 去掉 subgraph 双层框（subgraph + 内部节点 = 两层边框），改为单层 node， 把原 subgraph 标题作为节点首行加粗显示
- themeVariables.fontSize 设为 18px，默认可读性更好
- 加粗关键字段（层名 / 服务器地址 / GeoIP filter）便于一眼识别
- wrappingWidth 调到 1000、nodeSpacing/rankSpacing 略增，避免文字挤边