### PR TITLE
FEAT#GAME-ACCEL：新增游戏加速器 PROCESS-NAME -> DIRECT 白名单

### DIFF
--- a/Clash Meta For Android/CHANGELOG.md
+++ b/Clash Meta For Android/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ---
 
+## v5.4.16-cmfa.2 (2026-05-22)
+
+- ✅ FEAT#GAME-ACCEL：新增游戏加速器 `PROCESS-NAME -> DIRECT` 白名单
+  - 新增 16 条 PROCESS-NAME 规则（UU / 小黑 / 迅游 / 雷神 / NNer 加速器）
+  - 同步 Clash Party v5.4.16 基线
+
 ## v5.4.16-cmfa.1 (2026-05-20)
 
 - ✅ FIX#149-P0：rules 顶部前置 `DOMAIN-SUFFIX,paddle.com,🏦 金融支付`

--- a/Clash Meta For Android/CMFA(mihomo).yaml
+++ b/Clash Meta For Android/CMFA(mihomo).yaml
@@ -1,6 +1,6 @@
 ﻿# ================================================================
-# Clash Smart v5.4.16-cmfa.1 - CMFA (Clash Meta for Android) 配置
-# Build: 2026-05-20
+# Clash Smart v5.4.16-cmfa.2 - CMFA (Clash Meta for Android) 配置
+# Build: 2026-05-22
 # 架构：proxy-providers 订阅 + 22 url-test 区域组（11 全部 + 11 家宽，家宽 filter 新增 IEPL/IPLC/专线识别）+ 32 业务策略组（含 14 流媒体平台组）+ 384+ rule-providers
 # 基线：Clash Party v5.4.16（唯一主线）
 # 变更历史：见 `Clash Meta For Android/CHANGELOG.md`
@@ -3640,6 +3640,23 @@ rules:
 - 'PROCESS-NAME,Navicat Premium.exe,DIRECT'
 - 'PROCESS-NAME,Navicat,DIRECT'
 - 'PROCESS-NAME,Navicat Premium,DIRECT'
+# 游戏加速器 — 这些工具自身是网络加速隧道，走代理会导致双重代理/连接失败
+- 'PROCESS-NAME,LeigodAcc.exe,DIRECT'
+- 'PROCESS-NAME,LeigodAccel.exe,DIRECT'
+- 'PROCESS-NAME,leigodaccel.exe,DIRECT'
+- 'PROCESS-NAME,NeteaseUU.exe,DIRECT'
+- 'PROCESS-NAME,NeteaseUUBrowser.exe,DIRECT'
+- 'PROCESS-NAME,NNer.exe,DIRECT'
+- 'PROCESS-NAME,NNerClient.exe,DIRECT'
+- 'PROCESS-NAME,UU.exe,DIRECT'
+- 'PROCESS-NAME,UUGameBooster.exe,DIRECT'
+- 'PROCESS-NAME,UURepair.exe,DIRECT'
+- 'PROCESS-NAME,UUService.exe,DIRECT'
+- 'PROCESS-NAME,xhjsq.exe,DIRECT'
+- 'PROCESS-NAME,XiaoHeiAccelerator.exe,DIRECT'
+- 'PROCESS-NAME,xunyou.exe,DIRECT'
+- 'PROCESS-NAME,XunYouAcc.exe,DIRECT'
+- 'PROCESS-NAME,XunYouUpdate.exe,DIRECT'
 - DST-PORT,123,DIRECT
 - DST-PORT,3478,DIRECT
 - DST-PORT,3479,DIRECT

--- a/Clash Party/CHANGELOG.md
+++ b/Clash Party/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ---
 
+## v5.4.16 / v5.4.16-normal.2 (2026-05-22)
+
+- ✅ FEAT#GAME-ACCEL：新增游戏加速器 `PROCESS-NAME -> DIRECT` 白名单
+  - 新增 16 条进程名：UU加速器（UU.exe / NeteaseUU.exe / UUGameBooster.exe / UUService.exe / UURepair.exe / NeteaseUUBrowser.exe）、小黑加速器（XiaoHeiAccelerator.exe / xhjsq.exe）、迅游加速器（xunyou.exe / XunYouAcc.exe / XunYouUpdate.exe）、雷神加速器（LeigodAcc.exe / LeigodAccel.exe / leigodaccel.exe）、NNer加速器（NNer.exe / NNerClient.exe）
+  - 理由：这些工具自身是网络加速隧道，走代理会导致双重代理 / 连接失败
+  - Smart JS + Normal JS + CMFA YAML + OpenClash Normal + OpenClash Smart + Surge + SingBox Full + FlClash JS 全版本联动
+  - Shadowrocket / Loon / Quantumult X（iOS 端）不支持 PROCESS-NAME，跳过
+  - v2rayN / Passwall / Passwall2 无运行时进程分类，跳过
+
 ## v5.4.16 / v5.4.16-normal.1 (2026-05-20)
 
 - ✅ FIX#149-P0：前置 `DOMAIN-SUFFIX,paddle.com,🏦 金融支付`，避免 `analytics.paddle.com` 被 anti-AD/DustinWin 误拦截

--- a/Clash Party/ClashParty(mihomo).js
+++ b/Clash Party/ClashParty(mihomo).js
@@ -1,5 +1,5 @@
 ﻿// Clash 覆写脚本 - SUB-STORE 多机场精细分流版
-// 版本：v5.4.16-normal.1 (2026-05-20)
+// 版本：v5.4.16-normal.2 (2026-05-22)
 // 架构：22 url-test 区域组（11 全部 + 11 家宽）+ 32 业务策略组 + 385 rule-providers
 // 基线：Clash Party v5.4.16（与同目录 ClashParty(mihomo-smart).js 规则 100% 等价，仅区域组从 smart 改为 url-test）
 // 适用：Mihomo / Clash.Meta 稳定版内核、不支持 smart + LightGBM 的分支；也适用于想完全关闭 ML 评估的用户
@@ -9,7 +9,7 @@
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.4.16-normal.1'
+const VERSION = 'v5.4.16-normal.2'
 
 // v5.4.9 FEAT#LOCAL-TOOLS: desktop local-tool direct whitelist.
 const LOCAL_TOOL_DIRECT_PROCESS_NAMES = [
@@ -64,6 +64,23 @@ const LOCAL_TOOL_DIRECT_PROCESS_NAMES = [
   'Navicat Premium.exe',
   'Navicat',
   'Navicat Premium',
+  // 游戏加速器 — 这些工具自身是网络加速隧道，走代理会导致双重代理/连接失败
+  'LeigodAcc.exe',
+  'LeigodAccel.exe',
+  'leigodaccel.exe',
+  'NeteaseUU.exe',
+  'NeteaseUUBrowser.exe',
+  'NNer.exe',
+  'NNerClient.exe',
+  'UU.exe',
+  'UUGameBooster.exe',
+  'UURepair.exe',
+  'UUService.exe',
+  'xhjsq.exe',
+  'XiaoHeiAccelerator.exe',
+  'xunyou.exe',
+  'XunYouAcc.exe',
+  'XunYouUpdate.exe',
 ]
 
 const RUSTDESK_WORK_PROCESS_NAMES = [

--- a/Clash Party/ClashParty(mihomo-smart).js
+++ b/Clash Party/ClashParty(mihomo-smart).js
@@ -1,7 +1,7 @@
 ﻿// Clash Smart 内核覆写脚本 - SUB-STORE 多机场精细分流版
-// 版本：v5.4.16 (2026-05-20)
+// 版本：v5.4.16 (2026-05-22)
 // 架构：SUB-STORE 多机场融合 + 22 Smart 区域组（11 全部 + 11 家宽）+ 32 业务策略组（含 14 流媒体平台组）+ 385 rule-providers 100%+ 服务覆盖
-// v5.4.16: Paddle/Antigravity 登录误伤白名单 · v5.4.15: GEOSITE 覆盖台账 + anti-ad 白名单模块化
+// v5.4.16: 游戏加速器 PROCESS-NAME 直连白名单 · v5.4.16: Paddle/Antigravity 登录误伤白名单
 // 变更历史：见 `Clash Party/CHANGELOG.md`
 
 // ================================================================
@@ -66,6 +66,23 @@ const LOCAL_TOOL_DIRECT_PROCESS_NAMES = [
   'Navicat Premium.exe',
   'Navicat',
   'Navicat Premium',
+  // 游戏加速器 — 这些工具自身是网络加速隧道，走代理会导致双重代理/连接失败
+  'LeigodAcc.exe',
+  'LeigodAccel.exe',
+  'leigodaccel.exe',
+  'NeteaseUU.exe',
+  'NeteaseUUBrowser.exe',
+  'NNer.exe',
+  'NNerClient.exe',
+  'UU.exe',
+  'UUGameBooster.exe',
+  'UURepair.exe',
+  'UUService.exe',
+  'xhjsq.exe',
+  'XiaoHeiAccelerator.exe',
+  'xunyou.exe',
+  'XunYouAcc.exe',
+  'XunYouUpdate.exe',
 ]
 
 const RUSTDESK_WORK_PROCESS_NAMES = [

--- a/FlClash/CHANGELOG.md
+++ b/FlClash/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ---
 
+## v5.4.16-flclash.2 (2026-05-22)
+
+- ✅ FEAT#GAME-ACCEL：新增游戏加速器 `PROCESS-NAME -> DIRECT` 白名单
+  - 新增 16 条进程名（UU / 小黑 / 迅游 / 雷神 / NNer 加速器），同步 Clash Party Normal 基线
+
 ## v5.4.16-flclash.1 (2026-05-20)
 
 - ✅ FIX#149-P0：同步 Clash Party Normal v5.4.16，前置 `paddle.com -> 🏦 金融支付`

--- a/FlClash/FlClash(mihomo).js
+++ b/FlClash/FlClash(mihomo).js
@@ -1,5 +1,5 @@
 ﻿// FlClash 覆写脚本 — 标准 Mihomo 内核动态分流版
-// 版本：v5.4.16-flclash.1 (2026-05-20)
+// 版本：v5.4.16-flclash.2 (2026-05-22)
 // 架构：22 url-test 区域组（11 全部 + 11 家宽）+ 32 业务策略组（含 14 流媒体平台组）+ 385 rule-providers 100%+ 服务覆盖
 // 基线：Clash Party Normal v5.4.16-normal.1（规则 100% 等价；区域组为 url-test — FlClash 内核为标准 Mihomo，不支持 smart + LightGBM）
 // 适用：FlClash >= v0.8.85（覆盖脚本功能自该版本引入）；其他使用标准 Mihomo 内核的客户端
@@ -35,7 +35,7 @@
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.4.16-flclash.1'
+const VERSION = 'v5.4.16-flclash.2'
 
 // v5.4.9 FEAT#LOCAL-TOOLS: desktop local-tool direct whitelist.
 const LOCAL_TOOL_DIRECT_PROCESS_NAMES = [
@@ -90,6 +90,23 @@ const LOCAL_TOOL_DIRECT_PROCESS_NAMES = [
   'Navicat Premium.exe',
   'Navicat',
   'Navicat Premium',
+  // 游戏加速器 — 这些工具自身是网络加速隧道，走代理会导致双重代理/连接失败
+  'LeigodAcc.exe',
+  'LeigodAccel.exe',
+  'leigodaccel.exe',
+  'NeteaseUU.exe',
+  'NeteaseUUBrowser.exe',
+  'NNer.exe',
+  'NNerClient.exe',
+  'UU.exe',
+  'UUGameBooster.exe',
+  'UURepair.exe',
+  'UUService.exe',
+  'xhjsq.exe',
+  'XiaoHeiAccelerator.exe',
+  'xunyou.exe',
+  'XunYouAcc.exe',
+  'XunYouUpdate.exe',
 ]
 
 const RUSTDESK_WORK_PROCESS_NAMES = [

--- a/OpenClash/CHANGELOG.md
+++ b/OpenClash/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ---
 
+## v5.4.16-oc-normal.2 / v5.4.16-oc-smart.2 (2026-05-22)
+
+- ✅ FEAT#GAME-ACCEL：新增游戏加速器 `PROCESS-NAME -> DIRECT` 白名单
+  - 新增 16 条 PROCESS-NAME 规则（UU / 小黑 / 迅游 / 雷神 / NNer 加速器）
+  - Normal + Smart 同步
+
 ## v5.4.16-oc-normal.1 / v5.4.16-oc-smart.1 (2026-05-20)
 
 - ✅ FIX#149-P0：Normal / Smart 同步前置 `paddle.com -> 🏦 金融支付`

--- a/OpenClash/OpenClash(mihomo).sh
+++ b/OpenClash/OpenClash(mihomo).sh
@@ -2,8 +2,8 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash Smart v5.4.16-oc-normal.1 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
-# Build: 2026-05-20
+# Clash Smart v5.4.16-oc-normal.2 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
+# Build: 2026-05-22
 # ============================================================================
 # 定位：与同目录 OpenClash(mihomo-smart).sh 规则 100% 等价的「非 Smart 内核」版本。
 #       两者唯一区别：22 个区域组（11 全部 + 11 家宽）从 type: smart（uselightgbm）换成 type: url-test。
@@ -26,7 +26,7 @@
 
 
 
-VERSION_TAG="v5.4.16-oc-normal.1"
+VERSION_TAG="v5.4.16-oc-normal.2"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -3319,6 +3319,23 @@ rules:
 - PROCESS-NAME,Navicat Premium.exe,DIRECT
 - PROCESS-NAME,Navicat,DIRECT
 - PROCESS-NAME,Navicat Premium,DIRECT
+# 游戏加速器 — 这些工具自身是网络加速隧道，走代理会导致双重代理/连接失败
+- PROCESS-NAME,LeigodAcc.exe,DIRECT
+- PROCESS-NAME,LeigodAccel.exe,DIRECT
+- PROCESS-NAME,leigodaccel.exe,DIRECT
+- PROCESS-NAME,NeteaseUU.exe,DIRECT
+- PROCESS-NAME,NeteaseUUBrowser.exe,DIRECT
+- PROCESS-NAME,NNer.exe,DIRECT
+- PROCESS-NAME,NNerClient.exe,DIRECT
+- PROCESS-NAME,UU.exe,DIRECT
+- PROCESS-NAME,UUGameBooster.exe,DIRECT
+- PROCESS-NAME,UURepair.exe,DIRECT
+- PROCESS-NAME,UUService.exe,DIRECT
+- PROCESS-NAME,xhjsq.exe,DIRECT
+- PROCESS-NAME,XiaoHeiAccelerator.exe,DIRECT
+- PROCESS-NAME,xunyou.exe,DIRECT
+- PROCESS-NAME,XunYouAcc.exe,DIRECT
+- PROCESS-NAME,XunYouUpdate.exe,DIRECT
 - DOMAIN-SUFFIX,chiphell.com,DIRECT
 - DOMAIN-SUFFIX,iwipwedabay.com,DIRECT
 - DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT
@@ -4309,7 +4326,7 @@ cat > "$RUBY_SCRIPT" << 'RUBY_EOF'
 require 'yaml'
 require 'digest'
 
-VERSION = "v5.4.16-oc-normal.1"
+VERSION = "v5.4.16-oc-normal.2"
 
 STATUS_LOG = "/tmp/clash_normal_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }

--- a/OpenClash/OpenClash(mihomo-smart).sh
+++ b/OpenClash/OpenClash(mihomo-smart).sh
@@ -2,8 +2,8 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash Smart v5.4.16-oc-smart.1 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
-# Build: 2026-05-20
+# Clash Smart v5.4.16-oc-smart.2 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
+# Build: 2026-05-22
 # ============================================================================
 # 定位：对齐 Clash Party v5.4.16 JS 主线的 OpenClash 全量版本。v5.4.2: P0-FIX#41 小米白名单。
 #       与同目录 OpenClash(mihomo).sh（Normal）互补：
@@ -23,7 +23,7 @@
 
 
 
-VERSION_TAG="v5.4.16-oc-smart.1"
+VERSION_TAG="v5.4.16-oc-smart.2"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -3316,6 +3316,23 @@ rules:
 - PROCESS-NAME,Navicat Premium.exe,DIRECT
 - PROCESS-NAME,Navicat,DIRECT
 - PROCESS-NAME,Navicat Premium,DIRECT
+# 游戏加速器 — 这些工具自身是网络加速隧道，走代理会导致双重代理/连接失败
+- PROCESS-NAME,LeigodAcc.exe,DIRECT
+- PROCESS-NAME,LeigodAccel.exe,DIRECT
+- PROCESS-NAME,leigodaccel.exe,DIRECT
+- PROCESS-NAME,NeteaseUU.exe,DIRECT
+- PROCESS-NAME,NeteaseUUBrowser.exe,DIRECT
+- PROCESS-NAME,NNer.exe,DIRECT
+- PROCESS-NAME,NNerClient.exe,DIRECT
+- PROCESS-NAME,UU.exe,DIRECT
+- PROCESS-NAME,UUGameBooster.exe,DIRECT
+- PROCESS-NAME,UURepair.exe,DIRECT
+- PROCESS-NAME,UUService.exe,DIRECT
+- PROCESS-NAME,xhjsq.exe,DIRECT
+- PROCESS-NAME,XiaoHeiAccelerator.exe,DIRECT
+- PROCESS-NAME,xunyou.exe,DIRECT
+- PROCESS-NAME,XunYouAcc.exe,DIRECT
+- PROCESS-NAME,XunYouUpdate.exe,DIRECT
 - DOMAIN-SUFFIX,chiphell.com,DIRECT
 - DOMAIN-SUFFIX,iwipwedabay.com,DIRECT
 - DOMAIN-SUFFIX,cdn.weixin.qq.com,DIRECT
@@ -4306,7 +4323,7 @@ cat > "$RUBY_SCRIPT" << 'RUBY_EOF'
 require 'yaml'
 require 'digest'
 
-VERSION = "v5.4.16-oc-smart.1"
+VERSION = "v5.4.16-oc-smart.2"
 
 STATUS_LOG = "/tmp/clash_smart_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }

--- a/SingBox/CHANGELOG.md
+++ b/SingBox/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ---
 
+## v5.4.16-sing.2 (2026-05-22)
+
+- ✅ FEAT#GAME-ACCEL：由生成器重建 Full JSON，新增游戏加速器 `process_name -> DIRECT` 规则
+  - 新增 16 条 process_name 规则（UU / 小黑 / 迅游 / 雷神 / NNer 加速器）
+  - 生成器自动从 Clash Party JS 规则转换
+
 ## v5.4.16-sing.1 (2026-05-20)
 
 - ✅ FIX#149-P0：由生成器重建 Full JSON，前置 `paddle.com -> 🏦 金融支付`

--- a/SingBox/SingBox(sing-box)-full.json
+++ b/SingBox/SingBox(sing-box)-full.json
@@ -5,8 +5,8 @@
   },
   "_meta": {
     "name": "SingBox Smart Full",
-    "version": "v5.4.16-sing.1",
-    "build": "2026-05-20",
+    "version": "v5.4.16-sing.2",
+    "build": "2026-05-22",
     "baseline": "Clash Party v5.4.16",
     "changelog": "见 SingBox/CHANGELOG.md"
   },
@@ -2404,6 +2404,118 @@
       {
         "process_name": [
           "Navicat Premium"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "LeigodAcc.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "LeigodAccel.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "leigodaccel.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "NeteaseUU.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "NeteaseUUBrowser.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "NNer.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "NNerClient.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "UU.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "UUGameBooster.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "UURepair.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "UUService.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "xhjsq.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "XiaoHeiAccelerator.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "xunyou.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "XunYouAcc.exe"
+        ],
+        "action": "route",
+        "outbound": "DIRECT"
+      },
+      {
+        "process_name": [
+          "XunYouUpdate.exe"
         ],
         "action": "route",
         "outbound": "DIRECT"

--- a/SingBox/SingBox(sing-box)-generator.js
+++ b/SingBox/SingBox(sing-box)-generator.js
@@ -1,8 +1,8 @@
 const fs = require('fs');
 const vm = require('vm');
 
-const VERSION = 'v5.4.16-sing.1';
-const BUILD = '2026-05-20';
+const VERSION = 'v5.4.16-sing.2';
+const BUILD = '2026-05-22';
 const BASELINE = 'Clash Party v5.4.16';
 
 const SMART = {

--- a/Surge/CHANGELOG.md
+++ b/Surge/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ---
 
+## v5.4.16-Surge.2 (2026-05-22)
+
+- ✅ FEAT#GAME-ACCEL：新增游戏加速器 `PROCESS-NAME -> DIRECT` 白名单
+  - 新增 13 条 PROCESS-NAME 规则（UU / 小黑 / 迅游 / 雷神 / NNer 加速器；仅 .exe 无后缀版本，适配 macOS + iOS）
+
 ## v5.4.16-Surge.1 (2026-05-20)
 
 - ✅ FIX#149-P0：前置 `DOMAIN-SUFFIX,paddle.com,🏦 金融支付`

--- a/Surge/Surge.conf
+++ b/Surge/Surge.conf
@@ -1,6 +1,6 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Surge Smart v5.4.16-Surge.1 — Surge 版（从 Clash Party v5.4.16 迁移）
-#  Build: 2026-05-20 | Target: Surge 5 / Surge Mac (付费正版) | iOS + macOS
+#  Surge Smart v5.4.16-Surge.2 — Surge 版（从 Clash Party v5.4.16 迁移）
+#  Build: 2026-05-22 | Target: Surge 5 / Surge Mac (付费正版) | iOS + macOS
 #  架构：22 区域 url-test 组（11 全部 + 11 家宽）+ 32 业务 select 组（含 14 流媒体平台组）+ ~290 RULE-SET
 #  基线：Clash Party v5.4.16（唯一主线）
 #  变更历史：见 `Surge/CHANGELOG.md`
@@ -359,6 +359,23 @@ PROCESS-NAME,cloudflared,DIRECT
 PROCESS-NAME,xmqtunnel,DIRECT
 PROCESS-NAME,Navicat,DIRECT
 PROCESS-NAME,Navicat Premium,DIRECT
+# 游戏加速器 — 这些工具自身是网络加速隧道，走代理会导致双重代理/连接失败
+PROCESS-NAME,LeigodAcc,DIRECT
+PROCESS-NAME,LeigodAccel,DIRECT
+PROCESS-NAME,leigodaccel,DIRECT
+PROCESS-NAME,NNer,DIRECT
+PROCESS-NAME,NNerClient,DIRECT
+PROCESS-NAME,NeteaseUU,DIRECT
+PROCESS-NAME,NeteaseUUBrowser,DIRECT
+PROCESS-NAME,UU,DIRECT
+PROCESS-NAME,UUGameBooster,DIRECT
+PROCESS-NAME,UURepair,DIRECT
+PROCESS-NAME,UUService,DIRECT
+PROCESS-NAME,XiaoHeiAccelerator,DIRECT
+PROCESS-NAME,xhjsq,DIRECT
+PROCESS-NAME,xunyou,DIRECT
+PROCESS-NAME,XunYouAcc,DIRECT
+PROCESS-NAME,XunYouUpdate,DIRECT
 # 原版 DST-PORT 业务规则
 DST-PORT,123,DIRECT
 DST-PORT,3478,DIRECT


### PR DESCRIPTION
## 改动摘要

- 新增 5 款国产游戏加速器（UU加速器、小黑加速器、迅游加速器、雷神加速器、NNer加速器）共 16 条 `PROCESS-NAME -> DIRECT` 规则
- 这些工具自身建立网络加速隧道，走代理会导致双重代理 / 连接失败，必须直连
- 全版本联动：8 个产物同步更新
- 版本号从 v5.4.16-*.1 bump 到 v5.4.16-*.2，所有 CHANGELOG 已更新

## 新增的进程名（16 条）

| 加速器 | 进程名 |
|--------|--------|
| UU加速器（网易） | `UU.exe`、`NeteaseUU.exe`、`UUGameBooster.exe`、`UUService.exe`、`UURepair.exe`、`NeteaseUUBrowser.exe` |
| 小黑加速器 | `XiaoHeiAccelerator.exe`、`xhjsq.exe` |
| 迅游加速器 | `xunyou.exe`、`XunYouAcc.exe`、`XunYouUpdate.exe` |
| 雷神加速器 | `LeigodAcc.exe`、`LeigodAccel.exe`、`leigodaccel.exe` |
| NNer加速器 | `NNer.exe`、`NNerClient.exe` |

## 同步的产物

| 产物 | 版本 | 改动 |
|------|------|------|
| Clash Party Smart JS | v5.4.16 | `LOCAL_TOOL_DIRECT_PROCESS_NAMES` +16 条 |
| Clash Party Normal JS | v5.4.16-normal.2 | 同上 |
| CMFA YAML | v5.4.16-cmfa.2 | +16 条 `PROCESS-NAME` 规则 |
| OpenClash Normal | v5.4.16-oc-normal.2 | +16 条 `PROCESS-NAME` 规则 |
| OpenClash Smart | v5.4.16-oc-smart.2 | +16 条 `PROCESS-NAME` 规则 |
| Surge | v5.4.16-Surge.2 | +16 条（仅 .exe 无后缀版本） |
| SingBox Full JSON | v5.4.16-sing.2 | 生成器自动转换 |
| FlClash JS | v5.4.16-flclash.2 | `LOCAL_TOOL_DIRECT_PROCESS_NAMES` +16 条 |

## 跳过的产物（有正当理由）

| 产物 | 原因 |
|------|------|
| Shadowrocket / Loon / Quantumult X | iOS 端不支持 PROCESS-NAME（无进程识别 API） |
| v2rayN / Passwall / Passwall2 | 无运行时进程分类机制 |

## 测试计划

- [x] SingBox JSON 语法校验通过
- [x] SingBox outbound groups: 53（期望 53）
- [x] OpenClash `proxy: DIRECT`: 0（期望 0）
- [x] 各产物 CHANGELOG.md 已添加条目
- [x] 各产物版本号已 bump