### PR TITLE
docs(openclash): restore missing script path field and fix §3.4 ordering

### DIFF
--- a/OpenClash/README.md
+++ b/OpenClash/README.md
@@ -46,7 +46,7 @@
 
 LuCI → **服务 → OpenClash → 覆写设置（Overwrite Settings）**。
 
-后续两步导入（`.conf` 和 `.sh` 路径）都在这一页里完成。
+后续三步都在这一页里完成：导入 `.conf`（§3.3）→ 上传 `.sh`（§3.4）→ 填脚本路径（§3.5）。
 
 <img width="1280" height="678" alt="① 覆写设置页面入口" src="https://github.com/user-attachments/assets/3f7f16a8-f01c-4f7d-ad17-338140088a9a" />
 
@@ -63,32 +63,25 @@ LuCI → **服务 → OpenClash → 覆写设置（Overwrite Settings）**。
 
 <img width="1280" height="678" alt="② .conf 上传位置（在覆写设置页面里）" src="https://github.com/user-attachments/assets/3a204b9e-ccc8-4b1f-8ed9-3dd1c1e66e7b" />
 
-### 3.4 告诉 OpenClash 调用哪份覆写脚本（关键一步）
+### 3.4 把 `.sh` 覆写脚本上传到路由器
 
-回到刚才的 **覆写设置** 页面，在 **自定义 OpenClash 脚本（Custom Overwrite Script）** 字段填入脚本路径（二选一，对应你装的内核）：
+回到覆写设置页面，在底部有一排"脚本槽位"卡片（`default` / 已存在的脚本 / **`+`** 新建按钮），每张卡片右侧都有一个开关。
 
-- Smart 内核 → `/etc/openclash/OpenClash(mihomo-smart).sh`
-- Normal 内核 → `/etc/openclash/OpenClash(mihomo).sh`
+1. 点击最左边的 **`+`** 卡片（新建脚本槽位）
+2. 在弹出的编辑器里：
+   - **方式 A（最简单）**：把仓库里的 `OpenClash/OpenClash(mihomo-smart).sh`（或 `OpenClash(mihomo).sh`）整份内容**复制粘贴**进编辑器
+   - **方式 B**：用编辑器右上角的"导入 / 上传"按钮，选择本地的 `.sh` 文件
+3. 给这个槽位起个名字（比如 `clash-smart` / `clash-normal`），保存
+4. 在底部卡片列表里找到刚保存的脚本，把右侧开关拨到 **开**（同时把其他覆写脚本的开关**关掉**，OpenClash 一次只用一份生效的覆写）
+5. 点击页面底部 **应用**（或保存并应用）
 
-点击保存并应用。
+> **二选一**：装的是 Mihomo Smart / Meta Alpha 内核就上 `OpenClash(mihomo-smart).sh`；装的是普通 Meta 稳定内核就上 `OpenClash(mihomo).sh`。两份都上传也行，但**只能开一个**。
 
-> ⚠️ **这一步不能省。** `OpenClash(mihomo).conf`（§3.3 导入的）只管 DNS/Sniffer/核心类型/GeoX 更新等 30 多项 UCI 选项，**不包含**脚本路径。如果不在这里填路径，OpenClash 不知道要去调用哪份覆写脚本，规则策略就不会生效。
+<img width="1280" height="678" alt="③ .sh 脚本上传位置（覆写设置页面底部 + 号 + 开关）" src="https://github.com/user-attachments/assets/e03460ea-606c-4e1b-b45b-a76bc8158abf" />
 
-`OpenClash(mihomo).conf` 与覆写脚本是**平行叠加**的关系：`.conf` 设定基础 UCI 环境，`.sh` 注入完整分流策略（46 代理组 / 385 rule-providers / 975 rules）。两步**都做**才能正常工作。
+#### 备选：用命令行 `scp` 上传（高级用户 / 多台路由器批量部署）
 
-#### 把 `.sh` 文件送到路由器上
-
-脚本路径填好之后，你需要确保那个路径下确实有对应的 `.sh` 文件。两种方式：
-
-##### 方式 A：通过 WebUI 在线创建/上传
-
-在覆写设置页面底部有一排"脚本槽位"卡片（`default` / **`+`** 新建），这是 OpenClash WebUI 提供的在线编辑功能：
-
-1. 点击 **`+`** 卡片新建一个脚本槽位
-2. 在弹出的编辑器里，把仓库里的 `.sh` 内容**复制粘贴**进去（或点击编辑器右上角"导入"按钮上传本地文件）
-3. 给这个槽位起个名字（比如 `clash-smart` / `clash-normal`），**保存**即可——WebUI 会自动把脚本保存到 `/etc/openclash/` 下
-
-##### 方式 B：通过 `scp` 上传（SSH / 批量部署）
+如果你更习惯命令行，或者要批量同步多台路由器，可以走 SSH 直接把脚本铺到 `/etc/openclash/`：
 
 ```bash
 # 路径里的 ( ) 是 shell 语法 token，必须加引号
@@ -100,9 +93,22 @@ ssh root@192.168.1.1 "chmod +x '/etc/openclash/OpenClash(mihomo-smart).sh' '/etc
 
 不熟悉命令行的也可以用 WinSCP / Cyberduck / FileZilla 拖拽到 `/etc/openclash/`，再 SSH 进去 `chmod +x`。
 
-> **确认文件到了之后**，回 §3.4 开头检查"自定义 OpenClash 脚本"字段里填的路径，是否与文件实际位置一致。保存应用后，下次 OpenClash 启动 / 订阅更新时就会自动加载这份脚本，在 `.conf` 灌好的基础配置之上**叠加**完整分流策略。
+> 文件传上去之后先不要急着启动——下面还有一步。
 
-### 3.5 导入订阅并启动
+### 3.5 告诉 OpenClash 用哪份脚本（填路径）
+
+在 **覆写设置** 页面找到 **自定义 OpenClash 脚本（Custom Overwrite Script）** 字段，填入你刚才上传的脚本路径（二选一，对应你装的内核）：
+
+- Smart 内核 → `/etc/openclash/OpenClash(mihomo-smart).sh`
+- Normal 内核 → `/etc/openclash/OpenClash(mihomo).sh`
+
+点击**保存并应用**。
+
+> ⚠️ **这一步不能省。** §3.3 导入的 `OpenClash(mihomo).conf` 只管 DNS/Sniffer/核心类型/GeoX 更新等 30 多项 UCI 选项，**不包含**脚本路径。如果不在这里填路径，OpenClash 不知道要去调用哪份 `.sh`，你上传的脚本再完整也不会生效。
+>
+> `.conf` 与 `.sh` 是**平行叠加**的关系：`.conf` 设定基础 UCI 环境，**再在"自定义 OpenClash 脚本"字段里指定 `.sh` 路径**，OpenClash 才能在启动时加载这份覆写脚本注入完整分流策略（46 代理组 / 385 rule-providers / 975 rules）。三步**都做**才能正常工作。
+
+### 3.6 导入订阅并启动
 
 LuCI → **配置订阅** → 添加订阅链接 → 下载 → **全局设置** 选择该配置 → 启动 OpenClash。
 


### PR DESCRIPTION
## Summary

修复 OpenClash 使用说明 §3.4 中两个问题：

**问题 1：顺序颠倒**
- 旧版描述先填路径、再上传文件，实际应该是**先上传 `.sh` 文件、再填路径**
- 已拆为 §3.4（上传 `.sh`）→ §3.5（填脚本路径）两个独立小节

**问题 2：错误地删了关键步骤**
- 恢复详细的上传/粘贴操作步骤（编号列表 1-5）
- 恢复第三张截图（.sh 脚本槽位位置）
- 恢复 scp 备选方案

**同步更新：**
- §3.2 描述从"后续两步"改为"后续三步"
- 保留 `.conf` 不包含脚本路径的重要说明（在 §3.5 引述框里）

## 影响面

- 仅改 `OpenClash/README.md`，不影响任何产物文件
- 其他平台（CMFA / Shadowrocket / SingBox / Passwall 等）不受影响