### PR TITLE
fix(code-review): 修复 CLAUDE.md 自检命令 + Passwall/Passwall2 版本对齐至 v5.2.8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,7 +341,7 @@ node -e "const d=JSON.parse(require('fs').readFileSync('SingBox/SingBox(sing-box
 grep -c "proxy: DIRECT" "OpenClash/OpenClash(mihomo).sh"                    # 期望 0
 grep -c "proxy: '☁️ 云与CDN'" "Clash Meta For Android/CMFA(mihomo).yaml"         # 期望 0
 grep -c "proxy: '🚫 受限网站'" "Clash Meta For Android/CMFA(mihomo).yaml"        # 期望 ≥ 300
-grep -c "proxy: 🚫 受限网站" "OpenClash/OpenClash(mihomo).sh"               # 期望 ≥ 130
+grep -c "proxy: \"\\\\U0001F6AB 受限网站\"" "OpenClash/OpenClash(mihomo).sh"               # 期望 ≥ 130
 grep -c "proxy: \"\\\\U0001F6AB 受限网站\"" "OpenClash/OpenClash(mihomo-smart).sh"  # 期望 ≥ 380
 
 # 3) 禁止死引用（旗帜 emoji 与组名 emoji 必须匹配；忽略注释行）

--- a/Passwall/CHANGELOG.md
+++ b/Passwall/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ---
 
+## v5.2.8-pw.3 (2026-04-24) — ★ 版本号对齐 v5.2.8 基线
+
+跟随 Clash Party v5.2.8 基线版本号对齐。本产物无功能性变更，因为：
+
+| FIX# | 描述 | Passwall 影响 |
+|------|------|--------------|
+| #27 | 新建 `mirrors/` 目录，静默 classical provider 警告 | **N/A** — Passwall 无 rule-provider 概念（静态 shunt_rules 本地域名/IP 匹配） |
+| #28 | APAC 区域分类扩展（HK/TW/JP/KR 并入 APAC；US 并入 AMERICAS） | **N/A** — Passwall 无运行时节点分类（用户的 geosite/geoip + UCI 节点列表，无自动归类） |
+| #24-#26 | 节点名分类 / fallback / 订阅清理 | **N/A** — Passwall 无 proxy-groups 嵌套和订阅预处理 |
+
 ## v5.2.6-pw.2 (2026-04-24) — ★ Passwall 专属目录初版
 
 本次 PR 新建 `Passwall/` 独立目录，提供面向 Passwall 全功能版的 28 条 shunt rule 参考，与已有的 `Passwall2/` 目录内容互通但各有侧重。

--- a/Passwall/Passwall(xray+sing-box)-apply.sh
+++ b/Passwall/Passwall(xray+sing-box)-apply.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # ═══════════════════════════════════════════════════════════════════════════
 # Smart-Config-Kit for Passwall — UCI batch helper
-# Version: v5.2.6-pw.2 | Build 2026-04-24
+# Version: v5.2.8-pw.3 | Build 2026-04-24
 #
 # 用途：一次性在 Passwall（全功能版）中创建 28 条 shunt rule（含域名列表 + IP 列表），
 #       每条目标节点留空（NEED_CONFIG），用户之后到 LuCI 里手工选节点。

--- a/Passwall2/CHANGELOG.md
+++ b/Passwall2/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ---
 
+## v5.2.8-pw2.3 (2026-04-24) — ★ 版本号对齐 v5.2.8 基线
+
+跟随 Clash Party v5.2.8 基线版本号对齐。本产物无功能性变更（同构审计 N/A 理由同 Passwall `v5.2.8-pw.3`）。
+
 ## v5.2.6-pw2.2 (2026-04-23) — ★ 致命 bug 修复 + 定位纠正
 
 本次 PR 源自用户指出的两个错误，经深度调研 Passwall / Passwall2 官方仓库（`Openwrt-Passwall` org）+ `shunt_rules.lua` 源码后修复。

--- a/Passwall2/Passwall2(xray+sing-box)-apply.sh
+++ b/Passwall2/Passwall2(xray+sing-box)-apply.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # ═══════════════════════════════════════════════════════════════════════════
 # Smart-Config-Kit for Passwall / Passwall2 — UCI batch helper
-# Version: v5.2.6-pw2.2 | Build 2026-04-23
+# Version: v5.2.8-pw2.3 | Build 2026-04-24
 #
 # 用途：一次性在 Passwall2 中创建 28 条 shunt rule（含域名列表 + IP 列表），
 #       每条目标节点留空（NEED_CONFIG），用户之后到 LuCI 里手工选节点。


### PR DESCRIPTION
- CLAUDE.md §5: OC Normal grep 模式修正为 Unicode escape（与 OC Smart 一致）
- Passwall: v5.2.6-pw.2 → v5.2.8-pw.3 + CHANGELOG 标注同构审计 N/A
- Passwall2: v5.2.6-pw2.2 → v5.2.8-pw2.3 + CHANGELOG 标注同构审计 N/A