### PR TITLE
fix: REGIONS 显式补齐 alpha-3 码 HKG/TWN/JPN/SGP

### DIFF
--- a/OpenClash/CHANGELOG.md
+++ b/OpenClash/CHANGELOG.md
@@ -16,6 +16,7 @@
   - `JP` → `\bJP\b`（防命中 JPG/JPMorgan）、`SG` → `\bSG\b`（防命中 SGP）
   - `US\b` → `\bUS\b`（补起始 boundary，防 FOCUS 等内含 US 的词误匹配）
   - 同步 OpenClash Full
+- ★ FIX-OC-01α：显式补齐 alpha-3 码 `HKG`/`TWN`/`JPN`/`SGP`（`\b` 丢失子串匹配能力后需显式声明，与 FIX#24 的 `KOR` 做法一致）
 - Bump: `v5.2.8-oc-normal.4` → `v5.2.9-oc-normal.5`
 
 ### v5.2.8-oc-normal.4 (2026-04-24) — DNSPod DoH 端点切换为纯 IP 形式
@@ -107,6 +108,7 @@
 ### v5.2.9-oc-full.5 (2026-04-25) — 兼容性审计修复
 
 - ★ FIX-OC-01：REGIONS 正则补齐 HK/TW/JP/SG/US 的 `\b` word boundary（与 Normal 同步）
+- ★ FIX-OC-01α：显式补齐 alpha-3 码 `HKG`/`TWN`/`JPN`/`SGP`（与 Normal 同步）
 - Bump: `v5.2.8-oc-full.4` → `v5.2.9-oc-full.5`
 
 ### v5.2.8-oc-full.4 (2026-04-24) — DNSPod DoH 端点切换为纯 IP 形式

--- a/OpenClash/OpenClash(mihomo).sh
+++ b/OpenClash/OpenClash(mihomo).sh
@@ -4240,13 +4240,13 @@ status "[filter] raw=#{raw_proxies.size} filtered=#{filtered_proxies.size} home=
 # Phase 1b: 区域分类
 # ---------------------------------------------------------------
 REGIONS = {
-  "HK"  => /香港|\bHK\b|Hong\s?Kong|🇭🇰/i,
-  "TW"  => /台湾|台灣|\bTW\b|Taiwan|🇹🇼/i,
-  "JP"  => /日本|\bJP\b|Japan|🇯🇵|Tokyo|Osaka/i,
-  # v5.2.6-oc-normal.1 FIX#24-P0: 补 KOR（TW/JP/SG 已能通过子串匹配命中 TWN/JPN/SGP，
-  #   但 KOR 不是 KR 的子串，原始 /KR/ 无法匹配 "KOR 01" 这类节点）
+  "HK"  => /香港|\bHK\b|HKG|Hong\s?Kong|🇭🇰/i,
+  "TW"  => /台湾|台灣|\bTW\b|TWN|Taiwan|🇹🇼/i,
+  "JP"  => /日本|\bJP\b|JPN|Japan|🇯🇵|Tokyo|Osaka/i,
+  # v5.2.6-oc-normal.1 FIX#24-P0: 补 KOR（KOR 不是 KR 的子串，原始 /KR/ 无法匹配 "KOR 01"）
+  #   HK/TW/JP/SG 使用 \b 防误匹配，显式补充 alpha-3 码 HKG/TWN/JPN/SGP
   "KR"  => /韩国|韓國|KR|KOR|Korea|Korean|🇰🇷|Seoul/i,
-  "SG"  => /新加坡|\bSG\b|Singapore|🇸🇬/i,
+  "SG"  => /新加坡|\bSG\b|SGP|Singapore|🇸🇬/i,
   "US"  => /美国|美國|\bUS\b|USA|United\s?States|America|🇺🇸|Los\s?Angeles|New\s?York|Seattle|Silicon|San\s?Jose/i,
   "UK"  => /英国|英國|UK\b|GB\b|Britain|London|🇬🇧/i,
   "DE"  => /德国|德國|DE\b|Germany|Frankfurt|🇩🇪/i,

--- a/OpenClash/OpenClash(mihomo-smart).sh
+++ b/OpenClash/OpenClash(mihomo-smart).sh
@@ -4237,13 +4237,13 @@ status "[filter] raw=#{raw_proxies.size} filtered=#{filtered_proxies.size} remov
 # Phase 1b: 区域分类
 # ---------------------------------------------------------------
 REGIONS = {
-  "HK"  => /香港|\bHK\b|Hong\s?Kong|🇭🇰/i,
-  "TW"  => /台湾|台灣|\bTW\b|Taiwan|🇹🇼/i,
-  "JP"  => /日本|\bJP\b|Japan|🇯🇵|Tokyo|Osaka/i,
-  # v5.2.6-oc-full FIX#24-P0: 补 KOR（TW/JP/SG 子串匹配能命中 TWN/JPN/SGP，
-  #   但 KOR 不是 KR 的子串，原始 /KR/ 无法匹配 "KOR 01"）
+  "HK"  => /香港|\bHK\b|HKG|Hong\s?Kong|🇭🇰/i,
+  "TW"  => /台湾|台灣|\bTW\b|TWN|Taiwan|🇹🇼/i,
+  "JP"  => /日本|\bJP\b|JPN|Japan|🇯🇵|Tokyo|Osaka/i,
+  # v5.2.6-oc-full FIX#24-P0: 补 KOR（KOR 不是 KR 的子串，原始 /KR/ 无法匹配 "KOR 01"）
+  #   HK/TW/JP/SG 使用 \b 防误匹配，显式补充 alpha-3 码 HKG/TWN/JPN/SGP
   "KR"  => /韩国|韓國|KR|KOR|Korea|Korean|🇰🇷|Seoul/i,
-  "SG"  => /新加坡|\bSG\b|Singapore|🇸🇬/i,
+  "SG"  => /新加坡|\bSG\b|SGP|Singapore|🇸🇬/i,
   "US"  => /美国|美國|\bUS\b|USA|United\s?States|America|🇺🇸|Los\s?Angeles|New\s?York|Seattle|Silicon|San\s?Jose/i,
   "UK"  => /英国|英國|UK\b|GB\b|Britain|London|🇬🇧/i,
   "DE"  => /德国|德國|DE\b|Germany|Frankfurt|🇩🇪/i,


### PR DESCRIPTION
\bHK\b 不匹配 HKG、\bTW\b 不匹配 TWN，显式追加 alpha-3 字面量
（与 FIX#24 的 KOR 做法一致），更新相关注释。