### PR TITLE
fix: Weixin.exe 进程强制 DIRECT + SingBox 生成器重跑修复 hulu.jp 目标组

### DIFF
--- a/Clash Party/CHANGELOG.md
+++ b/Clash Party/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ---
 
+## v5.3.1 (2026-04-28)
+
+- ★ **Weixin.exe 进程强制 DIRECT**：微信进程直连，不走代理
+  - `PROCESS-NAME,Weixin.exe,🏠 国内网站` → `PROCESS-NAME,Weixin.exe,DIRECT`
+  - Weixin.exe 从 DIRECT-block 前置匹配，QQ.exe / WeChat.exe 保持 `🏠 国内网站` 不变
+  - 同步产物：Clash Party Normal / SingBox Full（CMFA / OpenClash 无 PROCESS-NAME 语义，豁免）
+
 ## v5.3.0 (2026-04-26)
 
 - ★ **REFACTOR#2**：流媒体分组架构重构——按区域 → 按平台（解决跨区低价订阅的解锁碎片化问题）

--- a/Clash Party/ClashParty(mihomo).js
+++ b/Clash Party/ClashParty(mihomo).js
@@ -1,5 +1,5 @@
 // Clash 普通内核覆写脚本 - SUB-STORE 多机场精细分流版（非 Smart 内核）
-// 版本：v5.3.0-normal.1 (2026-04-26)
+// 版本：v5.3.0-normal.2 (2026-04-28)
 // 架构：SUB-STORE 多机场融合 + 18 url-test 区域组（9 全部 + 9 家宽）+ 31 业务策略组（含 13 流媒体平台组）+ 371+ rule-providers 100%+ 服务覆盖
 // 基线：Clash Party v5.3.0（与同目录 ClashParty(mihomo-smart).js 规则 100% 等价，仅 18 区域组从 smart 改为 url-test）
 // 适用：Mihomo / Clash.Meta 稳定版内核、不支持 smart + LightGBM 的分支；也适用于想完全关闭 ML 评估的用户
@@ -9,7 +9,7 @@
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.3.0-normal.1'
+const VERSION = 'v5.3.0-normal.2'
 
 // ================================================================
 //  模块 A：节点过滤 / 家宽识别
@@ -1181,6 +1181,7 @@ function injectRules(config) {
     'DOMAIN,ip.cip.cc,DIRECT',
     'PROCESS-NAME,gsupservice.exe,DIRECT',
     'PROCESS-NAME,gchsvc.exe,DIRECT',
+    'PROCESS-NAME,Weixin.exe,DIRECT',
     'DST-PORT,26880,DIRECT',
     'DST-PORT,6540,DIRECT',
     'DST-PORT,33068,DIRECT',
@@ -1188,7 +1189,6 @@ function injectRules(config) {
     'DST-PORT,3478,DIRECT',
     'DST-PORT,3479,DIRECT',
     `PROCESS-NAME,QQ.exe,${BIZ.CN_SITE}`,
-    `PROCESS-NAME,Weixin.exe,${BIZ.CN_SITE}`,
     `PROCESS-NAME,WeChat.exe,${BIZ.CN_SITE}`,
     'DOMAIN-SUFFIX,chiphell.com,DIRECT',
     'DOMAIN-SUFFIX,iwipwedabay.com,DIRECT',

--- a/Clash Party/ClashParty(mihomo-smart).js
+++ b/Clash Party/ClashParty(mihomo-smart).js
@@ -1,5 +1,5 @@
 // Clash Smart 内核覆写脚本 - SUB-STORE 多机场精细分流版
-// 版本：v5.3.0 (2026-04-26)
+// 版本：v5.3.1 (2026-04-28)
 // 架构：SUB-STORE 多机场融合 + 18 Smart 区域组（9 全部 + 9 家宽）+ 31 业务策略组（含 13 流媒体平台组）+ 371+ rule-providers 100%+ 服务覆盖
 // 变更历史：见 `Clash Party/CHANGELOG.md`
 
@@ -7,7 +7,7 @@
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.3.0'
+const VERSION = 'v5.3.1'
 
 // ================================================================
 //  模块 A：节点过滤 / 家宽识别
@@ -1179,6 +1179,7 @@ function injectRules(config) {
     'DOMAIN,ip.cip.cc,DIRECT',
     'PROCESS-NAME,gsupservice.exe,DIRECT',
     'PROCESS-NAME,gchsvc.exe,DIRECT',
+    'PROCESS-NAME,Weixin.exe,DIRECT',
     'DST-PORT,26880,DIRECT',
     'DST-PORT,6540,DIRECT',
     'DST-PORT,33068,DIRECT',
@@ -1186,7 +1187,6 @@ function injectRules(config) {
     'DST-PORT,3478,DIRECT',
     'DST-PORT,3479,DIRECT',
     `PROCESS-NAME,QQ.exe,${BIZ.CN_SITE}`,
-    `PROCESS-NAME,Weixin.exe,${BIZ.CN_SITE}`,
     `PROCESS-NAME,WeChat.exe,${BIZ.CN_SITE}`,
     'DOMAIN-SUFFIX,chiphell.com,DIRECT',
     'DOMAIN-SUFFIX,iwipwedabay.com,DIRECT',

--- a/SingBox/CHANGELOG.md
+++ b/SingBox/CHANGELOG.md
@@ -6,6 +6,12 @@
 ---
 
 
+## v5.3.1-sing.1 (2026-04-28)
+
+- ★ **Weixin.exe 进程强制 DIRECT**（跟随 Clash Party v5.3.1 基线，由生成器自动重生成）
+  - `route.rules[].outbound`：Weixin.exe → `DIRECT`（原 `🏠 国内网站`）
+  - 版本号 `v5.3.0-sing.1` → `v5.3.1-sing.1`
+
 ## v5.3.0-sing.1 (2026-04-26)
 
 - ★ REFACTOR#2：流媒体分组架构重构——按区域 → 按平台（7→13 流媒体组）

--- a/SingBox/SingBox(sing-box)-full.json
+++ b/SingBox/SingBox(sing-box)-full.json
@@ -5,9 +5,9 @@
   },
   "_meta": {
     "name": "SingBox Smart Full",
-    "version": "v5.3.0-sing.1",
-    "build": "2026-04-26",
-    "baseline": "Clash Party v5.3.0",
+    "version": "v5.3.1-sing.1",
+    "build": "2026-04-28",
+    "baseline": "Clash Party v5.3.1",
     "changelog": "见 SingBox/CHANGELOG.md"
   },
   "experimental": {
@@ -1797,6 +1797,13 @@
         "outbound": "DIRECT"
       },
       {
+        "process_name": [
+          "Weixin.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
         "port": [
           26880
         ],
@@ -1841,13 +1848,6 @@
       {
         "process_name": [
           "QQ.exe"
-        ],
-        "action": "route",
-        "outbound": "🏠 国内网站"
-      },
-      {
-        "process_name": [
-          "Weixin.exe"
         ],
         "action": "route",
         "outbound": "🏠 国内网站"
@@ -3967,14 +3967,14 @@
           "hulu.jp"
         ],
         "action": "route",
-        "outbound": "🇯🇵 日韩流媒体"
+        "outbound": "📺 Hulu"
       },
       {
         "domain_suffix": [
           "happyon.jp"
         ],
         "action": "route",
-        "outbound": "🇯🇵 日韩流媒体"
+        "outbound": "📺 Hulu"
       },
       {
         "domain_suffix": [

--- a/SingBox/SingBox(sing-box)-generator.js
+++ b/SingBox/SingBox(sing-box)-generator.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const vm = require('vm');
 
-const VERSION = 'v5.3.0-sing.1';
-const BUILD = '2026-04-26';
-const BASELINE = 'Clash Party v5.3.0';
+const VERSION = 'v5.3.1-sing.1';
+const BUILD = '2026-04-28';
+const BASELINE = 'Clash Party v5.3.1';
 
 const SMART = {
   GLOBAL: '🌍 全球节点',


### PR DESCRIPTION
## Summary
- `PROCESS-NAME,Weixin.exe` 从 `🏠 国内网站` 代理组改为 `DIRECT` 直连前置匹配
- 覆盖 3 份桌面端产物：Clash Party Smart / Clash Party Normal / SingBox Full

## Changes
| 产物 | 版本变更 | 说明 |
|------|----------|------|
| Clash Party Smart JS | v5.3.0 → v5.3.1 | Weixin.exe 移入 DIRECT 前置块 |
| Clash Party Normal JS | v5.3.0-normal.1 → v5.3.0-normal.2 | 同上 |
| SingBox Full JSON | v5.3.0-sing.1 → v5.3.1-sing.1 | generator.js 重新生成 |
| SingBox generator.js | 版本号/baseline 更新 | 跟随基线 |

## 豁免产物
- **CMFA / OpenClash**: Android 进程名非 `.exe` 格式，软路由无法匹配客户端进程，PROCESS-NAME 无意义
- **Shadowrocket / Surge / Loon / QX**: iOS 无进程识别 API
- **Passwall / Passwall2**: OpenWrt 分流规则不支持进程匹配
- **v2rayN Xray**: Xray 路由不支持进程名匹配

## Side fix
SingBox 生成器重跑时顺带修复：`hulu.jp` / `happyon.jp` 目标组 `🇯🇵 日韩流媒体` → `📺 Hulu`（v5.3.0 REFACTOR#2 遗留的不同步）

## Test plan
- [x] Clash Party Smart: `grep PROCESS-NAME,Weixin.exe,DIRECT` = 1, old CN_SITE ref = 0
- [x] Clash Party Normal: 同上
- [x] SingBox: `process_name: ["Weixin.exe"]` outbound = DIRECT
- [x] CMFA/OpenClash: unchanged (restored)
- [x] SingBox JSON valid
- [x] QQ.exe / WeChat.exe → CN_SITE unchanged