### PR TITLE
dns: 切换 DNSPod DoH 端点为纯 IP (https://1.12.12.12/dns-query)

### DIFF
--- a/Clash Meta For Android/CHANGELOG.md
+++ b/Clash Meta For Android/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 ---
 
+## v5.2.8-cmfa.5 (2026-04-24) — DNSPod DoH 端点切换为纯 IP 形式
+
+- ★ `nameserver` / `proxy-server-nameserver` / `direct-nameserver` 三段里的
+  `https://doh.pub/dns-query` 全部替换为 `https://1.12.12.12/dns-query`
+  - DNSPod 同时提供 `doh.pub` 域名形式与 `1.12.12.12` 纯 IP 形式两种 DoH 端点
+  - 纯 IP 形式**无需 bootstrap DNS 解析 `doh.pub`**，消除"冷启动时 DoH 自依赖"的
+    潜在死锁（bootstrap 阶段 `default-nameserver` 只需解析 `dns.alidns.com` 和
+    `dns.cloudflare.com`，不再需要解析 `doh.pub`）
+- 版本号 `v5.2.8-cmfa.4` → `v5.2.8-cmfa.5`
+
 ## v5.2.8-cmfa.4 (2026-04-24)
 
 - ★ **删除 2 个离线 rule-provider**（与 Clash Party v5.2.1 对齐）

--- a/Clash Meta For Android/CMFA(mihomo).yaml
+++ b/Clash Meta For Android/CMFA(mihomo).yaml
@@ -1,5 +1,5 @@
 # ================================================================
-# Clash Smart v5.2.8-cmfa.4 - CMFA (Clash Meta for Android) 配置
+# Clash Smart v5.2.8-cmfa.5 - CMFA (Clash Meta for Android) 配置
 # Build: 2026-04-24
 # 架构：proxy-providers 订阅 + 18 url-test 区域组（9 全部 + 9 家宽）+ 28 业务策略组 + 384 rule-providers
 # 基线：Clash Party v5.2.8（唯一主线）
@@ -72,15 +72,15 @@ dns:
   - 8.8.8.8
   nameserver:
   - 'https://dns.alidns.com/dns-query'
-  - 'https://doh.pub/dns-query'
+  - 'https://1.12.12.12/dns-query'
   proxy-server-nameserver:
   - 'https://dns.cloudflare.com/dns-query'
   - 'https://dns.google/dns-query'
   - 'https://dns.alidns.com/dns-query'
-  - 'https://doh.pub/dns-query'
+  - 'https://1.12.12.12/dns-query'
   direct-nameserver:
   - 'https://dns.alidns.com/dns-query'
-  - 'https://doh.pub/dns-query'
+  - 'https://1.12.12.12/dns-query'
   fallback:
   - 'https://dns.google/dns-query'
   - 'https://dns.cloudflare.com/dns-query'

--- a/Clash Party/README.md
+++ b/Clash Party/README.md
@@ -208,15 +208,15 @@ dns:
     - 8.8.8.8
   nameserver:
     - https://223.5.5.5/dns-query
-    - https://doh.pub/dns-query
+    - https://1.12.12.12/dns-query
   proxy-server-nameserver:
     - https://1.1.1.1/dns-query
     - https://8.8.8.8/dns-query
     - https://223.5.5.5/dns-query
-    - https://doh.pub/dns-query
+    - https://1.12.12.12/dns-query
   direct-nameserver:
     - https://223.5.5.5/dns-query
-    - https://doh.pub/dns-query
+    - https://1.12.12.12/dns-query
   fallback:
     - https://1.1.1.1/dns-query
     - https://8.8.8.8/dns-query

--- a/Loon/CHANGELOG.md
+++ b/Loon/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ---
 
+## v5.2.8-Loon.6 (2026-04-24) — DNSPod DoH 端点切换为纯 IP 形式
+
+- ★ `doh-server` 里的 `https://doh.pub/dns-query` 替换为 `https://1.12.12.12/dns-query`
+  - DNSPod 纯 IP 形式 DoH 端点，**无需 bootstrap 解析 `doh.pub` 域名**，iOS 冷启动更稳
+- 版本号 `v5.2.8-Loon.5` → `v5.2.8-Loon.6`
+
 ## v5.2.8-Loon.5 (2026-04-23) — 基线对齐 Clash Party v5.2.8（无代码改动）
 
 - 跟随基线 bump：`v5.2.4-Loon.4` → `v5.2.8-Loon.5`

--- a/Loon/Loon.conf
+++ b/Loon/Loon.conf
@@ -1,6 +1,6 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Loon Smart v5.2.8-Loon.5 — Loon 版（从 Clash Party v5.2.8 迁移）
-#  Build: 2026-04-23 | Target: Loon iOS (App Store 付费正版)
+#  Loon Smart v5.2.8-Loon.6 — Loon 版（从 Clash Party v5.2.8 迁移）
+#  Build: 2026-04-24 | Target: Loon iOS (App Store 付费正版)
 #  架构：18 区域 url-test 组（9 全部 + 9 家宽）+ 28 业务 select 组 + 288 [Remote Rule] 订阅规则集
 #  基线：Clash Party v5.2.8（唯一主线）
 #  变更历史：见 `Loon/CHANGELOG.md`
@@ -21,7 +21,7 @@ bypass-tun = 10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,1
 # ─── DNS （对齐 Clash Party 基线：国内明文 DNS + 国外 DoH 备用） ─────────────
 # Loon `dns-server` 仅接受 `system` 与纯 IP；DoH URL 必须放 `doh-server`。
 dns-server = system, 223.5.5.5, 119.29.29.29
-doh-server = https://doh.pub/dns-query, https://dns.alidns.com/dns-query, https://1.1.1.1/dns-query, https://8.8.8.8/dns-query
+doh-server = https://1.12.12.12/dns-query, https://dns.alidns.com/dns-query, https://1.1.1.1/dns-query, https://8.8.8.8/dns-query
 
 # IPv6（Loon 原生字段名 `ipv6`，不是 `ipv6-enabled`）
 ipv6 = true

--- a/OpenClash/CHANGELOG.md
+++ b/OpenClash/CHANGELOG.md
@@ -9,6 +9,14 @@
 
 ## Normal（`OpenClash(mihomo).sh`，非 Smart 内核 / url-test 版）
 
+### v5.2.8-oc-normal.4 (2026-04-24) — DNSPod DoH 端点切换为纯 IP 形式
+
+- ★ `nameserver` / `proxy-server-nameserver` / `direct-nameserver` 三段里的
+  `https://doh.pub/dns-query` 全部替换为 `https://1.12.12.12/dns-query`
+  - DNSPod 纯 IP 形式 DoH 端点，**无需 bootstrap 解析 `doh.pub` 域名**，消除冷启动时
+    DoH 自依赖的潜在死锁
+- 版本号 `v5.2.8-oc-normal.3` → `v5.2.8-oc-normal.4`
+
 ### v5.2.8-oc-normal.3 (2026-04-23)
 
 - ★ **FIX#28-P0**（节点分类多归属）：🌏 亚太节点组缺 HK/TW/JP/KR、🌎 美洲节点组缺 US
@@ -86,6 +94,14 @@
 ---
 
 ## Full（`OpenClash(mihomo-smart).sh`）
+
+### v5.2.8-oc-full.4 (2026-04-24) — DNSPod DoH 端点切换为纯 IP 形式
+
+- ★ `nameserver` / `proxy-server-nameserver` / `direct-nameserver` 三段里的
+  `https://doh.pub/dns-query` 全部替换为 `https://1.12.12.12/dns-query`（与 Normal 同步）
+  - DNSPod 纯 IP 形式 DoH 端点，**无需 bootstrap 解析 `doh.pub` 域名**，消除冷启动时
+    DoH 自依赖的潜在死锁
+- 版本号 `v5.2.8-oc-full.3` → `v5.2.8-oc-full.4`（shell + Ruby 两处 VERSION 同步 bump）
 
 ### v5.2.8-oc-full.3 (2026-04-23)
 

--- a/OpenClash/OpenClash(mihomo).sh
+++ b/OpenClash/OpenClash(mihomo).sh
@@ -2,7 +2,7 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash v5.2.8-oc-normal.3 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
+# Clash v5.2.8-oc-normal.4 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
 # ============================================================================
 # 定位：与同目录 OpenClash(mihomo-smart).sh 规则 100% 等价的「非 Smart 内核」版本。
 #       两者唯一区别：18 个区域组（9 全部 + 9 家宽）从 type: smart（uselightgbm）换成 type: url-test。
@@ -24,7 +24,7 @@
 
 
 
-VERSION_TAG="v5.2.8-oc-normal.3"
+VERSION_TAG="v5.2.8-oc-normal.4"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -102,15 +102,15 @@ dns:
     - https://8.8.8.8/dns-query
   nameserver:
   - https://223.5.5.5/dns-query
-  - https://doh.pub/dns-query
+  - https://1.12.12.12/dns-query
   proxy-server-nameserver:
   - https://1.1.1.1/dns-query
   - https://8.8.8.8/dns-query
   - https://223.5.5.5/dns-query
-  - https://doh.pub/dns-query
+  - https://1.12.12.12/dns-query
   direct-nameserver:
   - https://223.5.5.5/dns-query
-  - https://doh.pub/dns-query
+  - https://1.12.12.12/dns-query
   fallback:
   - https://1.1.1.1/dns-query
   - https://8.8.8.8/dns-query

--- a/OpenClash/OpenClash(mihomo-smart).sh
+++ b/OpenClash/OpenClash(mihomo-smart).sh
@@ -2,7 +2,7 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash Smart v5.2.8-oc-full.3 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
+# Clash Smart v5.2.8-oc-full.4 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
 # ============================================================================
 # 定位：对齐 Clash Party v5.2.8 JS 主线的 OpenClash 全量版本。
 #       与同目录 OpenClash(mihomo).sh（Normal）互补：
@@ -22,7 +22,7 @@
 
 
 
-VERSION_TAG="v5.2.8-oc-full.3"
+VERSION_TAG="v5.2.8-oc-full.4"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -100,15 +100,15 @@ dns:
     - https://8.8.8.8/dns-query
   nameserver:
   - https://223.5.5.5/dns-query
-  - https://doh.pub/dns-query
+  - https://1.12.12.12/dns-query
   proxy-server-nameserver:
   - https://1.1.1.1/dns-query
   - https://8.8.8.8/dns-query
   - https://223.5.5.5/dns-query
-  - https://doh.pub/dns-query
+  - https://1.12.12.12/dns-query
   direct-nameserver:
   - https://223.5.5.5/dns-query
-  - https://doh.pub/dns-query
+  - https://1.12.12.12/dns-query
   fallback:
   - https://1.1.1.1/dns-query
   - https://8.8.8.8/dns-query
@@ -4193,7 +4193,7 @@ cat > "$RUBY_SCRIPT" << 'RUBY_EOF'
 require 'yaml'
 require 'digest'
 
-VERSION = "v5.2.8-oc-full.3"
+VERSION = "v5.2.8-oc-full.4"
 
 STATUS_LOG = "/tmp/clash_smart_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }

--- a/Quantumult X/CHANGELOG.md
+++ b/Quantumult X/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ---
 
+## v5.2.8-QX.4 (2026-04-24) — DNSPod DoH 端点切换为纯 IP 形式
+
+- ★ `[dns]` 段里的 `server=https://doh.pub/dns-query` 替换为
+  `server=https://1.12.12.12/dns-query`
+  - DNSPod 纯 IP 形式 DoH 端点，**无需 bootstrap 解析 `doh.pub` 域名**，iOS 冷启动更稳
+- 版本号 `v5.2.8-QX.3` → `v5.2.8-QX.4`
+
 ## v5.2.8-QX.3 (2026-04-23) — 基线对齐 Clash Party v5.2.8（无代码改动）
 
 - 跟随基线 bump：`v5.2.5-QX.2` → `v5.2.8-QX.3`

--- a/Quantumult X/QuantumultX.conf
+++ b/Quantumult X/QuantumultX.conf
@@ -1,6 +1,6 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Quantumult X Smart v5.2.8-QX.3 — Quantumult X 版（从 Clash Party v5.2.8 迁移）
-#  Build: 2026-04-23 | Target: Quantumult X iOS (App Store 付费正版)
+#  Quantumult X Smart v5.2.8-QX.4 — Quantumult X 版（从 Clash Party v5.2.8 迁移）
+#  Build: 2026-04-24 | Target: Quantumult X iOS (App Store 付费正版)
 #  架构：18 区域 url-latency-benchmark（9 全部 + 9 家宽）+ 28 业务 static + 288 filter_remote + 567 filter_local
 #  基线：Clash Party v5.2.8（唯一主线）
 #  变更历史：见 `Quantumult X/CHANGELOG.md`
@@ -20,7 +20,7 @@ fallback_udp_policy=reject
 # 对齐 Clash Party 基线：国内 DoH 为主 + 国外 DoH 备用
 server=223.5.5.5
 server=119.29.29.29
-server=https://doh.pub/dns-query
+server=https://1.12.12.12/dns-query
 server=https://dns.alidns.com/dns-query
 server=https://1.1.1.1/dns-query
 server=https://8.8.8.8/dns-query

--- a/Quantumult X/README.md
+++ b/Quantumult X/README.md
@@ -166,7 +166,7 @@ QX 的 DNS 配置用多行 `server=` 声明：
 ```
 server=223.5.5.5
 server=119.29.29.29
-server=https://doh.pub/dns-query
+server=https://1.12.12.12/dns-query
 server=https://dns.alidns.com/dns-query
 server=https://1.1.1.1/dns-query
 server=https://8.8.8.8/dns-query

--- a/README.md
+++ b/README.md
@@ -276,9 +276,9 @@ flowchart TB
 
     Gate{{"<b>🔀 按域名性质分三路查询</b>"}}
 
-    L2["<b>② nameserver</b> &nbsp;·&nbsp; 国内域名主通道 &nbsp;·&nbsp; DoH<br/><br/><b>AliDNS</b> &nbsp; https://223.5.5.5/dns-query<br/><b>DNSPod</b> &nbsp; https://doh.pub/dns-query<br/>大陆站点 / 国内 CDN 用国内权威 DoH &nbsp;→&nbsp; 不被 ISP 记录"]
+    L2["<b>② nameserver</b> &nbsp;·&nbsp; 国内域名主通道 &nbsp;·&nbsp; DoH<br/><br/><b>AliDNS</b> &nbsp; https://223.5.5.5/dns-query<br/><b>DNSPod</b> &nbsp; https://1.12.12.12/dns-query<br/>大陆站点 / 国内 CDN 用国内权威 DoH &nbsp;→&nbsp; 不被 ISP 记录"]
 
-    L3["<b>③ proxy-server-nameserver</b> &nbsp;·&nbsp; 机场节点域名解析 &nbsp;·&nbsp; DoH<br/><br/><b>Cloudflare</b> &nbsp; https://1.1.1.1/dns-query<br/><b>Google</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://8.8.8.8/dns-query<br/><b>AliDNS</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://223.5.5.5/dns-query<br/><b>DNSPod</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://doh.pub/dns-query<br/>解析 node.xxx-airport.com 走加密 DoH<br/>→&nbsp; 节点域名与 IP 都不暴露给 ISP，也不被 DNS 污染"]
+    L3["<b>③ proxy-server-nameserver</b> &nbsp;·&nbsp; 机场节点域名解析 &nbsp;·&nbsp; DoH<br/><br/><b>Cloudflare</b> &nbsp; https://1.1.1.1/dns-query<br/><b>Google</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://8.8.8.8/dns-query<br/><b>AliDNS</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://223.5.5.5/dns-query<br/><b>DNSPod</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://1.12.12.12/dns-query<br/>解析 node.xxx-airport.com 走加密 DoH<br/>→&nbsp; 节点域名与 IP 都不暴露给 ISP，也不被 DNS 污染"]
 
     L4["<b>④ fallback</b> &nbsp;·&nbsp; 海外域名回退通道 &nbsp;·&nbsp; DoH + GeoIP 解毒<br/><br/><b>Cloudflare</b> &nbsp; https://1.1.1.1/dns-query<br/><b>Google</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://8.8.8.8/dns-query<br/><b>fallback-filter.geoip-code: CN</b><br/>海外域名若查出 CN 段 IP（说明被污染）<br/>→&nbsp; 自动切 fallback 重查，避开 GFW 注入的假 IP"]
 
@@ -311,7 +311,7 @@ flowchart TB
 ### 推荐做法
 
 1. **首选加密 DoH**。不要用明文 UDP DNS（`114.114.114.114` / `8.8.8.8` 直连 53）——`114.114.114.114` 在大陆运营商会做劫持，`8.8.8.8` 会被 GFW 污染 + ISP 看到你在用海外 DNS。
-2. **国内 DoH 建议用 AliDNS + DNSPod 组合**（`https://223.5.5.5/dns-query` + `https://doh.pub/dns-query`）。两家都是中国合规 DoH，在 443 端口的 TLS 流量里 ISP 无法区分。
+2. **国内 DoH 建议用 AliDNS + DNSPod 组合**（`https://223.5.5.5/dns-query` + `https://1.12.12.12/dns-query`）。两家都是中国合规 DoH，在 443 端口的 TLS 流量里 ISP 无法区分。
 3. **海外 DoH 建议用 Cloudflare + Google**（`https://1.1.1.1/dns-query` + `https://8.8.8.8/dns-query`）。Cloudflare 额外支持 ODoH / ECH，隐私更好。
 4. **`proxy-server-nameserver` 必须单独配置**（容易忽略）。这是解决"机场节点 IP 被针对性封"的关键——让机场节点域名的解析也走海外 DoH 而不是默认通道。
 5. **fake-ip 模式强烈推荐**（`enhanced-mode: fake-ip`）。比 redir-host 快 + 无本地缓存污染 + 规则命中更精准。
@@ -326,7 +326,7 @@ https://whoami.cloudflare.com    # 应显示 Cloudflare DoH
 
 # 2) 命令行直接测 DoH 可达
 curl -H 'accept: application/dns-json' \
-  'https://doh.pub/dns-query?name=google.com&type=A'
+  'https://1.12.12.12/dns-query?name=google.com&type=A'
 # 成功 = 返回 JSON（含 Answer 字段）
 
 # 3) 抓包确认查询走 443（不是 53）

--- a/Shadowrocket/CHANGELOG.md
+++ b/Shadowrocket/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ---
 
+## v5.2.8-SR.6 (2026-04-24) — DNSPod DoH 端点切换为纯 IP 形式
+
+- ★ `dns-server` / `proxy-dns-server` 里的 `https://doh.pub/dns-query` 全部替换为
+  `https://1.12.12.12/dns-query`
+  - DNSPod 纯 IP 形式 DoH 端点，**无需 bootstrap 解析 `doh.pub` 域名**，iOS 冷启动
+    或低信号环境下更稳
+- 版本号 `v5.2.8-SR.5` → `v5.2.8-SR.6`
+
 ## v5.2.8-SR.5 (2026-04-23) — 基线对齐 Clash Party v5.2.8（无代码改动）
 
 - 跟随基线 bump：`v5.2.6-SR.4` → `v5.2.8-SR.5`

--- a/Shadowrocket/Shadowrocket.conf
+++ b/Shadowrocket/Shadowrocket.conf
@@ -1,6 +1,6 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Shadowrocket Smart v5.2.8-SR.5 — 小火箭版（从 Clash Party v5.2.8 迁移重构）
-#  Build: 2026-04-23 | Target: Shadowrocket iOS (App Store 正版) | macOS 通用
+#  Shadowrocket Smart v5.2.8-SR.6 — 小火箭版（从 Clash Party v5.2.8 迁移重构）
+#  Build: 2026-04-24 | Target: Shadowrocket iOS (App Store 正版) | macOS 通用
 #  架构：18 区域 url-test 组（9 全部 + 9 家宽）+ 28 业务策略组 + ~290 RULE-SET
 #  基线：Clash Party v5.2.8（唯一主线）
 #  变更历史：见 `Shadowrocket/CHANGELOG.md`
@@ -20,12 +20,12 @@ tun-excluded-routes = 10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16
 # SR 设计上不区分 nameserver / direct-nameserver：dns-server 同时服务于两者
 # 直连类域名通过此 DNS 解析（国内域名用国内 DoH 更快更准）
 # 并发查询策略：多个 DNS 同时发起，采用最先返回的结果
-dns-server = https://dns.alidns.com/dns-query,https://doh.pub/dns-query,223.5.5.5,119.29.29.29
+dns-server = https://dns.alidns.com/dns-query,https://1.12.12.12/dns-query,223.5.5.5,119.29.29.29
 
 # ─── 代理域名 DNS（对应 Clash proxy-server-nameserver；隐藏参数） ─────────────
 # 用于解析节点本身的域名（如 node.xxx.com），以及经代理连接时的 DNS 查询
 # 国外 DoH 前置，防止国内 DNS 对代理类域名返回污染结果
-proxy-dns-server = https://dns.cloudflare.com/dns-query,https://dns.google/dns-query,https://dns.alidns.com/dns-query,https://doh.pub/dns-query
+proxy-dns-server = https://dns.cloudflare.com/dns-query,https://dns.google/dns-query,https://dns.alidns.com/dns-query,https://1.12.12.12/dns-query
 
 # ─── 备用 DNS（对应 Clash fallback；主 DNS 超时 2s 后回退） ───────────────────
 # 国外 DoH 做 fallback，确保 DNS 污染或超时情况下仍能解析

--- a/Surge/CHANGELOG.md
+++ b/Surge/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ---
 
+## v5.2.8-Surge.5 (2026-04-24) — DNSPod DoH 端点切换为纯 IP 形式
+
+- ★ `encrypted-dns-server` 里的 `https://doh.pub/dns-query` 替换为
+  `https://1.12.12.12/dns-query`
+  - DNSPod 纯 IP 形式 DoH 端点，**无需 bootstrap 解析 `doh.pub` 域名**，冷启动更稳
+- 版本号 `v5.2.8-Surge.4` → `v5.2.8-Surge.5`
+
 ## v5.2.8-Surge.4 (2026-04-23) — 基线对齐 Clash Party v5.2.8（无代码改动）
 
 - 跟随基线 bump：`v5.2.6-Surge.3` → `v5.2.8-Surge.4`

--- a/Surge/Surge.conf
+++ b/Surge/Surge.conf
@@ -1,6 +1,6 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Surge Smart v5.2.8-Surge.4 — Surge 版（从 Clash Party v5.2.8 迁移）
-#  Build: 2026-04-23 | Target: Surge 5 / Surge Mac (付费正版) | iOS + macOS
+#  Surge Smart v5.2.8-Surge.5 — Surge 版（从 Clash Party v5.2.8 迁移）
+#  Build: 2026-04-24 | Target: Surge 5 / Surge Mac (付费正版) | iOS + macOS
 #  架构：18 区域 url-test 组（9 全部 + 9 家宽）+ 28 业务 select 组 + ~290 RULE-SET
 #  基线：Clash Party v5.2.8（唯一主线）
 #  变更历史：见 `Surge/CHANGELOG.md`
@@ -29,7 +29,7 @@ read-etc-hosts = true
 # Surge 的 dns-server 是"通用"解析；encrypted-dns-server 专用于 DoH/DoT，
 # 两者都填时 Surge 会并发，最先返回结果的优先。
 dns-server = 223.5.5.5, 119.29.29.29, system
-encrypted-dns-server = https://doh.pub/dns-query, https://dns.alidns.com/dns-query, https://1.1.1.1/dns-query, https://8.8.8.8/dns-query
+encrypted-dns-server = https://1.12.12.12/dns-query, https://dns.alidns.com/dns-query, https://1.1.1.1/dns-query, https://8.8.8.8/dns-query
 encrypted-dns-follow-outbound-mode = false
 
 # DNS 劫持：劫持系统里硬编码的 8.8.8.8/4.4.4.4 查询（Netflix/Chromecast 常见）到 Surge DNS。


### PR DESCRIPTION
## Summary

- 所有产物配置里的 `https://doh.pub/dns-query` 全部替换为 `https://1.12.12.12/dns-query`
- DNSPod 纯 IP 形式 DoH 端点：**无需 bootstrap 解析 `doh.pub` 域名**，消除冷启动时 DoH 自依赖的潜在死锁
- 各产物版本号 + Build 日期 bump、对应 `<子目录>/CHANGELOG.md` 顶部新增一节（符合 CLAUDE.md §1.3 规范）

## 影响矩阵

| 产物 | 版本变化 | 改动位置 |
|------|----------|----------|
| CMFA | `v5.2.8-cmfa.4` → `.5` | `nameserver` / `proxy-server-nameserver` / `direct-nameserver` 三段 3 处 |
| OpenClash Normal | `v5.2.8-oc-normal.3` → `.4` | heredoc YAML 里 3 处 |
| OpenClash Smart (Full) | `v5.2.8-oc-full.3` → `.4` | heredoc YAML 里 3 处（shell + Ruby 两处 VERSION 同步 bump） |
| Shadowrocket | `v5.2.8-SR.5` → `.6` | `dns-server` + `proxy-dns-server` |
| Surge | `v5.2.8-Surge.4` → `.5` | `encrypted-dns-server` |
| Loon | `v5.2.8-Loon.5` → `.6` | `doh-server` |
| Quantumult X | `v5.2.8-QX.3` → `.4` | `[dns] server=` |
| 根 README.md | 文档 | 3 处 DoH 流程图 + 推荐做法段 + curl 示例 |
| Clash Party/README.md | 文档 | nameserver / proxy-server-nameserver / direct-nameserver 示例 3 处 |
| Quantumult X/README.md | 文档 | `[dns]` 示例段 1 处 |

## 未同步项（依 CLAUDE.md §1.4 例外 + §1.5 审计）

- **Clash Party JS 主线**：基线本来就不内嵌 DNS 配置（FIX#6 起移除了 DNS rule-provider），无可改
- **SingBox Full / Generator**：当前 `dns` 段不使用 `doh.pub`，无需改动
- **v2rayN Xray routing**：无 DoH 配置字段，无需改动
- **Loon/CHANGELOG.md** v5.2.4-Loon.2 段里对 v5.2.3 bug 的描述保留原状（历史记录不可篡改）
- **`{Loon,OpenClash,Surge}/README.md`** 里 "doh.pub / alidns / ..." 这类把 `doh.pub` 作为**品牌别名**的参考表未动（并非完整 URL）

## 官方文档核对

- DNSPod 公开 DoH 端点：`doh.pub`（域名）与 `1.12.12.12` / `120.53.53.53`（纯 IP）**语义等价**，后者免去 bootstrap，冷启动更稳
- mihomo / CMFA / OpenClash：`nameserver` / `direct-nameserver` / `proxy-server-nameserver` 均接受纯 IP 形式 DoH URL（[mihomo DNS 文档](https://wiki.metacubex.one/config/dns/)）
- Shadowrocket `dns-server` / `proxy-dns-server` / Surge `encrypted-dns-server` / Loon `doh-server` / QX `server=` 均为**完整 URL** 字段，IP 或域名都接受

## Test plan

- [x] §5.1 代理组数：CMFA=46 / OC Normal=28 / OC Smart=28 / SR=46 / Surge=46 / Loon=46 / QX=46
- [x] §5.2 RP proxy 字段：CMFA=385 / OC Normal=385 / OC Smart=385（`🚫 受限网站`）
- [x] §5.3 SR 死引用扫描通过
- [x] §5.4 SingBox Full JSON / v2rayN JSON 合法
- [x] §5 OpenClash full override YAML：providers=385 / rules=975（Psych 重复顶层键检查通过）
- [x] `grep -rn "https://doh.pub/dns-query"` 结果仅剩 CHANGELOG 描述行 + Loon 历史段

https://claude.ai/code/session_01FhW5JnrL39uj4Ms1WKV9hP

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhW5JnrL39uj4Ms1WKV9hP)_