### PR TITLE
fix(openclash-smart): fake-ip-filter 误含币安域名导致 docker 场景走错代理出口

### DIFF
--- a/OpenClash/OpenClash(mihomo-smart).sh
+++ b/OpenClash/OpenClash(mihomo-smart).sh
@@ -64,9 +64,6 @@ dns:
   - +.stun.*.*.*
   - +.ntp.org
   - +.pool.ntp.org
-  - +.binance.com
-  - +.binancefuture.com
-  - +.binance.vision
   - +.n.n.srv.nintendo.net
   - +.stun.playstation.net
   - +.xboxlive.com


### PR DESCRIPTION
fake-ip-filter 中命中的域名会跳过 fake-ip 路径,客户端直接拿真实公网 IP。 这让 OpenClash 失去 fake-ip 表反向查域名的捷径,binance.com 的规则匹配 只能靠 sniffer 在 TLS ClientHello 阶段嗅探 SNI 兜底。

在 Docker 容器(尤其 Docker Desktop on Windows + WSL2)场景下,容器 DNS 链路存在嵌入式 DNS 缓存 / dns: 公共 IP 绕开 dnsmasq 等多种 race,sniffer SNI 兜底失败时,binance 流量会按 IP 命中 GEOIP,cloudflare 进 ☁️ 云与CDN 组,或 MATCH 进 🐟 漏网之鱼,绕开 💰 加密货币 代理组,表现为断连或走错节点。

历史上 sniffer.skip-domain 同样误含币安域名已在 #112/#115(commit 2bc7647) 修复;本次清理 fake-ip-filter 中遗留的同类问题。

移除:
  - +.binance.com
  - +.binancefuture.com
  - +.binance.vision

正常 PC / 手机客户端通过路由器 dnsmasq → mihomo 标准链路不受影响。