### PR TITLE
chore: replace IP-based DoH URLs with domain names across all products

### DIFF
--- a/Clash Meta For Android/CMFA(mihomo).yaml
+++ b/Clash Meta For Android/CMFA(mihomo).yaml
@@ -68,22 +68,22 @@ dns:
   - 8.8.8.8
   nameserver:
   - 'https://dns.alidns.com/dns-query'
-  - 'https://1.12.12.12/dns-query'
+  - 'https://doh.pub/dns-query'
   proxy-server-nameserver:
   - 'https://dns.cloudflare.com/dns-query'
   - 'https://dns.google/dns-query'
   - 'https://dns.alidns.com/dns-query'
-  - 'https://1.12.12.12/dns-query'
+  - 'https://doh.pub/dns-query'
   direct-nameserver:
   - 'https://dns.alidns.com/dns-query'
-  - 'https://1.12.12.12/dns-query'
+  - 'https://doh.pub/dns-query'
   nameserver-policy:
     '+.jsdelivr.net':
-    - 'https://1.1.1.1/dns-query'
-    - 'https://8.8.8.8/dns-query'
+    - 'https://cloudflare-dns.com/dns-query'
+    - 'https://dns.google/dns-query'
     '+.github.com':
-    - 'https://1.1.1.1/dns-query'
-    - 'https://8.8.8.8/dns-query'
+    - 'https://cloudflare-dns.com/dns-query'
+    - 'https://dns.google/dns-query'
   fallback:
   - 'https://dns.google/dns-query'
   - 'https://dns.cloudflare.com/dns-query'

--- a/Clash Party/README.md
+++ b/Clash Party/README.md
@@ -207,19 +207,19 @@ dns:
     - 1.1.1.1
     - 8.8.8.8
   nameserver:
-    - https://223.5.5.5/dns-query
-    - https://1.12.12.12/dns-query
+    - https://dns.alidns.com/dns-query
+    - https://doh.pub/dns-query
   proxy-server-nameserver:
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
-    - https://223.5.5.5/dns-query
-    - https://1.12.12.12/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
+    - https://dns.alidns.com/dns-query
+    - https://doh.pub/dns-query
   direct-nameserver:
-    - https://223.5.5.5/dns-query
-    - https://1.12.12.12/dns-query
+    - https://dns.alidns.com/dns-query
+    - https://doh.pub/dns-query
   fallback:
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
   fallback-filter:
     geoip: true
     geoip-code: CN

--- a/Loon/Loon.conf
+++ b/Loon/Loon.conf
@@ -21,7 +21,7 @@ bypass-tun = 10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16.0.0/12,1
 # ─── DNS （对齐 Clash Party 基线：国内明文 DNS + 国外 DoH 备用） ─────────────
 # Loon `dns-server` 仅接受 `system` 与纯 IP；DoH URL 必须放 `doh-server`。
 dns-server = system, 223.5.5.5, 119.29.29.29
-doh-server = https://1.12.12.12/dns-query, https://dns.alidns.com/dns-query, https://1.1.1.1/dns-query, https://8.8.8.8/dns-query
+doh-server = https://doh.pub/dns-query, https://dns.alidns.com/dns-query, https://cloudflare-dns.com/dns-query, https://dns.google/dns-query
 
 # IPv6（Loon 原生字段名 `ipv6`，不是 `ipv6-enabled`）
 ipv6 = true

--- a/OpenClash/OpenClash(mihomo).sh
+++ b/OpenClash/OpenClash(mihomo).sh
@@ -87,34 +87,34 @@ dns:
   - 8.8.8.8
   nameserver-policy:
     '+.jsdelivr.net':
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
     '+.github.com':
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
     '+.githubusercontent.com':
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
     '+.githubassets.com':
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
     '+.fastly.net':
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
   nameserver:
-  - https://223.5.5.5/dns-query
-  - https://1.12.12.12/dns-query
+  - https://dns.alidns.com/dns-query
+  - https://doh.pub/dns-query
   proxy-server-nameserver:
-  - https://1.1.1.1/dns-query
-  - https://8.8.8.8/dns-query
-  - https://223.5.5.5/dns-query
-  - https://1.12.12.12/dns-query
+  - https://cloudflare-dns.com/dns-query
+  - https://dns.google/dns-query
+  - https://dns.alidns.com/dns-query
+  - https://doh.pub/dns-query
   direct-nameserver:
-  - https://223.5.5.5/dns-query
-  - https://1.12.12.12/dns-query
+  - https://dns.alidns.com/dns-query
+  - https://doh.pub/dns-query
   fallback:
-  - https://1.1.1.1/dns-query
-  - https://8.8.8.8/dns-query
+  - https://cloudflare-dns.com/dns-query
+  - https://dns.google/dns-query
   fallback-filter:
     geoip: true
     geoip-code: CN

--- a/OpenClash/OpenClash(mihomo-smart).sh
+++ b/OpenClash/OpenClash(mihomo-smart).sh
@@ -84,34 +84,34 @@ dns:
   - 8.8.8.8
   nameserver-policy:
     '+.jsdelivr.net':
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
     '+.github.com':
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
     '+.githubusercontent.com':
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
     '+.githubassets.com':
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
     '+.fastly.net':
-    - https://1.1.1.1/dns-query
-    - https://8.8.8.8/dns-query
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
   nameserver:
-  - https://223.5.5.5/dns-query
-  - https://1.12.12.12/dns-query
+  - https://dns.alidns.com/dns-query
+  - https://doh.pub/dns-query
   proxy-server-nameserver:
-  - https://1.1.1.1/dns-query
-  - https://8.8.8.8/dns-query
-  - https://223.5.5.5/dns-query
-  - https://1.12.12.12/dns-query
+  - https://cloudflare-dns.com/dns-query
+  - https://dns.google/dns-query
+  - https://dns.alidns.com/dns-query
+  - https://doh.pub/dns-query
   direct-nameserver:
-  - https://223.5.5.5/dns-query
-  - https://1.12.12.12/dns-query
+  - https://dns.alidns.com/dns-query
+  - https://doh.pub/dns-query
   fallback:
-  - https://1.1.1.1/dns-query
-  - https://8.8.8.8/dns-query
+  - https://cloudflare-dns.com/dns-query
+  - https://dns.google/dns-query
   fallback-filter:
     geoip: true
     geoip-code: CN

--- a/Quantumult X/QuantumultX.conf
+++ b/Quantumult X/QuantumultX.conf
@@ -20,10 +20,10 @@ fallback_udp_policy=reject
 # 对齐 Clash Party 基线：国内 DoH 为主 + 国外 DoH 备用
 server=223.5.5.5
 server=119.29.29.29
-server=https://1.12.12.12/dns-query
+server=https://doh.pub/dns-query
 server=https://dns.alidns.com/dns-query
-server=https://1.1.1.1/dns-query
-server=https://8.8.8.8/dns-query
+server=https://cloudflare-dns.com/dns-query
+server=https://dns.google/dns-query
 # DNS 劫持（Netflix / Chromecast 硬编码 DNS）
 server=/*.apple.com/system
 server=/*.icloud.com/system

--- a/Quantumult X/README.md
+++ b/Quantumult X/README.md
@@ -166,10 +166,10 @@ QX 的 DNS 配置用多行 `server=` 声明：
 ```
 server=223.5.5.5
 server=119.29.29.29
-server=https://1.12.12.12/dns-query
+server=https://doh.pub/dns-query
 server=https://dns.alidns.com/dns-query
-server=https://1.1.1.1/dns-query
-server=https://8.8.8.8/dns-query
+server=https://cloudflare-dns.com/dns-query
+server=https://dns.google/dns-query
 server=/*.apple.com/system     # 系统 DNS 处理 Apple 服务
 server=/*.icloud.com/system
 no-ipv6                        # QX 的 IPv6 策略（与 Clash `ipv6: false` 对齐）

--- a/README.md
+++ b/README.md
@@ -240,11 +240,11 @@ flowchart TB
 
     Gate{{"<b>🔀 按域名性质分三路查询</b>"}}
 
-    L2["<b>② nameserver</b> &nbsp;·&nbsp; 国内域名主通道 &nbsp;·&nbsp; DoH<br/><br/><b>AliDNS</b> &nbsp; https://223.5.5.5/dns-query<br/><b>DNSPod</b> &nbsp; https://1.12.12.12/dns-query<br/>大陆站点 / 国内 CDN 用国内权威 DoH &nbsp;→&nbsp; 不被 ISP 记录"]
+    L2["<b>② nameserver</b> &nbsp;·&nbsp; 国内域名主通道 &nbsp;·&nbsp; DoH<br/><br/><b>AliDNS</b> &nbsp; https://dns.alidns.com/dns-query<br/><b>DNSPod</b> &nbsp; https://doh.pub/dns-query<br/>大陆站点 / 国内 CDN 用国内权威 DoH &nbsp;→&nbsp; 不被 ISP 记录"]
 
-    L3["<b>③ proxy-server-nameserver</b> &nbsp;·&nbsp; 机场节点域名解析 &nbsp;·&nbsp; DoH<br/><br/><b>Cloudflare</b> &nbsp; https://1.1.1.1/dns-query<br/><b>Google</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://8.8.8.8/dns-query<br/><b>AliDNS</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://223.5.5.5/dns-query<br/><b>DNSPod</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://1.12.12.12/dns-query<br/>解析 node.xxx-airport.com 走加密 DoH<br/>→&nbsp; 节点域名与 IP 都不暴露给 ISP，也不被 DNS 污染"]
+    L3["<b>③ proxy-server-nameserver</b> &nbsp;·&nbsp; 机场节点域名解析 &nbsp;·&nbsp; DoH<br/><br/><b>Cloudflare</b> &nbsp; https://cloudflare-dns.com/dns-query<br/><b>Google</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://dns.google/dns-query<br/><b>AliDNS</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://dns.alidns.com/dns-query<br/><b>DNSPod</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://doh.pub/dns-query<br/>解析 node.xxx-airport.com 走加密 DoH<br/>→&nbsp; 节点域名与 IP 都不暴露给 ISP，也不被 DNS 污染"]
 
-    L4["<b>④ fallback</b> &nbsp;·&nbsp; 海外域名回退通道 &nbsp;·&nbsp; DoH + GeoIP 解毒<br/><br/><b>Cloudflare</b> &nbsp; https://1.1.1.1/dns-query<br/><b>Google</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://8.8.8.8/dns-query<br/><b>fallback-filter.geoip-code: CN</b><br/>海外域名若查出 CN 段 IP（说明被污染）<br/>→&nbsp; 自动切 fallback 重查，避开 GFW 注入的假 IP"]
+    L4["<b>④ fallback</b> &nbsp;·&nbsp; 海外域名回退通道 &nbsp;·&nbsp; DoH + GeoIP 解毒<br/><br/><b>Cloudflare</b> &nbsp; https://cloudflare-dns.com/dns-query<br/><b>Google</b> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; https://dns.google/dns-query<br/><b>fallback-filter.geoip-code: CN</b><br/>海外域名若查出 CN 段 IP（说明被污染）<br/>→&nbsp; 自动切 fallback 重查，避开 GFW 注入的假 IP"]
 
     Start --> L1
     L1 ==>|"<b>bootstrap 成功后，所有业务查询全走加密 DoH</b>"| Gate
@@ -275,8 +275,8 @@ flowchart TB
 ### 推荐做法
 
 1. **首选加密 DoH**。不要用明文 UDP DNS（`114.114.114.114` / `8.8.8.8` 直连 53）——`114.114.114.114` 在大陆运营商会做劫持，`8.8.8.8` 会被 GFW 污染 + ISP 看到你在用海外 DNS。
-2. **国内 DoH 建议用 AliDNS + DNSPod 组合**（`https://223.5.5.5/dns-query` + `https://1.12.12.12/dns-query`）。两家都是中国合规 DoH，在 443 端口的 TLS 流量里 ISP 无法区分。
-3. **海外 DoH 建议用 Cloudflare + Google**（`https://1.1.1.1/dns-query` + `https://8.8.8.8/dns-query`）。Cloudflare 额外支持 ODoH / ECH，隐私更好。
+2. **国内 DoH 建议用 AliDNS + DNSPod 组合**（`https://dns.alidns.com/dns-query` + `https://doh.pub/dns-query`）。两家都是中国合规 DoH，在 443 端口的 TLS 流量里 ISP 无法区分。
+3. **海外 DoH 建议用 Cloudflare + Google**（`https://cloudflare-dns.com/dns-query` + `https://dns.google/dns-query`）。Cloudflare 额外支持 ODoH / ECH，隐私更好。
 4. **`proxy-server-nameserver` 必须单独配置**（容易忽略）。这是解决"机场节点 IP 被针对性封"的关键——让机场节点域名的解析也走海外 DoH 而不是默认通道。
 5. **fake-ip 模式强烈推荐**（`enhanced-mode: fake-ip`）。比 redir-host 快 + 无本地缓存污染 + 规则命中更精准。
 6. **别在 `hosts:` 里写业务域名**。`hosts:` 只适合给 bootstrap DoH（例如 `one.one.one.one → 1.1.1.1`）写兜底 IP，用来规避 DNS 冷启动死锁；写业务域名会让本配置的规则命中失效。
@@ -290,7 +290,7 @@ https://whoami.cloudflare.com    # 应显示 Cloudflare DoH
 
 # 2) 命令行直接测 DoH 可达
 curl -H 'accept: application/dns-json' \
-  'https://1.12.12.12/dns-query?name=google.com&type=A'
+  'https://doh.pub/dns-query?name=google.com&type=A'
 # 成功 = 返回 JSON（含 Answer 字段）
 
 # 3) 抓包确认查询走 443（不是 53）

--- a/Shadowrocket/Shadowrocket.conf
+++ b/Shadowrocket/Shadowrocket.conf
@@ -20,12 +20,12 @@ tun-excluded-routes = 10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,172.16
 # SR 设计上不区分 nameserver / direct-nameserver：dns-server 同时服务于两者
 # 直连类域名通过此 DNS 解析（国内域名用国内 DoH 更快更准）
 # 并发查询策略：多个 DNS 同时发起，采用最先返回的结果
-dns-server = https://dns.alidns.com/dns-query,https://1.12.12.12/dns-query,223.5.5.5,119.29.29.29
+dns-server = https://dns.alidns.com/dns-query,https://doh.pub/dns-query,223.5.5.5,119.29.29.29
 
 # ─── 代理域名 DNS（对应 Clash proxy-server-nameserver；隐藏参数） ─────────────
 # 用于解析节点本身的域名（如 node.xxx.com），以及经代理连接时的 DNS 查询
 # 国外 DoH 前置，防止国内 DNS 对代理类域名返回污染结果
-proxy-dns-server = https://dns.cloudflare.com/dns-query,https://dns.google/dns-query,https://dns.alidns.com/dns-query,https://1.12.12.12/dns-query
+proxy-dns-server = https://dns.cloudflare.com/dns-query,https://dns.google/dns-query,https://dns.alidns.com/dns-query,https://doh.pub/dns-query
 
 # ─── 备用 DNS（对应 Clash fallback；主 DNS 超时 2s 后回退） ───────────────────
 # 国外 DoH 做 fallback，确保 DNS 污染或超时情况下仍能解析

--- a/SingBox/README.md
+++ b/SingBox/README.md
@@ -198,8 +198,8 @@ node 'SingBox/SingBox(sing-box)-generator.js'
 为贴近 Clash Party 使用教程中的「DNS + Sniffer + GeoX URL」补充项，`SingBox(sing-box)-full.json` 已对应实现：
 
 - **DNS 增强**：
-  - `dns_direct`（223.5.5.5 DoH）用于国内规则集；
-  - `dns_proxy`（1.1.1.1 DoH）用于代理解析；
+  - `dns_direct`（dns.alidns.com DoH）用于国内规则集；
+  - `dns_proxy`（cloudflare-dns.com DoH）用于代理解析；
   - 广告 DNS 规则使用 `action: "reject"` 返回拒绝响应。
 - **嗅探增强**：
   - `inbounds.tun.sniff=true`

--- a/SingBox/SingBox(sing-box)-full.json
+++ b/SingBox/SingBox(sing-box)-full.json
@@ -12,9 +12,9 @@
     },
     "_meta": {
       "name": "SingBox Smart Full",
-      "version": "v5.2.9-sing.1",
-      "build": "2026-04-25",
-      "baseline": "Clash Party v5.2.9",
+      "version": "v5.2.8-sing.2",
+      "build": "2026-04-23",
+      "baseline": "Clash Party v5.2.8",
       "changelog": "见 SingBox/CHANGELOG.md"
     }
   },
@@ -23,13 +23,13 @@
       {
         "tag": "dns_direct",
         "type": "https",
-        "server": "223.5.5.5",
+        "server": "dns.alidns.com",
         "detour": "DIRECT"
       },
       {
         "tag": "dns_proxy",
         "type": "https",
-        "server": "1.1.1.1",
+        "server": "cloudflare-dns.com",
         "detour": "🚀 节点选择"
       }
     ],

--- a/Surge/Surge.conf
+++ b/Surge/Surge.conf
@@ -29,7 +29,7 @@ read-etc-hosts = true
 # Surge 的 dns-server 是"通用"解析；encrypted-dns-server 专用于 DoH/DoT，
 # 两者都填时 Surge 会并发，最先返回结果的优先。
 dns-server = 223.5.5.5, 119.29.29.29, system
-encrypted-dns-server = https://1.12.12.12/dns-query, https://dns.alidns.com/dns-query, https://1.1.1.1/dns-query, https://8.8.8.8/dns-query
+encrypted-dns-server = https://doh.pub/dns-query, https://dns.alidns.com/dns-query, https://cloudflare-dns.com/dns-query, https://dns.google/dns-query
 encrypted-dns-follow-outbound-mode = false
 
 # DNS 劫持：劫持系统里硬编码的 8.8.8.8/4.4.4.4 查询（Netflix/Chromecast 常见）到 Surge DNS。


### PR DESCRIPTION
## Summary

将全仓库所有配置产物和文档中的 IP 形式 DoH URL 替换为域名形式：

| 旧 URL | 新 URL |
|--------|--------|
| `https://223.5.5.5/dns-query` | `https://dns.alidns.com/dns-query` |
| `https://1.12.12.12/dns-query` | `https://doh.pub/dns-query` |
| `https://1.1.1.1/dns-query` | `https://cloudflare-dns.com/dns-query` |
| `https://8.8.8.8/dns-query` | `https://dns.google/dns-query` |
| SingBox `"server": "223.5.5.5"` | `"server": "dns.alidns.com"` |
| SingBox `"server": "1.1.1.1"` | `"server": "cloudflare-dns.com"` |

## 影响面

| 文件 | 改动说明 |
|------|----------|
| CMFA(mihomo).yaml | nameserver/proxy-server-nameserver/direct-nameserver/nameserver-policy/fallback 中的 DoH URL |
| OpenClash(mihomo).sh / OpenClash(mihomo-smart).sh | nameserver/proxy-server-nameserver/direct-nameserver/fallback/nameserver-policy 中的 DoH URL |
| Shadowrocket.conf | dns-server / proxy-dns-server 中的 DoH URL |
| Surge.conf | encrypted-dns-server 中的 DoH URL |
| Loon.conf | doh-server 中的 DoH URL |
| QuantumultX.conf | [dns] server 中的 DoH URL |
| SingBox(sing-box)-full.json | dns.servers 的 server 字段（IP → 域名），已通过 generator 重新验证 |
| Clash Party / Quantumult X / SingBox / 根 README | 示例代码和文档中的 URL |
| CHANGELOG | 跳过（历史记录，不应修改） |