### PR TITLE
fix: 全年代码审查 — 修复 3 个潜在 BUG

### DIFF
--- a/Clash Party/ClashParty(mihomo).js
+++ b/Clash Party/ClashParty(mihomo).js
@@ -2208,7 +2208,8 @@ function cleanupSubscription(config) {
 function _simpleHash(str) {
   var hash = 0
   for (var i = 0; i < str.length; i++) { hash = ((hash << 5) - hash) + str.charCodeAt(i); hash |= 0 }
-  return Math.abs(hash)
+  // >>> 0 converts to unsigned 32-bit; avoids Math.abs(-2147483648) === -2147483648 edge case
+  return hash >>> 0
 }
 
 function injectSmartFingerprint(config) {

--- a/Clash Party/ClashParty(mihomo-smart).js
+++ b/Clash Party/ClashParty(mihomo-smart).js
@@ -2209,7 +2209,8 @@ function cleanupSubscription(config) {
 function _simpleHash(str) {
   var hash = 0
   for (var i = 0; i < str.length; i++) { hash = ((hash << 5) - hash) + str.charCodeAt(i); hash |= 0 }
-  return Math.abs(hash)
+  // >>> 0 converts to unsigned 32-bit; avoids Math.abs(-2147483648) === -2147483648 edge case
+  return hash >>> 0
 }
 
 function injectSmartFingerprint(config) {

--- a/OpenClash/OpenClash(mihomo).sh
+++ b/OpenClash/OpenClash(mihomo).sh
@@ -4252,6 +4252,21 @@ REGIONS = {
   "FR"  => /法国|法國|FR\b|France|Paris|🇫🇷/i,
   "NL"  => /荷兰|荷蘭|NL\b|Netherlands|Amsterdam|🇳🇱/i,
   "CH"  => /瑞士|CH\b|Switzerland|🇨🇭/i,
+  "IT"  => /意大利|義大利|IT\b|Italy|Milan|Rome|🇮🇹|FCO|MXP/i,
+  "ES"  => /西班牙|ES\b|Spain|Madrid|Barcelona|🇪🇸|MAD|BCN/i,
+  "PT"  => /葡萄牙|PT\b|Portugal|Lisbon|🇵🇹/i,
+  "GR"  => /希腊|希臘|GR\b|Greece|Athens|🇬🇷/i,
+  "AT"  => /奥地利|奧地利|AT\b|Austria|Vienna|🇦🇹|VIE/i,
+  "BE"  => /比利时|比利時|BE\b|Belgium|Brussels|🇧🇪/i,
+  "IE"  => /爱尔兰|愛爾蘭|IE\b|Ireland|Dublin|🇮🇪/i,
+  "DK"  => /丹麦|丹麥|DK\b|Denmark|Copenhagen|🇩🇰/i,
+  "SE"  => /瑞典|SE\b|Sweden|Stockholm|🇸🇪/i,
+  "FI"  => /芬兰|芬蘭|FI\b|Finland|Helsinki|🇫🇮/i,
+  "NO"  => /挪威|NO\b|Norway|Oslo|🇳🇴/i,
+  "PL"  => /波兰|波蘭|PL\b|Poland|Warsaw|🇵🇱|WAW/i,
+  "CZ"  => /捷克|CZ\b|Czech|Prague|🇨🇿/i,
+  "RO"  => /罗马尼亚|羅馬尼亞|RO\b|Romania|Bucharest|🇷🇴/i,
+  "HU"  => /匈牙利|HU\b|Hungary|Budapest|🇭🇺/i,
   "RU"  => /俄罗斯|俄羅斯|RU\b|Russia|Moscow|🇷🇺/i,
   "CA"  => /加拿大|CA\b|Canada|🇨🇦|Toronto|Vancouver/i,
   "MX"  => /墨西哥|MX\b|Mexico|🇲🇽/i,
@@ -4284,7 +4299,7 @@ GROUP_MAP = {
   "TW"     => ["TW"],
   "JP_KR"  => ["JP", "KR"],
   "US"     => ["US"],
-  "EU"     => ["UK", "DE", "FR", "NL", "CH", "RU"],
+  "EU"     => ["UK", "DE", "FR", "NL", "CH", "IT", "ES", "PT", "GR", "AT", "BE", "IE", "DK", "SE", "FI", "NO", "PL", "CZ", "RO", "HU", "RU"],
   "AM"     => ["US", "CA", "MX", "BR", "AR"],
   "AF"     => ["ZA", "EG", "NG"],
   "APAC"   => ["HK", "TW", "JP", "KR", "SG", "IN", "TH", "VN", "MY", "ID", "PH", "AU", "NZ", "TR", "AE"],
@@ -4384,7 +4399,7 @@ end
 FP_CANDIDATES = %w[chrome firefox safari edge ios android random]
 filtered_proxies.each do |p|
   t = p["type"].to_s
-  if %w[vless vmess trojan hysteria hysteria2 tuic].include?(t)
+  if %w[vless vmess trojan].include?(t)
     next if p["client-fingerprint"] && !p["client-fingerprint"].to_s.empty?
     digest = Digest::MD5.hexdigest(p["name"].to_s)
     idx = digest.to_i(16) % FP_CANDIDATES.size

--- a/OpenClash/OpenClash(mihomo-smart).sh
+++ b/OpenClash/OpenClash(mihomo-smart).sh
@@ -4250,6 +4250,21 @@ REGIONS = {
   "FR"  => /法国|法國|FR\b|France|Paris|🇫🇷/i,
   "NL"  => /荷兰|荷蘭|NL\b|Netherlands|Amsterdam|🇳🇱/i,
   "CH"  => /瑞士|CH\b|Switzerland|🇨🇭/i,
+  "IT"  => /意大利|義大利|IT\b|Italy|Milan|Rome|🇮🇹|FCO|MXP/i,
+  "ES"  => /西班牙|ES\b|Spain|Madrid|Barcelona|🇪🇸|MAD|BCN/i,
+  "PT"  => /葡萄牙|PT\b|Portugal|Lisbon|🇵🇹/i,
+  "GR"  => /希腊|希臘|GR\b|Greece|Athens|🇬🇷/i,
+  "AT"  => /奥地利|奧地利|AT\b|Austria|Vienna|🇦🇹|VIE/i,
+  "BE"  => /比利时|比利時|BE\b|Belgium|Brussels|🇧🇪/i,
+  "IE"  => /爱尔兰|愛爾蘭|IE\b|Ireland|Dublin|🇮🇪/i,
+  "DK"  => /丹麦|丹麥|DK\b|Denmark|Copenhagen|🇩🇰/i,
+  "SE"  => /瑞典|SE\b|Sweden|Stockholm|🇸🇪/i,
+  "FI"  => /芬兰|芬蘭|FI\b|Finland|Helsinki|🇫🇮/i,
+  "NO"  => /挪威|NO\b|Norway|Oslo|🇳🇴/i,
+  "PL"  => /波兰|波蘭|PL\b|Poland|Warsaw|🇵🇱|WAW/i,
+  "CZ"  => /捷克|CZ\b|Czech|Prague|🇨🇿/i,
+  "RO"  => /罗马尼亚|羅馬尼亞|RO\b|Romania|Bucharest|🇷🇴/i,
+  "HU"  => /匈牙利|HU\b|Hungary|Budapest|🇭🇺/i,
   "RU"  => /俄罗斯|俄羅斯|RU\b|Russia|Moscow|🇷🇺/i,
   "CA"  => /加拿大|CA\b|Canada|🇨🇦|Toronto|Vancouver/i,
   "MX"  => /墨西哥|MX\b|Mexico|🇲🇽/i,
@@ -4282,7 +4297,7 @@ GROUP_MAP = {
   "TW"     => ["TW"],
   "JP_KR"  => ["JP", "KR"],
   "US"     => ["US"],
-  "EU"     => ["UK", "DE", "FR", "NL", "CH", "RU"],
+  "EU"     => ["UK", "DE", "FR", "NL", "CH", "IT", "ES", "PT", "GR", "AT", "BE", "IE", "DK", "SE", "FI", "NO", "PL", "CZ", "RO", "HU", "RU"],
   "AM"     => ["US", "CA", "MX", "BR", "AR"],
   "AF"     => ["ZA", "EG", "NG"],
   "APAC"   => ["HK", "TW", "JP", "KR", "SG", "IN", "TH", "VN", "MY", "ID", "PH", "AU", "NZ", "TR", "AE"],
@@ -4382,7 +4397,7 @@ end
 FP_CANDIDATES = %w[chrome firefox safari edge ios android random]
 filtered_proxies.each do |p|
   t = p["type"].to_s
-  if %w[vless vmess trojan hysteria hysteria2 tuic].include?(t)
+  if %w[vless vmess trojan].include?(t)
     next if p["client-fingerprint"] && !p["client-fingerprint"].to_s.empty?
     digest = Digest::MD5.hexdigest(p["name"].to_s)
     idx = digest.to_i(16) % FP_CANDIDATES.size


### PR DESCRIPTION
## Summary

全仓库代码审查 (2026-04-25)，发现并修复 3 个潜在 BUG：

### BUG A (P2): OpenClash Ruby 指纹注入协议范围不一致
- [OpenClash/OpenClash(mihomo-smart).sh:4385](OpenClash/OpenClash(mihomo-smart).sh#L4385) / [OpenClash/OpenClash(mihomo).sh:4387](OpenClash/OpenClash(mihomo).sh#L4387)
- Ruby 版对 `hysteria`/`hysteria2`/`tuic` 注入了 `client-fingerprint`，但 JS 基线只对 `vless`/`vmess`/`trojan` 做
- hysteria 系列基于 QUIC，`client-fingerprint` 对其无效，对齐 JS 基线

### BUG B (P3): JS `_simpleHash` 负零溢出
- [Clash Party/ClashParty(mihomo-smart).js:2209](Clash%20Party/ClashParty(mihomo-smart).js#L2209) / [Clash Party/ClashParty(mihomo).js:2208](Clash%20Party/ClashParty(mihomo).js#L2208)
- `Math.abs(-2147483648)` → `-2147483648`（JS 32bit 经典坑）
- 导致 `fpFallbackCandidates[-4]` → `undefined`，指纹静默为空

### BUG C (P2): OpenClash Ruby REGIONS 缺少欧洲国家 ISO 码
- [OpenClash/OpenClash(mihomo-smart).sh:4239](OpenClash/OpenClash(mihomo-smart).sh#L4239) / [OpenClash/OpenClash(mihomo).sh:4241](OpenClash/OpenClash(mihomo).sh#L4241)
- JS 基线 EU 覆盖 ES/IT/PT/GR/PL/CZ 等全部欧洲国家，Ruby 只有 UK/DE/FR/NL/CH/RU
- 新增 15 条 REGIONS 正则 + 同步 GROUP_MAP["EU"]

## 影响面

| 产物 | 改动 | 位置 |
|------|------|------|
| Clash Party Smart JS | `_simpleHash` 修复 | 行 2209-2212 |
| Clash Party Normal JS | `_simpleHash` 修复 | 行 2209-2212 |
| OpenClash full (Smart) | REGIONS 扩充 + EU 组修复 + FP 协议收窄 | 行 4250-4399 |
| OpenClash normal | 同上 | 行 4252-4399 |

## 自检

```
CMFA groups: 46 ✓ | SR groups: 46 ✓ | Surge: 46 ✓ | Loon: 46 ✓
QX groups: 46 ✓ | SingBox: 47 ✓
CMFA proxy: DIRECT → 0 ✓ | proxy: 🚫受限网站 → 391 ✓
JSON validity: SingBox ✓ | v2rayN ✓
OC override YAML dup keys: rule-providers=1 rules=1 ✓
```