### PR TITLE
feat: v5.4.6 — WeChat CDN cdn.weixin.qq.com 全线直连

### DIFF
--- a/Clash Meta For Android/CHANGELOG.md
+++ b/Clash Meta For Android/CHANGELOG.md
@@ -6,6 +6,16 @@
 ---
 
 
+## v5.4.6-cmfa.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN 直连
+  - 新增 `DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT`（置于 iwipwedabay.com 后、binance 前）
+  - 跟随 Clash Party v5.4.6 基线
+
+## v5.4.5-cmfa.1 (2026-05-07)
+
+- ★ 全球节点置顶 + 全产品组顺序同步（跟随基线 v5.4.5）
+
 ## v5.4.4-cmfa.1 (2026-05-07)
 
 - ★ FIX#144：bbys.app DIRECT 规则

--- a/Clash Meta For Android/CMFA(mihomo).yaml
+++ b/Clash Meta For Android/CMFA(mihomo).yaml
@@ -1,8 +1,8 @@
 # ================================================================
-# Clash Smart v5.4.4-cmfa.1 - CMFA (Clash Meta for Android) 配置
-# Build: 2026-05-07
+# Clash Smart v5.4.6-cmfa.1 - CMFA (Clash Meta for Android) 配置
+# Build: 2026-05-08
 # 架构：proxy-providers 订阅 + 22 url-test 区域组（11 全部 + 11 家宽，家宽 filter 新增 IEPL/IPLC/专线识别）+ 31 业务策略组（含 13 流媒体平台组）+ 384+ rule-providers
-# 基线：Clash Party v5.4.4（唯一主线）
+# 基线：Clash Party v5.4.6（唯一主线）
 # 变更历史：见 `Clash Meta For Android/CHANGELOG.md`
 # ================================================================
 # ★ 快速上手：
@@ -3571,6 +3571,7 @@ rules:
 - DST-PORT,3479,DIRECT
 - DOMAIN-SUFFIX,chiphell.com,DIRECT
 - DOMAIN-SUFFIX,iwipwedabay.com,DIRECT
+- DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT
 - 'DOMAIN-SUFFIX,binance.vision,💰 加密货币'
 - 'DOMAIN-SUFFIX,binance.com,💰 加密货币'
 - 'DOMAIN-SUFFIX,binance.info,💰 加密货币'

--- a/Clash Party/CHANGELOG.md
+++ b/Clash Party/CHANGELOG.md
@@ -7,7 +7,13 @@
 
 ---
 
-## v5.4.4 / v5.4.4-normal.1 (2026-05-07)
+## v5.4.6 / v5.4.6-normal.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN `cdn.weixin.qq.com` 直连
+  - 新增 `DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT` 规则，所有微信 CDN 流量直连
+  - 全线 14 产物同步
+
+## v5.4.5 / v5.4.5-normal.1 (2026-05-07)
 
 - ★ FIX#142-P0：修复 v5.4.1+ 引入的 DNS 空壳 bug——`overwriteGeneral` 创建 `config.dns` 时未提供 `nameserver`
   - 当订阅无 DNS 配置时，`if (!config.dns) config.dns = {}` 创建空 DNS 对象

--- a/Clash Party/ClashParty(mihomo).js
+++ b/Clash Party/ClashParty(mihomo).js
@@ -1,7 +1,7 @@
 // Clash 覆写脚本 - SUB-STORE 多机场精细分流版
-// 版本：v5.4.5-normal.1 (2026-05-07)
+// 版本：v5.4.6-normal.1 (2026-05-08)
 // 架构：22 url-test 区域组（11 全部 + 11 家宽）+ 31 业务策略组 + 371+ rule-providers
-// 基线：Clash Party v5.4.5（与同目录 ClashParty(mihomo-smart).js 规则 100% 等价，仅区域组从 smart 改为 url-test）
+// 基线：Clash Party v5.4.6（与同目录 ClashParty(mihomo-smart).js 规则 100% 等价，仅区域组从 smart 改为 url-test）
 // 适用：Mihomo / Clash.Meta 稳定版内核、不支持 smart + LightGBM 的分支；也适用于想完全关闭 ML 评估的用户
 // 变更历史：见 `Clash Party/CHANGELOG.md`
 
@@ -9,7 +9,7 @@
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.4.5-normal.1'
+const VERSION = 'v5.4.6-normal.1'
 
 // ================================================================
 //  模块 A：节点过滤 / 家宽识别
@@ -1220,6 +1220,7 @@ function injectRules(config) {
     'DST-PORT,3479,DIRECT',
     'DOMAIN-SUFFIX,chiphell.com,DIRECT',
     'DOMAIN-SUFFIX,iwipwedabay.com,DIRECT',
+    'DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT',
     // v5.2.0 CLEAN#2: Binance 精确 DOMAIN 规则已清理（全部被同组 DOMAIN-SUFFIX 覆盖）
     // 保留 fake-ip-filter 中的精确域名（DNS 层独立于规则层，不受影响）
     `DOMAIN-SUFFIX,binance.vision,${BIZ.CRYPTO}`,

--- a/Clash Party/ClashParty(mihomo-smart).js
+++ b/Clash Party/ClashParty(mihomo-smart).js
@@ -1,14 +1,14 @@
 // Clash Smart 内核覆写脚本 - SUB-STORE 多机场精细分流版
-// 版本：v5.4.5 (2026-05-07)
+// 版本：v5.4.6 (2026-05-08)
 // 架构：SUB-STORE 多机场融合 + 22 Smart 区域组（11 全部 + 11 家宽）+ 31 业务策略组（含 13 流媒体平台组）+ 371+ rule-providers 100%+ 服务覆盖
-// v5.4.5: 🌍 全球节点置顶 · v5.4.4: FIX#142 DNS · FIX#144 bbys.app · FEAT#143 IEPL/IPLC
+// v5.4.6: WeChat CDN 直连 · v5.4.5: 🌍 全球节点置顶 · v5.4.4: FIX#142 DNS · FIX#144 bbys.app · FEAT#143 IEPL/IPLC
 // 变更历史：见 `Clash Party/CHANGELOG.md`
 
 // ================================================================
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.4.5'
+const VERSION = 'v5.4.6'
 
 // ================================================================
 //  模块 A：节点过滤 / 家宽识别
@@ -1218,6 +1218,7 @@ function injectRules(config) {
     'DST-PORT,3479,DIRECT',
     'DOMAIN-SUFFIX,chiphell.com,DIRECT',
     'DOMAIN-SUFFIX,iwipwedabay.com,DIRECT',
+    'DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT',
     // v5.2.0 CLEAN#2: Binance 精确 DOMAIN 规则已清理（全部被同组 DOMAIN-SUFFIX 覆盖）
     // 保留 fake-ip-filter 中的精确域名（DNS 层独立于规则层，不受影响）
     `DOMAIN-SUFFIX,binance.vision,${BIZ.CRYPTO}`,

--- a/FlClash/CHANGELOG.md
+++ b/FlClash/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 ---
 
+## v5.4.6-flclash.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN 直连 — 新增 `DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT`
+  - 置于 iwipwedabay.com 后、binance 前
+  - 跟随 Clash Party Normal v5.4.6-normal.1 基线
+
+## v5.4.5-flclash.1 (2026-05-07)
+
+- ★ 全球节点置顶 + 全产品组顺序同步（跟随基线 v5.4.5）
+
 ## v5.4.4-flclash.1 (2026-05-07)
 
 - ★ FIX#142-CRITICAL：DNS 安全兜底 nameserver 注入 — 避免空 DNS 导致 DIRECT 超时

--- a/FlClash/FlClash(mihomo).js
+++ b/FlClash/FlClash(mihomo).js
@@ -1,7 +1,7 @@
 // FlClash 覆写脚本 — 标准 Mihomo 内核动态分流版
-// 版本：v5.4.5-flclash.1 (2026-05-07)
+// 版本：v5.4.6-flclash.1 (2026-05-08)
 // 架构：22 url-test 区域组（11 全部 + 11 家宽）+ 31 业务策略组（含 13 流媒体平台组）+ 371+ rule-providers 100%+ 服务覆盖
-// 基线：Clash Party Normal v5.4.5-normal.1（规则 100% 等价；区域组为 url-test — FlClash 内核为标准 Mihomo，不支持 smart + LightGBM）
+// 基线：Clash Party Normal v5.4.6-normal.1（规则 100% 等价；区域组为 url-test — FlClash 内核为标准 Mihomo，不支持 smart + LightGBM）
 // 适用：FlClash >= v0.8.85（覆盖脚本功能自该版本引入）；其他使用标准 Mihomo 内核的客户端
 // 变更历史：见 `FlClash/CHANGELOG.md`
 //
@@ -35,7 +35,7 @@
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.4.5-flclash.1'
+const VERSION = 'v5.4.6-flclash.1'
 
 // FlClash JS 引擎环境兼容：QuickJS 可能不提供 console，安全包装
 var log = (typeof console !== 'undefined' && console.log) ? console.log.bind(console) : function(){}
@@ -1244,6 +1244,7 @@ function injectRules(config) {
     'DST-PORT,3479,DIRECT',
     'DOMAIN-SUFFIX,chiphell.com,DIRECT',
     'DOMAIN-SUFFIX,iwipwedabay.com,DIRECT',
+    'DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT',
     // v5.2.0 CLEAN#2: Binance 精确 DOMAIN 规则已清理（全部被同组 DOMAIN-SUFFIX 覆盖）
     // 保留 fake-ip-filter 中的精确域名（DNS 层独立于规则层，不受影响）
     `DOMAIN-SUFFIX,binance.vision,${BIZ.CRYPTO}`,

--- a/Loon/CHANGELOG.md
+++ b/Loon/CHANGELOG.md
@@ -5,6 +5,16 @@
 ---
 
 
+## v5.4.6-Loon.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN 直连 — 新增 `DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT`
+  - 于阶段 7（国内邮箱直连）`mail.qq.com` 后新增，WeChat CDN 域名直连
+  - 跟随 Clash Party v5.4.6 基线
+
+## v5.4.5-Loon.1 (2026-05-07)
+
+- ★ 全球节点置顶 + 全产品组顺序同步（跟随基线 v5.4.5）
+
 ## v5.4.4-Loon.1 (2026-05-07)
 
 - ★ FIX#144：新增 bbys.app 直连规则（国内可访问视频站点 CDN 域名直连）

--- a/Loon/Loon.conf
+++ b/Loon/Loon.conf
@@ -1,8 +1,8 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Loon Smart v5.4.4-Loon.1 — Loon 版（从 Clash Party v5.4.4 迁移）
-#  Build: 2026-05-07 | Target: Loon iOS (App Store 付费正版)
+#  Loon Smart v5.4.6-Loon.1 — Loon 版（从 Clash Party v5.4.6 迁移）
+#  Build: 2026-05-08 | Target: Loon iOS (App Store 付费正版)
 #  架构：18 区域 url-test 组（9 全部 + 9 家宽）+ 31 业务 select 组（含 13 流媒体平台组）+ 288 [Remote Rule] 订阅规则集
-#  基线：Clash Party v5.4.4（唯一主线）
+#  基线：Clash Party v5.4.6（唯一主线）
 #  变更历史：见 `Loon/CHANGELOG.md`
 # ══════════════════════════════════════════════════════════════════════════════
 
@@ -797,6 +797,7 @@ DOMAIN-SUFFIX,fastmail.fm,🌐 国外网站
 # bm7 邮件规则集
 # 国内邮箱直连
 DOMAIN-SUFFIX,mail.qq.com,DIRECT
+DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT
 DOMAIN-SUFFIX,mail.163.com,DIRECT
 DOMAIN-SUFFIX,mail.126.com,DIRECT
 DOMAIN-SUFFIX,mail.sina.com.cn,DIRECT

--- a/OpenClash/CHANGELOG.md
+++ b/OpenClash/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ---
 
+## v5.4.6-oc-normal.1 / v5.4.6-oc-smart.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN 直连
+  - 两份 shell 脚本 rules 段新增 `DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT`（置于 iwipwedabay.com 后、binance 前）
+  - 跟随 Clash Party v5.4.6 基线
+
+## v5.4.5-oc-normal.1 / v5.4.5-oc-smart.1 (2026-05-07)
+
+- ★ 全球节点置顶 + 全产品组顺序同步（跟随基线 v5.4.5）
+
 ## v5.4.4-oc-normal.1 / v5.4.4-oc-smart.1 (2026-05-07)
 
 - ★ FIX#144：bbys.app DIRECT 规则

--- a/OpenClash/OpenClash(mihomo).sh
+++ b/OpenClash/OpenClash(mihomo).sh
@@ -2,8 +2,8 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash Smart v5.4.4-oc-normal.1 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
-# Build: 2026-05-07
+# Clash Smart v5.4.6-oc-normal.1 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
+# Build: 2026-05-08
 # ============================================================================
 # 定位：与同目录 OpenClash(mihomo-smart).sh 规则 100% 等价的「非 Smart 内核」版本。
 #       两者唯一区别：22 个区域组（11 全部 + 11 家宽）从 type: smart（uselightgbm）换成 type: url-test。
@@ -26,7 +26,7 @@
 
 
 
-VERSION_TAG="v5.4.4-oc-normal.1"
+VERSION_TAG="v5.4.6-oc-normal.1"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -3242,6 +3242,7 @@ rules:
 - "PROCESS-NAME,WeChat.exe,\U0001F3E0 国内网站"
 - DOMAIN-SUFFIX,chiphell.com,DIRECT
 - DOMAIN-SUFFIX,iwipwedabay.com,DIRECT
+- DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT
 - "DOMAIN-SUFFIX,binance.vision,\U0001F4B0 加密货币"
 - "DOMAIN-SUFFIX,binance.com,\U0001F4B0 加密货币"
 - "DOMAIN-SUFFIX,binance.info,\U0001F4B0 加密货币"

--- a/OpenClash/OpenClash(mihomo-smart).sh
+++ b/OpenClash/OpenClash(mihomo-smart).sh
@@ -2,8 +2,8 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash Smart v5.4.4-oc-smart.1 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
-# Build: 2026-05-07
+# Clash Smart v5.4.6-oc-smart.1 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
+# Build: 2026-05-08
 # ============================================================================
 # 定位：对齐 Clash Party v5.4.3 JS 主线的 OpenClash 全量版本。v5.4.2: P0-FIX#41 小米白名单。
 #       与同目录 OpenClash(mihomo).sh（Normal）互补：
@@ -23,7 +23,7 @@
 
 
 
-VERSION_TAG="v5.4.4-oc-smart.1"
+VERSION_TAG="v5.4.6-oc-smart.1"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -3239,6 +3239,7 @@ rules:
 - "PROCESS-NAME,WeChat.exe,\U0001F3E0 国内网站"
 - DOMAIN-SUFFIX,chiphell.com,DIRECT
 - DOMAIN-SUFFIX,iwipwedabay.com,DIRECT
+- DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT
 - "DOMAIN-SUFFIX,binance.vision,\U0001F4B0 加密货币"
 - "DOMAIN-SUFFIX,binance.com,\U0001F4B0 加密货币"
 - "DOMAIN-SUFFIX,binance.info,\U0001F4B0 加密货币"
@@ -4184,7 +4185,7 @@ cat > "$RUBY_SCRIPT" << 'RUBY_EOF'
 require 'yaml'
 require 'digest'
 
-VERSION = "v5.4.1-oc-smart.1"
+VERSION = "v5.4.6-oc-smart.1"
 
 STATUS_LOG = "/tmp/clash_smart_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }

--- a/Passwall/CHANGELOG.md
+++ b/Passwall/CHANGELOG.md
@@ -8,6 +8,16 @@
 ---
 
 
+## v5.4.6-pw.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN 直连
+  - `shunt-rules/27-cn-site.list` 新增 `domain:cdn.weixin.qq.com`（置于 bbys.app 之后、geosite:cn 之前）
+  - 跟随 Clash Party v5.4.6 基线
+
+## v5.4.5-pw.1 (2026-05-07)
+
+- ★ 全球节点置顶 + 全产品组顺序同步（跟随基线 v5.4.5）
+
 ## v5.4.4-pw.1 (2026-05-07)
 
 - ★ FIX#144：bbys.app 视频播放走直连

--- a/Passwall/Passwall(xray+sing-box)-apply.sh
+++ b/Passwall/Passwall(xray+sing-box)-apply.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # ═══════════════════════════════════════════════════════════════════════════
 # Smart-Config-Kit for Passwall — UCI batch helper
-# Version: v5.4.4-pw.1 | Build 2026-05-07
+# Version: v5.4.6-pw.1 | Build 2026-05-08
 #
 # 用途：一次性在 Passwall（全功能版）中创建 31 条 shunt rule（含域名列表 + IP 列表），
 #       每条目标节点留空（NEED_CONFIG），用户之后到 LuCI 里手工选节点。

--- a/Passwall/shunt-rules/27-cn-site.list
+++ b/Passwall/shunt-rules/27-cn-site.list
@@ -7,6 +7,7 @@
 
 # [Domain List]
 domain:bbys.app
+domain:cdn.weixin.qq.com
 geosite:cn
 
 # [IP List]

--- a/Passwall2/CHANGELOG.md
+++ b/Passwall2/CHANGELOG.md
@@ -7,6 +7,16 @@
 ---
 
 
+## v5.4.6-pw2.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN 直连
+  - `shunt-rules/27-cn-site.list` 新增 `domain:cdn.weixin.qq.com`（置于 bbys.app 之后、geosite:cn 之前）
+  - 跟随 Clash Party v5.4.6 基线
+
+## v5.4.5-pw2.1 (2026-05-07)
+
+- ★ 全球节点置顶 + 全产品组顺序同步（跟随基线 v5.4.5）
+
 ## v5.4.4-pw2.1 (2026-05-07)
 
 - ★ FIX#144：bbys.app 视频播放走直连

--- a/Passwall2/Passwall2(xray+sing-box)-apply.sh
+++ b/Passwall2/Passwall2(xray+sing-box)-apply.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # ═══════════════════════════════════════════════════════════════════════════
 # Smart-Config-Kit for Passwall / Passwall2 — UCI batch helper
-# Version: v5.4.4-pw2.1 | Build 2026-05-07
+# Version: v5.4.6-pw2.1 | Build 2026-05-08
 #
 # 用途：一次性在 Passwall2 中创建 31 条 shunt rule（含域名列表 + IP 列表），
 #       每条目标节点留空（NEED_CONFIG），用户之后到 LuCI 里手工选节点。

--- a/Passwall2/shunt-rules/27-cn-site.list
+++ b/Passwall2/shunt-rules/27-cn-site.list
@@ -7,6 +7,7 @@
 
 # [Domain List]
 domain:bbys.app
+domain:cdn.weixin.qq.com
 geosite:cn
 
 # [IP List]

--- a/Quantumult X/CHANGELOG.md
+++ b/Quantumult X/CHANGELOG.md
@@ -7,6 +7,16 @@
 ---
 
 
+## v5.4.6-QX.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN 直连 — 新增 `host-suffix, cdn.weixin.qq.com, DIRECT`
+  - 于阶段 28（Chiphell 论坛直连）`iwipwedabay.com` 后新增，WeChat CDN 域名直连
+  - 跟随 Clash Party v5.4.6 基线
+
+## v5.4.5-QX.1 (2026-05-07)
+
+- ★ 全球节点置顶 + 全产品组顺序同步（跟随基线 v5.4.5）
+
 ## v5.4.4-QX.1 (2026-05-07)
 
 - ★ FIX#144：新增 bbys.app 直连规则（国内可访问视频站点 CDN 域名直连）

--- a/Quantumult X/QuantumultX.conf
+++ b/Quantumult X/QuantumultX.conf
@@ -1,8 +1,8 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Quantumult X Smart v5.4.4-QX.1 — Quantumult X 版（从 Clash Party v5.4.4 迁移）
-#  Build: 2026-05-07 | Target: Quantumult X iOS (App Store 付费正版)
+#  Quantumult X Smart v5.4.6-QX.1 — Quantumult X 版（从 Clash Party v5.4.6 迁移）
+#  Build: 2026-05-08 | Target: Quantumult X iOS (App Store 付费正版)
 #  架构：18 区域 url-latency-benchmark（9 全部 + 9 家宽）+ 31 业务 static（含 13 流媒体平台组）+ 288 filter_remote + 567 filter_local
-#  基线：Clash Party v5.4.4（唯一主线）
+#  基线：Clash Party v5.4.6（唯一主线）
 #  变更历史：见 `Quantumult X/CHANGELOG.md`
 # ══════════════════════════════════════════════════════════════════════════════
 
@@ -1104,6 +1104,7 @@ host-suffix, zxtdjy.com, 🏠 国内网站
 # Chiphell 论坛直连（原版 FIX）
 host-suffix, chiphell.com, DIRECT
 host-suffix, iwipwedabay.com, DIRECT
+host-suffix, cdn.weixin.qq.com, DIRECT
 host-suffix, bbys.app, DIRECT
 # Accademia 国内兜底
 # Aqara 国内 / 国际

--- a/Shadowrocket/CHANGELOG.md
+++ b/Shadowrocket/CHANGELOG.md
@@ -6,6 +6,16 @@
 ---
 
 
+## v5.4.6-SR.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN 直连 — 新增 `DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT`
+  - 于阶段 7（国内邮箱直连）`mail.qq.com` 后新增，WeChat CDN 域名直连
+  - 跟随 Clash Party v5.4.6 基线
+
+## v5.4.5-SR.1 (2026-05-07)
+
+- ★ 全球节点置顶 + 全产品组顺序同步（跟随基线 v5.4.5）
+
 ## v5.4.4-SR.1 (2026-05-07)
 
 - ★ FIX#144：新增 bbys.app 直连规则（国内可访问视频站点 CDN 域名直连）

--- a/Shadowrocket/Shadowrocket.conf
+++ b/Shadowrocket/Shadowrocket.conf
@@ -1,8 +1,8 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Shadowrocket Smart v5.4.4-SR.1 — 小火箭版（从 Clash Party v5.4.4 迁移重构）
-#  Build: 2026-05-07 | Target: Shadowrocket iOS (App Store 正版) | macOS 通用
+#  Shadowrocket Smart v5.4.6-SR.1 — 小火箭版（从 Clash Party v5.4.6 迁移重构）
+#  Build: 2026-05-08 | Target: Shadowrocket iOS (App Store 正版) | macOS 通用
 #  架构：18 区域 url-test 组（9 全部 + 9 家宽）+ 31 业务策略组（含 13 流媒体平台组）+ ~290 RULE-SET
-#  基线：Clash Party v5.4.4（唯一主线）
+#  基线：Clash Party v5.4.6（唯一主线）
 #  变更历史：见 `Shadowrocket/CHANGELOG.md`
 # ══════════════════════════════════════════════════════════════════════════════
 
@@ -560,6 +560,7 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Shadowrocket/Spark/Spark.list,🌐 国外网站
 # 国内邮箱直连
 DOMAIN-SUFFIX,mail.qq.com,DIRECT
+DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT
 DOMAIN-SUFFIX,mail.163.com,DIRECT
 DOMAIN-SUFFIX,mail.126.com,DIRECT
 DOMAIN-SUFFIX,mail.sina.com.cn,DIRECT

--- a/SingBox/CHANGELOG.md
+++ b/SingBox/CHANGELOG.md
@@ -6,6 +6,16 @@
 ---
 
 
+## v5.4.6-sing.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN 直连 — 新增 `domain_suffix: cdn.weixin.qq.com` → `outbound: DIRECT`
+  - 置于 iwipwedabay.com 后、binance 前
+  - 跟随 Clash Party v5.4.6 基线
+
+## v5.4.5-sing.1 (2026-05-07)
+
+- ★ 全球节点置顶 + 全产品组顺序同步（跟随基线 v5.4.5）
+
 ## v5.4.4-sing.1 (2026-05-07)
 
 - ★ FIX#144：bbys.app 视频播放走直连——新增 `domain_suffix: bbys.app` → `outbound: DIRECT`

--- a/SingBox/SingBox(sing-box)-full.json
+++ b/SingBox/SingBox(sing-box)-full.json
@@ -2039,6 +2039,13 @@
       },
       {
         "domain_suffix": [
+          "cdn.weixin.qq.com"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "domain_suffix": [
           "binance.vision"
         ],
         "action": "route",

--- a/SingBox/SingBox(sing-box)-generator.js
+++ b/SingBox/SingBox(sing-box)-generator.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const vm = require('vm');
 
-const VERSION = 'v5.4.4-sing.1';
-const BUILD = '2026-05-07';
-const BASELINE = 'Clash Party v5.4.4';
+const VERSION = 'v5.4.6-sing.1';
+const BUILD = '2026-05-08';
+const BASELINE = 'Clash Party v5.4.6';
 
 const SMART = {
   GLOBAL: '🌍 全球节点',

--- a/Surge/CHANGELOG.md
+++ b/Surge/CHANGELOG.md
@@ -5,6 +5,16 @@
 ---
 
 
+## v5.4.6-Surge.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN 直连 — 新增 `DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT`
+  - 于阶段 7（国内邮箱直连）`mail.qq.com` 后新增，WeChat CDN 域名直连
+  - 跟随 Clash Party v5.4.6 基线
+
+## v5.4.5-Surge.1 (2026-05-07)
+
+- ★ 全球节点置顶 + 全产品组顺序同步（跟随基线 v5.4.5）
+
 ## v5.4.4-Surge.1 (2026-05-07)
 
 - ★ FIX#144：新增 bbys.app 直连规则（国内可访问视频站点 CDN 域名直连）

--- a/Surge/Surge.conf
+++ b/Surge/Surge.conf
@@ -1,8 +1,8 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Surge Smart v5.4.4-Surge.1 — Surge 版（从 Clash Party v5.4.4 迁移）
-#  Build: 2026-05-07 | Target: Surge 5 / Surge Mac (付费正版) | iOS + macOS
+#  Surge Smart v5.4.6-Surge.1 — Surge 版（从 Clash Party v5.4.6 迁移）
+#  Build: 2026-05-08 | Target: Surge 5 / Surge Mac (付费正版) | iOS + macOS
 #  架构：18 区域 url-test 组（9 全部 + 9 家宽）+ 31 业务 select 组（含 13 流媒体平台组）+ ~290 RULE-SET
-#  基线：Clash Party v5.4.4（唯一主线）
+#  基线：Clash Party v5.4.6（唯一主线）
 #  变更历史：见 `Surge/CHANGELOG.md`
 # ══════════════════════════════════════════════════════════════════════════════
 
@@ -548,6 +548,7 @@ RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule
 RULE-SET,https://fastly.jsdelivr.net/gh/blackmatrix7/ios_rule_script@master/rule/Surge/Spark/Spark.list,🌐 国外网站
 # 国内邮箱直连
 DOMAIN-SUFFIX,mail.qq.com,DIRECT
+DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT
 DOMAIN-SUFFIX,mail.163.com,DIRECT
 DOMAIN-SUFFIX,mail.126.com,DIRECT
 DOMAIN-SUFFIX,mail.sina.com.cn,DIRECT

--- a/v2rayN/CHANGELOG.md
+++ b/v2rayN/CHANGELOG.md
@@ -8,6 +8,16 @@
 ---
 
 
+## v5.4.6-v2n.1 (2026-05-08)
+
+- ★ FEAT#145：WeChat CDN 直连 — 新增 `scki-052-cdn-weixin` 规则，`domain:cdn.weixin.qq.com` → `direct`
+  - 排在 `scki-051-bbys-app` 之后、`scki-099-final` 之前
+  - 跟随 Clash Party v5.4.6 基线
+
+## v5.4.5-v2n.1 (2026-05-07)
+
+- ★ 全球节点置顶 + 全产品组顺序同步（跟随基线 v5.4.5）
+
 ## v5.4.4-v2n.1 (2026-05-07)
 
 - ★ FIX#144：bbys.app 视频播放走直连——新增 `scki-051-bbys-app` 规则，`domain:bbys.app` → `direct`

--- a/v2rayN/v2rayN(xray).json
+++ b/v2rayN/v2rayN(xray).json
@@ -2,7 +2,7 @@
     {
       "id": "scki-000-meta",
       "enabled": false,
-      "remarks": "Smart-Config-Kit v5.4.4-v2n.1 | Build 2026-05-07 | Baseline Clash Party v5.4.4 (Feat SG 狮城节点豁免) | changelog: v2rayN/CHANGELOG.md",
+      "remarks": "Smart-Config-Kit v5.4.6-v2n.1 | Build 2026-05-08 | Baseline Clash Party v5.4.6 | changelog: v2rayN/CHANGELOG.md",
       "outboundTag": "direct",
       "domain": [
         "domain:smart-config-kit.invalid"
@@ -590,6 +590,20 @@
       "outboundTag": "direct",
       "domain": [
         "domain:bbys.app"
+      ],
+      "ip": [],
+      "port": "",
+      "protocol": [],
+      "inboundTag": [],
+      "network": "tcp,udp"
+    },
+    {
+      "id": "scki-052-cdn-weixin",
+      "enabled": true,
+      "remarks": "国内网站 - WeChat CDN cdn.weixin.qq.com → 直连",
+      "outboundTag": "direct",
+      "domain": [
+        "domain:cdn.weixin.qq.com"
       ],
       "ip": [],
       "port": "",


### PR DESCRIPTION
新增 `DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT` 规则，WeChat CDN 域名全网直连
## Summary
- 新增 `DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT` 规则，WeChat CDN 域名全网直连
- 14 产品全同步：Clash Party JS ×2 / CMFA / OpenClash ×2 / Shadowrocket / Surge / Loon / Quantumult X / SingBox / v2rayN / FlClash / Passwall / Passwall2
- 版本号 v5.4.5 → v5.4.6，所有 CHANGELOG 同步更新

## 影响矩阵
| # | 产物 | 规则格式 | 插入位置 |
|---|------|----------|----------|
| 0 | Clash Party Smart JS | `DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT` | iwipwedabay 后 |
| 0B | Clash Party Normal JS | 同上 | 同上 |
| 1 | CMFA YAML | `- DOMAIN-SUFFIX,...` | 同上 |
| 2 | OpenClash Normal | 同上 | 同上 |
| 3 | OpenClash Smart | 同上 | 同上 |
| 4 | Shadowrocket | `DOMAIN-SUFFIX,...` | mail.qq.com 后 |
| 5 | SingBox Full | `domain_suffix` → DIRECT | iwipwedabay 后 |
| 6 | v2rayN Xray | `domain:cdn.weixin.qq.com` → direct | bbys.app 后 |
| 7 | Surge | `DOMAIN-SUFFIX,...` | mail.qq.com 后 |
| 8 | Loon | 同上 | 同上 |
| 9 | Quantumult X | `host-suffix,...` | iwipwedabay 后 |
| 10 | Passwall | `domain:cdn.weixin.qq.com` | bbys.app 后 |
| 10B | Passwall2 | 同上 | 同上 |
| 11 | FlClash JS | `DOMAIN-SUFFIX,...` | iwipwedabay 后 |

## 自检
- SingBox JSON: VALID
- v2rayN JSON: VALID (items: 34)
- `cdn.weixin.qq.com` grep: 14/14 产物命中 ✓