### PR TITLE
fix(openclash): sniffer.skip-domain 误含币安域名导致 TLS 流量跳过 SNI 改写

### DIFF
--- a/OpenClash/CHANGELOG.md
+++ b/OpenClash/CHANGELOG.md
@@ -9,6 +9,18 @@
 
 ## Normal（`OpenClash(mihomo).sh`，非 Smart 内核 / url-test 版）
 
+### v5.2.10-oc-normal.2 (2026-04-25) — FIX: sniffer.skip-domain 误含币安域名导致 TLS 流量按 IP 路由
+
+- ★ **FIX：OpenClash sniffer.skip-domain 误含 3 条币安域名，导致 TLS SNI 改写被跳过**
+  - 现象：freqtrade/量化交易容器访问 `data.binance.vision`、`fapi.binance.com` 等时出现
+    `ContentLengthError` / `Cannot connect` / `TimeoutError`
+  - 根因：`sniffer.skip-domain` 含 `+.binance.com` / `+.binancefuture.com` / `+.binance.vision`，
+    sniffer 嗅出 SNI 后跳过域名改写，导致流量按原始 IP 路由 → 不命中
+    `DOMAIN-SUFFIX,binance.*,💰 加密货币` → `MATCH` → 🐟 漏网之鱼 → 代理节点拒接或无 SNI 流量超时
+  - 修复：删除 `skip-domain` 中 3 条币安条目，保留 `+.push.apple.com` 和 `Mijia Cloud`。
+    fake-ip 层仍正常给币安分配真实 IP，sniffer 嗅出 SNI 后按 `DOMAIN-SUFFIX` 规则正确分流到 💰 加密货币组
+  - 版本号 `v5.2.10-oc-normal.1` → `v5.2.10-oc-normal.2`
+
 ### v5.2.10-oc-normal.1 (2026-04-25) — 境外 DoH 端点改路由到 🚫 受限网站
 
 - ★ **FIX#39**（同构联动）：跟随 Clash Party v5.2.10 基线
@@ -114,6 +126,12 @@
 ---
 
 ## Full（`OpenClash(mihomo-smart).sh`）
+
+### v5.2.10-oc-full.2 (2026-04-25) — FIX: sniffer.skip-domain 误含币安域名导致 TLS 流量按 IP 路由
+
+- ★ sniffer.skip-domain 删除 3 条币安域名（与 Normal 同步）
+  - 根因 / 修复 / 影响同 Normal `v5.2.10-oc-normal.2`
+  - 版本号 `v5.2.10-oc-full.1` → `v5.2.10-oc-full.2`
 
 ### v5.2.10-oc-full.1 (2026-04-25) — 境外 DoH 端点改路由到 🚫 受限网站
 

--- a/OpenClash/OpenClash(mihomo).sh
+++ b/OpenClash/OpenClash(mihomo).sh
@@ -2,7 +2,7 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash v5.2.10-oc-normal.1 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
+# Clash v5.2.10-oc-normal.2 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
 # ============================================================================
 # 定位：与同目录 OpenClash(mihomo-smart).sh 规则 100% 等价的「非 Smart 内核」版本。
 #       两者唯一区别：18 个区域组（9 全部 + 9 家宽）从 type: smart（uselightgbm）换成 type: url-test。
@@ -25,7 +25,7 @@
 
 
 
-VERSION_TAG="v5.2.10-oc-normal.1"
+VERSION_TAG="v5.2.10-oc-normal.2"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -148,10 +148,7 @@ sniffer:
       - '4433'
   skip-domain:
   - +.push.apple.com
-  - +.binance.com
   - Mijia Cloud
-  - +.binancefuture.com
-  - +.binance.vision
   skip-dst-address:
   - 91.105.192.0/23
   - 91.108.4.0/22
@@ -4196,7 +4193,7 @@ cat > "$RUBY_SCRIPT" << 'RUBY_EOF'
 require 'yaml'
 require 'digest'
 
-VERSION = "v5.2.10-oc-normal.1"
+VERSION = "v5.2.10-oc-normal.2"
 
 STATUS_LOG = "/tmp/clash_normal_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }

--- a/OpenClash/OpenClash(mihomo-smart).sh
+++ b/OpenClash/OpenClash(mihomo-smart).sh
@@ -2,7 +2,7 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash Smart v5.2.10-oc-full.1 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
+# Clash Smart v5.2.10-oc-full.2 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
 # ============================================================================
 # 定位：对齐 Clash Party v5.2.10 JS 主线的 OpenClash 全量版本。
 #       与同目录 OpenClash(mihomo).sh（Normal）互补：
@@ -22,7 +22,7 @@
 
 
 
-VERSION_TAG="v5.2.10-oc-full.1"
+VERSION_TAG="v5.2.10-oc-full.2"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -145,10 +145,7 @@ sniffer:
       - '4433'
   skip-domain:
   - +.push.apple.com
-  - +.binance.com
   - Mijia Cloud
-  - +.binancefuture.com
-  - +.binance.vision
   skip-dst-address:
   - 91.105.192.0/23
   - 91.108.4.0/22
@@ -4193,7 +4190,7 @@ cat > "$RUBY_SCRIPT" << 'RUBY_EOF'
 require 'yaml'
 require 'digest'
 
-VERSION = "v5.2.10-oc-full.1"
+VERSION = "v5.2.10-oc-full.2"
 
 STATUS_LOG = "/tmp/clash_smart_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }


### PR DESCRIPTION
## Summary

- **问题**：OpenClash Normal + Full 两脚本的 `sniffer.skip-domain` 含 3 条币安域名（`+.binance.com` / `+.binancefuture.com` / `+.binance.vision`），导致 freqtrade 等量化交易容器访问币安 API 时出现 `ContentLengthError` / `Cannot connect` / `TimeoutError`
  
- **根因**：`skip-domain` 命中后 sniffer 跳过域名改写，流量按原始 CloudFront IP 路由 → 不命中 `DOMAIN-SUFFIX,binance.*,💰 加密货币` → `MATCH` → 🐟 漏网之鱼 → 代理节点无 SNI 拒接或直连超时

- **修复**：删除 `skip-domain` 中 3 条币安条目，保留 `+.push.apple.com` 和 `Mijia Cloud`

## 影响范围

| 文件 | 改动 |
|------|------|
| OpenClash/OpenClash(mihomo).sh | skip-domain 删 3 行 + 版本号 v5.2.10-oc-normal.1 → .2 |
| OpenClash/OpenClash(mihomo-smart).sh | skip-domain 删 3 行 + 版本号 v5.2.10-oc-full.1 → .2 |
| OpenClash/CHANGELOG.md | Normal + Full 各追加 v5.2.10-*-2 条目 |

### 不受影响的产物
- **CMFA** — skip-domain 仅有 `+.push.apple.com`，无币安条目
- **Shadowrocket / Surge / Loon / QX / SingBox / v2rayN / Passwall** — 均无 sniffer skip-domain 概念（平台差异豁免）
- **Clash Party JS** — 无 sniffer 配置

## 自检结果
- `proxy: DIRECT` 在 Normal = 0 / Full = 0 ✓
- Shadowrocket 无死引用 ✓