### PR TITLE
fix: QQ/WeChat/WeChatAppEx 全系列进程强制 DIRECT

### DIFF
--- a/Clash Party/CHANGELOG.md
+++ b/Clash Party/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ---
 
+## v5.3.2 (2026-04-28)
+
+- ★ **微信/QQ 全系列进程强制 DIRECT**：Weixin.exe / WeChatAppEx.exe / QQ.exe / WeChat.exe → DIRECT
+  - 四款 IM 进程全部移入 DIRECT 前置块，不再走代理组
+  - 新增 `PROCESS-NAME,WeChatAppEx.exe,DIRECT`（微信桌面版辅助进程）
+- 同步产物：Clash Party Normal / SingBox Full（CMFA / OpenClash 豁免）
+
 ## v5.3.1 (2026-04-28)
 
 - ★ **Weixin.exe 进程强制 DIRECT**：微信进程直连，不走代理

--- a/Clash Party/ClashParty(mihomo).js
+++ b/Clash Party/ClashParty(mihomo).js
@@ -1,5 +1,5 @@
 // Clash 普通内核覆写脚本 - SUB-STORE 多机场精细分流版（非 Smart 内核）
-// 版本：v5.3.0-normal.2 (2026-04-28)
+// 版本：v5.3.0-normal.3 (2026-04-28)
 // 架构：SUB-STORE 多机场融合 + 18 url-test 区域组（9 全部 + 9 家宽）+ 31 业务策略组（含 13 流媒体平台组）+ 371+ rule-providers 100%+ 服务覆盖
 // 基线：Clash Party v5.3.0（与同目录 ClashParty(mihomo-smart).js 规则 100% 等价，仅 18 区域组从 smart 改为 url-test）
 // 适用：Mihomo / Clash.Meta 稳定版内核、不支持 smart + LightGBM 的分支；也适用于想完全关闭 ML 评估的用户
@@ -9,7 +9,7 @@
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.3.0-normal.2'
+const VERSION = 'v5.3.0-normal.3'
 
 // ================================================================
 //  模块 A：节点过滤 / 家宽识别
@@ -1182,14 +1182,15 @@ function injectRules(config) {
     'PROCESS-NAME,gsupservice.exe,DIRECT',
     'PROCESS-NAME,gchsvc.exe,DIRECT',
     'PROCESS-NAME,Weixin.exe,DIRECT',
+    'PROCESS-NAME,WeChatAppEx.exe,DIRECT',
+    'PROCESS-NAME,QQ.exe,DIRECT',
+    'PROCESS-NAME,WeChat.exe,DIRECT',
     'DST-PORT,26880,DIRECT',
     'DST-PORT,6540,DIRECT',
     'DST-PORT,33068,DIRECT',
     'DST-PORT,123,DIRECT',
     'DST-PORT,3478,DIRECT',
     'DST-PORT,3479,DIRECT',
-    `PROCESS-NAME,QQ.exe,${BIZ.CN_SITE}`,
-    `PROCESS-NAME,WeChat.exe,${BIZ.CN_SITE}`,
     'DOMAIN-SUFFIX,chiphell.com,DIRECT',
     'DOMAIN-SUFFIX,iwipwedabay.com,DIRECT',
     // v5.2.0 CLEAN#2: Binance 精确 DOMAIN 规则已清理（全部被同组 DOMAIN-SUFFIX 覆盖）

--- a/Clash Party/ClashParty(mihomo-smart).js
+++ b/Clash Party/ClashParty(mihomo-smart).js
@@ -1,5 +1,5 @@
 // Clash Smart 内核覆写脚本 - SUB-STORE 多机场精细分流版
-// 版本：v5.3.1 (2026-04-28)
+// 版本：v5.3.2 (2026-04-28)
 // 架构：SUB-STORE 多机场融合 + 18 Smart 区域组（9 全部 + 9 家宽）+ 31 业务策略组（含 13 流媒体平台组）+ 371+ rule-providers 100%+ 服务覆盖
 // 变更历史：见 `Clash Party/CHANGELOG.md`
 
@@ -7,7 +7,7 @@
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.3.1'
+const VERSION = 'v5.3.2'
 
 // ================================================================
 //  模块 A：节点过滤 / 家宽识别
@@ -1180,14 +1180,15 @@ function injectRules(config) {
     'PROCESS-NAME,gsupservice.exe,DIRECT',
     'PROCESS-NAME,gchsvc.exe,DIRECT',
     'PROCESS-NAME,Weixin.exe,DIRECT',
+    'PROCESS-NAME,WeChatAppEx.exe,DIRECT',
+    'PROCESS-NAME,QQ.exe,DIRECT',
+    'PROCESS-NAME,WeChat.exe,DIRECT',
     'DST-PORT,26880,DIRECT',
     'DST-PORT,6540,DIRECT',
     'DST-PORT,33068,DIRECT',
     'DST-PORT,123,DIRECT',
     'DST-PORT,3478,DIRECT',
     'DST-PORT,3479,DIRECT',
-    `PROCESS-NAME,QQ.exe,${BIZ.CN_SITE}`,
-    `PROCESS-NAME,WeChat.exe,${BIZ.CN_SITE}`,
     'DOMAIN-SUFFIX,chiphell.com,DIRECT',
     'DOMAIN-SUFFIX,iwipwedabay.com,DIRECT',
     // v5.2.0 CLEAN#2: Binance 精确 DOMAIN 规则已清理（全部被同组 DOMAIN-SUFFIX 覆盖）

--- a/SingBox/CHANGELOG.md
+++ b/SingBox/CHANGELOG.md
@@ -6,6 +6,12 @@
 ---
 
 
+## v5.3.2-sing.1 (2026-04-28)
+
+- ★ **微信/QQ 全系列进程强制 DIRECT**（跟随 Clash Party v5.3.2 基线，由生成器自动重生成）
+  - `route.rules[].outbound`：新增 WeChatAppEx.exe / QQ.exe / WeChat.exe → `DIRECT`
+  - 版本号 `v5.3.1-sing.1` → `v5.3.2-sing.1`
+
 ## v5.3.1-sing.1 (2026-04-28)
 
 - ★ **Weixin.exe 进程强制 DIRECT**（跟随 Clash Party v5.3.1 基线，由生成器自动重生成）

--- a/SingBox/SingBox(sing-box)-full.json
+++ b/SingBox/SingBox(sing-box)-full.json
@@ -5,9 +5,9 @@
   },
   "_meta": {
     "name": "SingBox Smart Full",
-    "version": "v5.3.1-sing.1",
+    "version": "v5.3.2-sing.1",
     "build": "2026-04-28",
-    "baseline": "Clash Party v5.3.1",
+    "baseline": "Clash Party v5.3.2",
     "changelog": "见 SingBox/CHANGELOG.md"
   },
   "experimental": {
@@ -1804,6 +1804,27 @@
         "outbound": "DIRECT"
       },
       {
+        "process_name": [
+          "WeChatAppEx.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "QQ.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "WeChat.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
         "port": [
           26880
         ],
@@ -1844,20 +1865,6 @@
         ],
         "action": "route",
         "outbound": "DIRECT"
-      },
-      {
-        "process_name": [
-          "QQ.exe"
-        ],
-        "action": "route",
-        "outbound": "🏠 国内网站"
-      },
-      {
-        "process_name": [
-          "WeChat.exe"
-        ],
-        "action": "route",
-        "outbound": "🏠 国内网站"
       },
       {
         "domain_suffix": [

--- a/SingBox/SingBox(sing-box)-generator.js
+++ b/SingBox/SingBox(sing-box)-generator.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const vm = require('vm');
 
-const VERSION = 'v5.3.1-sing.1';
+const VERSION = 'v5.3.2-sing.1';
 const BUILD = '2026-04-28';
-const BASELINE = 'Clash Party v5.3.1';
+const BASELINE = 'Clash Party v5.3.2';
 
 const SMART = {
   GLOBAL: '🌍 全球节点',


### PR DESCRIPTION
## Summary
- QQ.exe / WeChat.exe / WeChatAppEx.exe 全部从 国内网站 代理组改为 DIRECT 直连
- 加上上一 PR 的 Weixin.exe，四款 IM 桌面进程全部走 DIRECT
- 覆盖：Clash Party Smart / Clash Party Normal / SingBox Full

## Changes
| 产物 | 版本变更 |
|------|----------|
| Clash Party Smart JS | v5.3.1 -> v5.3.2 |
| Clash Party Normal JS | v5.3.0-normal.2 -> v5.3.0-normal.3 |
| SingBox Full JSON | v5.3.1-sing.1 -> v5.3.2-sing.1 |

## DIRECT 进程完整列表（14 条）
WorkPro.exe / GCUService.exe / GCUBridge.exe / CCUWinUI.exe
HipsDaemon.exe / gdphost.exe / gehsender.exe / GSCService.exe
gsupservice.exe / gchsvc.exe
Weixin.exe / WeChatAppEx.exe / QQ.exe / WeChat.exe

## 豁免
CMFA / OpenClash / iOS / Passwall / v2rayN: 无 Windows 进程名语义