### PR TITLE
fix(clash-party): prevent DNS leak in split DNS config

### DIFF
--- a/Clash Party/ClashParty(mihomo).js
+++ b/Clash Party/ClashParty(mihomo).js
@@ -2302,22 +2302,73 @@ function overwriteGeneral(config) {
   // v5.4.4 FIX#142: 修复 v5.4.1+ 引入的 DNS 空壳 bug——创建 config.dns 时未提供 nameserver
   //   导致内核跳过默认 DNS，国内网站 DIRECT 连接因 DNS 解析失败而超时
   if (!config.dns) config.dns = {}
-  if (!config.dns['enhanced-mode']) config.dns['enhanced-mode'] = 'fake-ip'
+  config.dns.enable = true
+  if (!config.dns.listen) config.dns.listen = '0.0.0.0:1053'
+  config.dns['enhanced-mode'] = 'fake-ip'
+  config.dns['fake-ip-range'] = '198.18.0.1/16'
   config.dns.ipv6 = false
-  // v5.4.11 FIX#DNS-BOOTSTRAP: put plain IP DNS first to avoid DoH self-dependency.
-  var bootstrapDns = ['223.5.5.5', '119.29.29.29', '1.1.1.1', '8.8.8.8']
-  var directDns = ['223.5.5.5', '119.29.29.29']
-  var defaultDoH = ['https://dns.alidns.com/dns-query', 'https://doh.pub/dns-query']
-  var currentNameserver = Array.isArray(config.dns.nameserver) ? config.dns.nameserver : []
-  config.dns.nameserver = uniqList(directDns.concat(currentNameserver.length ? currentNameserver : defaultDoH))
+  config.dns['prefer-h3'] = false
+  config.dns['respect-rules'] = true
+  config.dns['use-system-hosts'] = false
+  config.dns['cache-algorithm'] = 'arc'
+  // FIX#DNS-LEAK: follow clash-verge-script's split DNS model.
+  // CN/private domains use domestic DoH; the default resolver set is foreign DoH and follows route rules.
+  var bootstrapDns = ['223.5.5.5', '1.2.4.8']
+  var domesticDns = ['https://223.5.5.5/dns-query', 'https://doh.pub/dns-query']
+  var foreignDns = ['https://208.67.222.222/dns-query', 'https://77.88.8.8/dns-query', 'https://1.1.1.1/dns-query', 'https://8.8.4.4/dns-query']
   config.dns['default-nameserver'] = bootstrapDns.slice()
-  config.dns['direct-nameserver'] = directDns.slice()
-  config.dns['proxy-server-nameserver'] = bootstrapDns.slice()
-  if (!Array.isArray(config.dns.fallback) || config.dns.fallback.length === 0) {
-    config.dns.fallback = ['https://cloudflare-dns.com/dns-query', 'https://dns.google/dns-query']
+  config.dns.nameserver = foreignDns.slice()
+  config.dns['proxy-server-nameserver'] = domesticDns.slice()
+  config.dns['direct-nameserver'] = domesticDns.slice()
+  config.dns['nameserver-policy'] = {
+    'geosite:private,cn': domesticDns.slice()
   }
+  delete config.dns.fallback
+  delete config.dns['fallback-filter']
   // v5.4.1 P0+P2: fake-ip-filter 扩展 + Hosts DNS 预解析
-  config.dns['fake-ip-filter'] = ['+.lan','+.local','time.*.com','ntp.*.com','+.market.xiaomi.com','+.localdomain','+.home.arpa','+.stun.*.*','+.stun.*.*.*','+.turn.*.*','+.turn.*.*.*','+.ntp.org','+.pool.ntp.org','+.n.n.srv.nintendo.net','+.stun.playstation.net','+.xboxlive.com','stun.l.google.com','stun1.l.google.com','stun2.l.google.com','stun3.l.google.com','stun4.l.google.com','global.turn.twilio.com','auth.docker.io','registry-1.docker.io','index.docker.io','hub.docker.com','production.cloudflare.docker.com','+.push.apple.com','+.pub.3gppnetwork.org','+.bing.com','+.rustdesk.com','+.miwifi.com']
+  config.dns['fake-ip-filter'] = [
+    '+.lan',
+    '+.local',
+    '+.localdomain',
+    '+.home.arpa',
+    '+.msftconnecttest.com',
+    '+.msftncsi.com',
+    'localhost.ptlogin2.qq.com',
+    'localhost.sec.qq.com',
+    'localhost.work.weixin.qq.com',
+    '+.in-addr.arpa',
+    '+.ip6.arpa',
+    'time.*.com',
+    'time.*.gov',
+    'ntp.*.com',
+    'pool.ntp.org',
+    '+.ntp.org',
+    '+.pool.ntp.org',
+    '+.market.xiaomi.com',
+    '+.stun.*.*',
+    '+.stun.*.*.*',
+    '+.turn.*.*',
+    '+.turn.*.*.*',
+    '+.n.n.srv.nintendo.net',
+    '+.stun.playstation.net',
+    '+.xboxlive.com',
+    'stun.l.google.com',
+    'stun1.l.google.com',
+    'stun2.l.google.com',
+    'stun3.l.google.com',
+    'stun4.l.google.com',
+    'global.turn.twilio.com',
+    'auth.docker.io',
+    'registry-1.docker.io',
+    'index.docker.io',
+    'hub.docker.com',
+    'production.cloudflare.docker.com',
+    '+.push.apple.com',
+    '+.pub.3gppnetwork.org',
+    '+.bing.com',
+    '+.rustdesk.com',
+    '+.miwifi.com'
+  ]
   if (!config.hosts) config.hosts = {}
   var dnsH = {'dns.alidns.com':['223.5.5.5','223.6.6.6'],'doh.pub':['119.29.29.29'],'dns.google':['8.8.8.8','8.8.4.4'],'cloudflare-dns.com':['1.1.1.1','1.0.0.1']}
   Object.keys(dnsH).forEach(function(k){if(!config.hosts[k])config.hosts[k]=dnsH[k]})
@@ -2348,15 +2399,6 @@ function overwriteGeneral(config) {
   var gcuExcludes = ['GCUService.exe', 'GCUBridge.exe', 'WorkPro.exe', 'GSCService.exe', 'gsupservice.exe', 'gchsvc.exe']
   gcuExcludes.forEach(function(proc) {
     if (config.tun['exclude-process'].indexOf(proc) === -1) { config.tun['exclude-process'].push(proc) }
-  })
-}
-
-function uniqList(list) {
-  var seen = {}
-  return list.filter(function(item) {
-    if (!item || seen[item]) return false
-    seen[item] = true
-    return true
   })
 }
 

--- a/Clash Party/ClashParty(mihomo-smart).js
+++ b/Clash Party/ClashParty(mihomo-smart).js
@@ -2332,30 +2332,47 @@ function overwriteGeneral(config) {
   // v5.4.4 FIX#142: 修复 v5.4.1+ 引入的 DNS 空壳 bug——创建 config.dns 时未提供 nameserver
   //   导致内核跳过默认 DNS，国内网站 DIRECT 连接因 DNS 解析失败而超时
   if (!config.dns) config.dns = {}
-  if (!config.dns['enhanced-mode']) config.dns['enhanced-mode'] = 'fake-ip'
+  config.dns.enable = true
+  if (!config.dns.listen) config.dns.listen = '0.0.0.0:1053'
+  config.dns['enhanced-mode'] = 'fake-ip'
+  config.dns['fake-ip-range'] = '198.18.0.1/16'
   config.dns.ipv6 = false
-  // v5.4.11 FIX#DNS-BOOTSTRAP: DoH-only configs can deadlock in TUN when the DoH
-  // endpoint itself is unreachable. Put plain IP DNS first and keep DoH as optional.
-  var bootstrapDns = ['223.5.5.5', '119.29.29.29', '1.1.1.1', '8.8.8.8']
-  var directDns = ['223.5.5.5', '119.29.29.29']
-  var defaultDoH = ['https://dns.alidns.com/dns-query', 'https://doh.pub/dns-query']
-  var currentNameserver = Array.isArray(config.dns.nameserver) ? config.dns.nameserver : []
-  config.dns.nameserver = uniqList(directDns.concat(currentNameserver.length ? currentNameserver : defaultDoH))
+  config.dns['prefer-h3'] = false
+  config.dns['respect-rules'] = true
+  config.dns['use-system-hosts'] = false
+  config.dns['cache-algorithm'] = 'arc'
+  // FIX#DNS-LEAK: follow clash-verge-script's split DNS model.
+  // CN/private domains use domestic DoH; the default resolver set is foreign DoH and follows route rules.
+  var bootstrapDns = ['223.5.5.5', '1.2.4.8']
+  var domesticDns = ['https://223.5.5.5/dns-query', 'https://doh.pub/dns-query']
+  var foreignDns = ['https://208.67.222.222/dns-query', 'https://77.88.8.8/dns-query', 'https://1.1.1.1/dns-query', 'https://8.8.4.4/dns-query']
   config.dns['default-nameserver'] = bootstrapDns.slice()
-  config.dns['direct-nameserver'] = directDns.slice()
-  config.dns['proxy-server-nameserver'] = bootstrapDns.slice()
-  if (!Array.isArray(config.dns.fallback) || config.dns.fallback.length === 0) {
-    config.dns.fallback = ['https://cloudflare-dns.com/dns-query', 'https://dns.google/dns-query']
+  config.dns.nameserver = foreignDns.slice()
+  config.dns['proxy-server-nameserver'] = domesticDns.slice()
+  config.dns['direct-nameserver'] = domesticDns.slice()
+  config.dns['nameserver-policy'] = {
+    'geosite:private,cn': domesticDns.slice()
   }
+  delete config.dns.fallback
+  delete config.dns['fallback-filter']
   // v5.4.1 P0: fake-ip-filter 扩展（Smart 内核不支持 fake-ip-filter-mode: rule，使用传统域名列表）
   config.dns['fake-ip-filter'] = [
     '+.lan',
     '+.local',
-    'time.*.com',
-    'ntp.*.com',
-    '+.market.xiaomi.com',
     '+.localdomain',
     '+.home.arpa',
+    '+.msftconnecttest.com',
+    '+.msftncsi.com',
+    'localhost.ptlogin2.qq.com',
+    'localhost.sec.qq.com',
+    'localhost.work.weixin.qq.com',
+    '+.in-addr.arpa',
+    '+.ip6.arpa',
+    'time.*.com',
+    'time.*.gov',
+    'ntp.*.com',
+    'pool.ntp.org',
+    '+.market.xiaomi.com',
     '+.stun.*.*',
     '+.stun.*.*.*',
     '+.turn.*.*',
@@ -2403,15 +2420,6 @@ function overwriteGeneral(config) {
   var gcuExcludes = ['GCUService.exe', 'GCUBridge.exe', 'WorkPro.exe', 'GSCService.exe', 'gsupservice.exe', 'gchsvc.exe']
   gcuExcludes.forEach(function(proc) {
     if (config.tun['exclude-process'].indexOf(proc) === -1) { config.tun['exclude-process'].push(proc) }
-  })
-}
-
-function uniqList(list) {
-  var seen = {}
-  return list.filter(function(item) {
-    if (!item || seen[item]) return false
-    seen[item] = true
-    return true
   })
 }
 

--- a/Clash Party/README.md
+++ b/Clash Party/README.md
@@ -208,38 +208,33 @@ DNS：
 
 ```yaml
 dns:
-  use-hosts: false
+  enable: true
+  listen: "0.0.0.0:1053"
+  ipv6: false
+  prefer-h3: false
   use-system-hosts: false
+  cache-algorithm: arc
   respect-rules: true
+  enhanced-mode: fake-ip
+  fake-ip-range: "198.18.0.1/16"
   default-nameserver:
     - 223.5.5.5
-    - 119.29.29.29
-    - 1.1.1.1
-    - 8.8.8.8
+    - 1.2.4.8
   nameserver:
-    - https://dns.alidns.com/dns-query
-    - https://doh.pub/dns-query
+    - https://208.67.222.222/dns-query
+    - https://77.88.8.8/dns-query
+    - https://1.1.1.1/dns-query
+    - https://8.8.4.4/dns-query
   proxy-server-nameserver:
-    - https://cloudflare-dns.com/dns-query
-    - https://dns.google/dns-query
-    - https://dns.alidns.com/dns-query
+    - https://223.5.5.5/dns-query
     - https://doh.pub/dns-query
   direct-nameserver:
-    - https://dns.alidns.com/dns-query
+    - https://223.5.5.5/dns-query
     - https://doh.pub/dns-query
-  fallback:
-    - https://cloudflare-dns.com/dns-query
-    - https://dns.google/dns-query
-  fallback-filter:
-    geoip: true
-    geoip-code: CN
-    ipcidr:
-      - 240.0.0.0/4
-      - 0.0.0.0/32
-      - 127.0.0.0/8
-      - 10.0.0.0/8
-      - 192.168.0.0/16
-    domain: []
+  nameserver-policy:
+    geosite:private,cn:
+      - https://223.5.5.5/dns-query
+      - https://doh.pub/dns-query
 ```
 
 Sniffer：


### PR DESCRIPTION
## Summary
- Align Clash Party DNS overwrite with clash-verge-script's split DNS model
- Route CN/private domains to domestic DoH via nameserver-policy and keep default DNS on foreign DoH with respect-rules enabled
- Remove inherited fallback/fallback-filter to avoid DNS leak paths, and update README example

## Verification
- node --check "Clash Party/ClashParty(mihomo).js"
- node --check "Clash Party/ClashParty(mihomo-smart).js"
- Sandbox main() smoke test confirmed fallback/fallback-filter are removed and split DNS policy is generated
- git diff --check
