### PR TITLE
docs(readme): DNS 图把 ② ③ ④ 三路改为竖列布局

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ flowchart TB
     Gate -->|"国内域名 / 国内 CDN"| L2
     Gate -->|"机场节点域名"| L3
     Gate -->|"海外域名"| L4
+    L2 ~~~ L3
+    L3 ~~~ L4
 
     style Start fill:#FFE9E9,stroke:#C0392B,stroke-width:3px,color:#000
     style L1 fill:#F5F5F5,stroke:#555,stroke-width:2px,color:#000


### PR DESCRIPTION
用 mermaid 的 ~~~ 隐形边（L2 ~~~ L3 ~~~ L4）强制三条 DoH 通道落在不同的 rank 上，由并排改为竖列堆叠；Gate 仍以带标签的可见箭头分别指向三者，通过
连线显示"同一分流节点的三个分支"语义，视觉纵深更清晰。