### PR TITLE
docs(readme): Google 生态 IP 一致性使用建议（#120）

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ flowchart LR
 | 🐟 漏网之鱼 | 以 GEOSITE/GEOIP/FINAL 兜底为主（非单一固定 provider） | MetaCubeX（geo 规则） |
 | 🛑 广告拦截 | `anti-ad` `sukka-phishing` `hagezi-tif` `advertising` `privacy` `acc-unsupportvpn` | DustinWin / SukkaW / Hagezi / blackmatrix7 / Accademia |
 
+> ⚠️ **Google 生态使用建议（已登录 Google 账号的用户务必留意）**
+>
+> 本仓库刻意把 Google 服务按业务类型拆到不同组：`gemini.google.com` → `🤖 AI 服务`、`google.com / drive` → `🔍 搜索引擎`、`gmail.com` → `📧 邮件服务`、`youtube.com` → `🇺🇸 美国流媒体`、`meet.google.com` → `🧑‍💼 会议协作`。这样可以让每类业务独立选路（例如 AI 走家宽节点抗限流，搜索走低延迟节点）。
+>
+> **代价**：Google 账号风控会对账号活动做 IP 一致性检查。若上述业务组指向**不同区域 / 不同出口 IP** 的节点，可能触发「我们的系统检测到您的计算机网络中存在异常流量」验证码，部分情况下会让 Gemini 等需账号鉴权的服务直接不可用（参见 [#120](https://github.com/IvanSolis1989/Smart-Config-Kit/issues/120)）。
+>
+> **解决办法**（任选其一，均无需改本仓库配置）：
+>
+> 1. 客户端 UI 里把 `🤖 AI 服务` / `🔍 搜索引擎` / `📧 邮件服务` 三组都指到**同一区域组**（例如统一 `🇺🇸 美国节点`）；
+> 2. 或干脆把这三组都指到 `🌍 全球节点`，让 Smart / url-test 自动收敛到同一节点；
+> 3. 若使用共享出口 IP 的廉价机场，建议优先尝试家宽 / IPLC 节点，机房 IP 命中风控概率更高。
+
 ---
 
 ## 🎯 差异化价值：补充 rule-provider 相对 `geosite.dat` + `geoip.dat` 的差异


### PR DESCRIPTION
## Summary

回应 #120：Gemini 在与 Google 主域走不同节点时偶发「异常流量」验证码 / 鉴权失败。

经评估**不是脚本 bug**——本仓库将 Google 服务按业务类型刻意拆到 5+ 个业务组（Gemini→AI、Google 搜索→搜索引擎、Gmail→邮件、YouTube→美国流媒体、Meet→会议协作），这是 28 业务组架构的核心设计，目的是让用户能为不同业务类型独立选路（AI 走家宽抗限流 / 搜索走低延迟 / 邮件走稳定线路）。

但这一设计的**代价**——Google 账号风控对账号活动做 IP 一致性检查——文档里此前没说，新用户容易踩坑。本 PR 在根 `README.md` 28 业务组速查表后追加一段「使用建议」callout，补齐这个文档缺口，给出三种用户侧解决办法（无需改任何产物配置）。

## 影响面

- ✅ 只改根 `README.md`（+12 行）
- ✅ **不**改任何产物配置 / 规则 / 代理组定义 / DNS
- ✅ **不**命中 CLAUDE.md §1.1 全版本联动触发条件，故无需 bump 11 个产物的版本号 / CHANGELOG
- ✅ 不影响 §5 自检命令

## Test plan

- [x] `git diff --stat` 仅 `README.md +12 -0`
- [x] markdown callout 语法预览正常（`> ⚠️ **...**` + 三行解释 + 1./2./3. 列表）
- [x] issue #120 链接可点开
- [ ] 维护者 review：表述是否准确、是否需要把这段建议同步到子目录 README（个人意见：暂不需要，根 README 是用户首读入口足够）

Closes #120

https://claude.ai/code/session_01X7iG4nKRFLrKfFT5AWpEsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7iG4nKRFLrKfFT5AWpEsR)_