### PR TITLE
feat: 借鉴 Proxy-override 批B — #6 节点过滤 junk 关键词补充 (v5.4.20)

### DIFF
--- a/Clash Meta For Android/CHANGELOG.md
+++ b/Clash Meta For Android/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 ---
 
+## v5.4.20-cmfa.1 (2026-05-30)
+
+借鉴 Proxy-override 批 B · #6 节点过滤关键词补充（spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：
+
+- proxy-providers `exclude-filter` 正则新增：中文 `免费` / `试用` / `应急`；英文 `\bSign\b` / `\bLogin\b` / `\bRegister\b` / `\bHelp\b` / `\bFAQ\b`（Go RE2 子串引擎下用 `\b` 词边界，避免误伤 Signal 等）
+- 不加「更新」「地址」（误伤风险高，owner spec 排除）
+- 一致性回归：`tools/test-info-node-filter.js` 覆盖本产物 exclude-filter
+- 🔢 版本：v5.4.19-cmfa.1 → v5.4.20-cmfa.1
+
 ## v5.4.19-cmfa.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A（跟随 Clash Party v5.4.19；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/Clash Meta For Android/CMFA(mihomo).yaml
+++ b/Clash Meta For Android/CMFA(mihomo).yaml
@@ -1,8 +1,10 @@
 # ================================================================
 # Clash Smart v5.4.19-cmfa.1 - CMFA (Clash Meta for Android) 配置
+﻿# ================================================================
+# Clash Smart v5.4.20-cmfa.1 - CMFA (Clash Meta for Android) 配置
 # Build: 2026-05-30
 # 架构：proxy-providers 订阅 + 22 url-test 区域组（11 全部 + 11 家宽，家宽 filter 新增 IEPL/IPLC/专线识别）+ 32 业务策略组（含 14 流媒体平台组）+ 384+ rule-providers
-# 基线：Clash Party v5.4.19（唯一主线）
+# 基线：Clash Party v5.4.20（唯一主线）
 # 变更历史：见 `Clash Meta For Android/CHANGELOG.md`
 # ================================================================
 # ★ 快速上手：
@@ -207,7 +209,8 @@ proxy-providers:
       enable: true
       url: 'https://www.gstatic.com/generate_204'
       interval: 300
-    exclude-filter: '(?i)(导航网址|距离下次重置|剩余流量|套餐到期|网址导航|官网|订阅|到期|剩余|重置)'
+    # v5.4.20 #6 借鉴 Proxy-override：补充 junk 关键词（免费/试用/应急 中文子串；Sign/Login/Register/Help/FAQ 英文用 \b 词边界，RE2 下避免误伤 Signal 等）
+    exclude-filter: '(?i)(导航网址|距离下次重置|剩余流量|套餐到期|网址导航|官网|订阅|到期|剩余|重置|免费|试用|应急|\bSign\b|\bLogin\b|\bRegister\b|\bHelp\b|\bFAQ\b)'
 proxy-groups:
   url: 'https://www.gstatic.com/generate_204'
   interval: 180

--- a/Clash Meta For Android/README.md
+++ b/Clash Meta For Android/README.md
@@ -4,7 +4,7 @@
 > 适用客户端：**Clash Meta For Android（CMFA）** / **FlClash** / **mihomo-party-android**（Android 原生）· **[ClashMi](https://github.com/KaringX/clashmi)**（跨平台 Flutter GUI，iOS/macOS/Android/Windows/Linux，复用同一 YAML；详见 §九）
 > 内核要求：**Mihomo**（原生 YAML 导入；区域组用 `url-test`，**不含 Smart + LightGBM**——CMFA 的静态 YAML 不支持 JS 覆写）
 > **FlClash 用户**：推荐使用 [FlClash 覆写脚本](../FlClash/FlClash(mihomo).js)（动态节点分类 + 家宽识别 + 订阅清理）。详见 [`FlClash/README.md`](../FlClash/README.md)。
-> 当前版本：**v5.4.19-cmfa.1**（跟随 Clash Party v5.4.19 主线；含借鉴 Proxy-override 批 A：国内 SDK/CDN 直连 + fake-ip-filter 补全 + direct-nameserver-follow-policy；DNS split-bootstrap 固定为 default 纯 IP + 其它 resolver 全 DoH，保留 GEOSITE 覆盖台账 / Cloudflare R2 / STUN/TURN 修复）
+> 当前版本：**v5.4.20-cmfa.1**（跟随 Clash Party v5.4.20 主线；含借鉴 Proxy-override 批 A+B：国内 SDK/CDN 直连 + fake-ip-filter 补全 + direct-nameserver-follow-policy + 节点过滤 junk 关键词补充；DNS split-bootstrap 固定为 default 纯 IP + 其它 resolver 全 DoH，保留 GEOSITE 覆盖台账 / Cloudflare R2 / STUN/TURN 修复）
 
 ---
 

--- a/Clash Party/CHANGELOG.md
+++ b/Clash Party/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ---
 
+## v5.4.20 / v5.4.20-normal.1 (2026-05-30)
+
+借鉴 Proxy-override 批 B · #6 节点过滤关键词补充（spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：
+
+- junk 节点过滤器 `isInfoNode` 新增关键词：中文子串 `免费` / `试用` / `应急`；英文（`\b` 词边界，防误伤 Signal 等）`Sign` / `Login` / `Register` / `Help` / `FAQ`
+- 不加「更新」「地址」（误伤风险高，owner spec 排除）
+- 回归测试：新增 `tools/test-info-node-filter.js`（6 mihomo 产物源码一致性）+ 扩展 `tools/validate-js-overwrites.js` fixture（3 JS 行为断言：8 个 junk 正例被过滤 + `Signal 香港 IEPL x1` 负例保留并分类 HK，验证 `\b` 词边界生效）
+- 🔢 版本：v5.4.19 → v5.4.20
+
 ## v5.4.19 / v5.4.19-normal.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A（低风险三项；设计 spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/Clash Party/ClashParty(mihomo).js
+++ b/Clash Party/ClashParty(mihomo).js
@@ -1,7 +1,7 @@
 ﻿// Clash 覆写脚本 - SUB-STORE 多机场精细分流版
-// 版本：v5.4.19-normal.1 (2026-05-30)
+// 版本：v5.4.20-normal.1 (2026-05-30)
 // 架构：22 url-test 区域组（11 全部 + 11 家宽）+ 32 业务策略组 + 385 rule-providers
-// 基线：Clash Party v5.4.19（与同目录 ClashParty(mihomo-smart).js 规则 100% 等价，仅区域组从 smart 改为 url-test）
+// 基线：Clash Party v5.4.20（与同目录 ClashParty(mihomo-smart).js 规则 100% 等价，仅区域组从 smart 改为 url-test）
 // 适用：Mihomo / Clash.Meta 稳定版内核、不支持 smart + LightGBM 的分支；也适用于想完全关闭 ML 评估的用户
 // 变更历史：见 `Clash Party/CHANGELOG.md`
 
@@ -9,7 +9,7 @@
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.4.19-normal.1'
+const VERSION = 'v5.4.20-normal.1'
 
 // v5.4.9 FEAT#LOCAL-TOOLS: desktop local-tool direct whitelist.
 const LOCAL_TOOL_DIRECT_PROCESS_NAMES = [
@@ -95,8 +95,9 @@ const RUSTDESK_WORK_PROCESS_NAMES = [
 // ================================================================
 
 function isInfoNode(name) {
-  const infoPatterns = ['导航网址', '距离下次重置', '剩余流量', '套餐到期', '网址导航', '官网', '订阅', '到期', '剩余', '重置']
-  const infoRes = [/\b(?:USE|USED|TOTAL|EXPIRE|EMAIL)\b/i, /Panel|Channel|Author|剩余流量|已用流量|到期时间|下次重置/i]
+  // v5.4.20 #6 借鉴 Proxy-override：补充 junk 关键词（免费/试用/应急 中文子串；Sign/Login/Register/Help/FAQ 英文用 \b 词边界，避免误伤 Signal 等合法节点）。不加「更新/地址」（误伤风险高）。
+  const infoPatterns = ['导航网址', '距离下次重置', '剩余流量', '套餐到期', '网址导航', '官网', '订阅', '到期', '剩余', '重置', '免费', '试用', '应急']
+  const infoRes = [/\b(?:USE|USED|TOTAL|EXPIRE|EMAIL)\b/i, /Panel|Channel|Author|剩余流量|已用流量|到期时间|下次重置/i, /\b(?:Sign|Login|Register|Help|FAQ)\b/i]
   const s = String(name || '')
   return infoPatterns.some(p => s.includes(p)) || infoRes.some(re => re.test(s))
 }

--- a/Clash Party/ClashParty(mihomo-smart).js
+++ b/Clash Party/ClashParty(mihomo-smart).js
@@ -1,14 +1,14 @@
 ﻿// Clash Smart 内核覆写脚本 - SUB-STORE 多机场精细分流版
-// 版本：v5.4.19 (2026-05-30)
+// 版本：v5.4.20 (2026-05-30)
 // 架构：SUB-STORE 多机场融合 + 22 Smart 区域组（11 全部 + 11 家宽）+ 32 业务策略组（含 14 流媒体平台组）+ 385 rule-providers 100%+ 服务覆盖
-// v5.4.19: 借鉴 Proxy-override 批A（国内SDK/CDN直连·fake-ip-filter补全·direct-nameserver-follow-policy）· v5.4.17: DNS 固定 default IP bootstrap
+// v5.4.20: 借鉴 Proxy-override 批B（#6 节点过滤 junk 关键词补充 免费/试用/应急/Sign/Login/Register/Help/FAQ）· v5.4.19: 批A（国内SDK/CDN直连·fake-ip-filter·direct-nameserver-follow-policy）· v5.4.17: DNS split-bootstrap
 // 变更历史：见 `Clash Party/CHANGELOG.md`
 
 // ================================================================
 //  版本常量
 // ================================================================
 
-const VERSION = 'v5.4.19'
+const VERSION = 'v5.4.20'
 
 // v5.4.9 FEAT#LOCAL-TOOLS:
 // Desktop-capable local tools that should not be routed through proxy nodes.
@@ -97,8 +97,9 @@ const RUSTDESK_WORK_PROCESS_NAMES = [
 // ================================================================
 
 function isInfoNode(name) {
-  const infoPatterns = ['导航网址', '距离下次重置', '剩余流量', '套餐到期', '网址导航', '官网', '订阅', '到期', '剩余', '重置']
-  const infoRes = [/\b(?:USE|USED|TOTAL|EXPIRE|EMAIL)\b/i, /Panel|Channel|Author|剩余流量|已用流量|到期时间|下次重置/i]
+  // v5.4.20 #6 借鉴 Proxy-override：补充 junk 关键词（免费/试用/应急 中文子串；Sign/Login/Register/Help/FAQ 英文用 \b 词边界，避免误伤 Signal 等合法节点）。不加「更新/地址」（误伤风险高）。
+  const infoPatterns = ['导航网址', '距离下次重置', '剩余流量', '套餐到期', '网址导航', '官网', '订阅', '到期', '剩余', '重置', '免费', '试用', '应急']
+  const infoRes = [/\b(?:USE|USED|TOTAL|EXPIRE|EMAIL)\b/i, /Panel|Channel|Author|剩余流量|已用流量|到期时间|下次重置/i, /\b(?:Sign|Login|Register|Help|FAQ)\b/i]
   const s = String(name || '')
   return infoPatterns.some(p => s.includes(p)) || infoRes.some(re => re.test(s))
 }

--- a/Clash Party/README.md
+++ b/Clash Party/README.md
@@ -1,8 +1,8 @@
 # Clash Party / Clash Verge / Mihomo Party 使用教程
 
 > 覆写脚本：**两份二选一**，规则 100% 等价，仅 22 区域组（11 全部 + 11 家宽）的内核选路算法不同
-> - `ClashParty(mihomo-smart).js`（**v5.4.19**，2026-05-30）— Smart 内核 + LightGBM ML 评估
-> - `ClashParty(mihomo).js`（**v5.4.19-normal.1**，2026-05-30）— 普通内核 url-test 延迟选路
+> - `ClashParty(mihomo-smart).js`（**v5.4.20**，2026-05-30）— Smart 内核 + LightGBM ML 评估
+> - `ClashParty(mihomo).js`（**v5.4.20-normal.1**，2026-05-30）— 普通内核 url-test 延迟选路
 >
 > UI 补充配置：已整合到本文「四、粘贴 UI 补充配置」章节
 > 架构：**SUB-STORE 多机场融合** + 22 区域组（11 全部 + 11 家宽）+ 32 业务策略组 + **385 rule-providers**

--- a/FlClash/CHANGELOG.md
+++ b/FlClash/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 ---
 
+## v5.4.20-flclash.1 (2026-05-30)
+
+借鉴 Proxy-override 批 B · #6 节点过滤关键词补充（跟随 Clash Party v5.4.20）：
+
+- junk 节点过滤器 `isInfoNode` 新增：中文 `免费` / `试用` / `应急`；英文（`\b` 词边界）`Sign` / `Login` / `Register` / `Help` / `FAQ`
+- 不加「更新」「地址」（误伤风险高）
+- 回归：`tools/validate-js-overwrites.js` flclash target fixture（junk 过滤 + Signal 守卫）+ `tools/test-info-node-filter.js` 一致性
+- 🔢 版本：v5.4.19-flclash.1 → v5.4.20-flclash.1
+
 ## v5.4.19-flclash.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A（跟随 Clash Party v5.4.19；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/FlClash/FlClash(mihomo).js
+++ b/FlClash/FlClash(mihomo).js
@@ -1,7 +1,9 @@
 // FlClash 覆写脚本 — 标准 Mihomo 内核动态分流版
 // 版本：v5.4.19-flclash.1 (2026-05-30)
+﻿// FlClash 覆写脚本 — 标准 Mihomo 内核动态分流版
+// 版本：v5.4.20-flclash.1 (2026-05-30)
 // 架构：22 url-test 区域组（11 全部 + 11 家宽）+ 32 业务策略组（含 14 流媒体平台组）+ 385 rule-providers 100%+ 服务覆盖
-// 基线：Clash Party Normal v5.4.19-normal.1（规则 100% 等价；区域组为 url-test — FlClash 内核为标准 Mihomo，不支持 smart + LightGBM）
+// 基线：Clash Party Normal v5.4.20-normal.1（规则 100% 等价；区域组为 url-test — FlClash 内核为标准 Mihomo，不支持 smart + LightGBM）
 // 适用：FlClash >= v0.8.85（覆盖脚本功能自该版本引入）；其他使用标准 Mihomo 内核的客户端
 // 变更历史：见 `FlClash/CHANGELOG.md`
 //
@@ -37,6 +39,7 @@
 
 const VERSION = 'v5.4.19-flclash.1'
 const VERSION = 'v5.4.17-flclash.2'
+const VERSION = 'v5.4.20-flclash.1'
 
 // v5.4.9 FEAT#LOCAL-TOOLS: desktop local-tool direct whitelist.
 const LOCAL_TOOL_DIRECT_PROCESS_NAMES = [
@@ -125,8 +128,9 @@ var log = (typeof console !== 'undefined' && console.log) ? console.log.bind(con
 // ================================================================
 
 function isInfoNode(name) {
-  const infoPatterns = ['导航网址', '距离下次重置', '剩余流量', '套餐到期', '网址导航', '官网', '订阅', '到期', '剩余', '重置']
-  const infoRes = [/\b(?:USE|USED|TOTAL|EXPIRE|EMAIL)\b/i, /Panel|Channel|Author|剩余流量|已用流量|到期时间|下次重置/i]
+  // v5.4.20 #6 借鉴 Proxy-override：补充 junk 关键词（免费/试用/应急 中文子串；Sign/Login/Register/Help/FAQ 英文用 \b 词边界，避免误伤 Signal 等合法节点）。不加「更新/地址」（误伤风险高）。
+  const infoPatterns = ['导航网址', '距离下次重置', '剩余流量', '套餐到期', '网址导航', '官网', '订阅', '到期', '剩余', '重置', '免费', '试用', '应急']
+  const infoRes = [/\b(?:USE|USED|TOTAL|EXPIRE|EMAIL)\b/i, /Panel|Channel|Author|剩余流量|已用流量|到期时间|下次重置/i, /\b(?:Sign|Login|Register|Help|FAQ)\b/i]
   const s = String(name || '')
   return infoPatterns.some(p => s.includes(p)) || infoRes.some(re => re.test(s))
 }

--- a/FlClash/README.md
+++ b/FlClash/README.md
@@ -3,7 +3,7 @@
 > 覆写脚本：`FlClash(mihomo).js`
 > 适用客户端：**FlClash**（Android / Windows / macOS / Linux）
 > 内核要求：FlClash >= **v0.8.85**
-> 当前版本：**v5.4.19-flclash.1**（22 url-test 区域组 + 32 业务策略组；含借鉴 Proxy-override 批 A：国内 SDK/CDN 直连 + fake-ip-filter 补全 + direct-nameserver-follow-policy；DNS split-bootstrap 固定为 default 纯 IP + 其它 resolver 全 DoH，保留 GEOSITE 覆盖台账 / Cloudflare R2 / STUN/TURN / RustDesk 修复）
+> 当前版本：**v5.4.20-flclash.1**（22 url-test 区域组 + 32 业务策略组；含借鉴 Proxy-override 批 A+B：国内 SDK/CDN 直连 + fake-ip-filter 补全 + direct-nameserver-follow-policy + 节点过滤 junk 关键词补充；DNS split-bootstrap 固定为 default 纯 IP + 其它 resolver 全 DoH，保留 GEOSITE 覆盖台账 / Cloudflare R2 / STUN/TURN / RustDesk 修复）
 
 <table><tr>
 <td><img width="160" alt="FlClash 截图1" src="https://github.com/user-attachments/assets/e88e0724-2bc0-4111-851e-e8aa0a9141d3"></td>

--- a/Loon/CHANGELOG.md
+++ b/Loon/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ---
 
+## v5.4.20-Loon.1 (2026-05-30)
+
+- N/A#6 节点过滤关键词补充（批 B）：Loon 不处理订阅去 junk（无运行时 junk 过滤器），#6 不适用；版本跟随 Clash Party v5.4.20 基线对齐。
+
 ## v5.4.19-Loon.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A · #2 国内 SDK/CDN 直连前置（跟随 Clash Party v5.4.19；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/Loon/Loon.conf
+++ b/Loon/Loon.conf
@@ -1,9 +1,10 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Loon Smart v5.4.19-Loon.1 — Loon 版（从 Clash Party v5.4.19 迁移）
+\#\ \ Loon\ Smart\ v5\.4\.20-Loon\.1 Loon 版（从 Clash Party v5.4.19 迁移）
 REMOVED_DUP_LINE#  Loon Smart v5.4.17-Loon.2 — Loon 版（从 Clash Party v5.4.17 迁移）
+#  Loon Smart v5.4.20-Loon.1 — Loon 版（从 Clash Party v5.4.20 迁移）
 #  Build: 2026-05-30 | Target: Loon iOS (App Store 付费正版)
 #  架构：22 区域 url-test 组（11 全部 + 11 家宽）+ 32 业务 select 组（含 14 流媒体平台组）+ 288 [Remote Rule] 订阅规则集
-#  基线：Clash Party v5.4.19（唯一主线）
+#  基线：Clash Party v5.4.20（唯一主线）
 #  变更历史：见 `Loon/CHANGELOG.md`
 # ══════════════════════════════════════════════════════════════════════════════
 

--- a/Loon/README.md
+++ b/Loon/README.md
@@ -1,7 +1,7 @@
-# Loon 使用教程（对齐 Clash Party v5.4.19）
+# Loon 使用教程（对齐 Clash Party v5.4.20）
 
 > 配置文件：`Loon/Loon.conf`
-> 版本：**v5.4.19-Loon.1**（Build 2026-05-30，详见 `Loon/CHANGELOG.md`；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连；DNS split-bootstrap 按 Loon 原生字段映射，UDP/443 仍按 `disable-udp-ports` 屏蔽）
+> 版本：**v5.4.20-Loon.1**（Build 2026-05-30，详见 `Loon/CHANGELOG.md`；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连；DNS split-bootstrap 按 Loon 原生字段映射，UDP/443 仍按 `disable-udp-ports` 屏蔽）
 > 目标：**Loon iOS（App Store 付费正版）**
 > 架构：22 区域 url-test 组（11 全部 + 11 家宽，[Remote Filter] NameRegex）+ 32 业务策略组 + 288 [Remote Rule] 订阅规则集
 

--- a/OpenClash/CHANGELOG.md
+++ b/OpenClash/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ---
 
+## v5.4.20-oc-normal.1 / v5.4.20-oc-smart.1 (2026-05-30)
+
+借鉴 Proxy-override 批 B · #6 节点过滤关键词补充（Normal / Smart 同步；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：
+
+- Ruby `INFO_PATTERNS` reject 数组新增：中文 `/免费/` `/试用/` `/应急/`；英文 `/\bSign\b/i` `/\bLogin\b/i` `/\bRegister\b/i` `/\bHelp\b/i` `/\bFAQ\b/i`（`\b` 词边界防误伤 Signal；`/注册/` Register 中文已存在）
+- 不加「更新」「地址」（误伤风险高，owner spec 排除）
+- 一致性回归：`tools/test-info-node-filter.js` 覆盖两份 .sh 的 Ruby INFO_PATTERNS
+- 🔢 版本：v5.4.19-oc-* → v5.4.20-oc-*
+
 ## v5.4.19-oc-normal.1 / v5.4.19-oc-smart.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A（Normal / Smart 同步；跟随 Clash Party v5.4.19；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/OpenClash/OpenClash(mihomo).conf
+++ b/OpenClash/OpenClash(mihomo).conf
@@ -1,5 +1,5 @@
-# Clash Smart v5.4.19-oc-reference — OpenClash 覆写模块参考快照
-# Baseline: Clash Party v5.4.19；权威产物为 OpenClash(mihomo).sh / OpenClash(mihomo-smart).sh（#2 国内 SDK/CDN 直连见两份 .sh heredoc）
+# Clash Smart v5.4.20-oc-reference — OpenClash 覆写模块参考快照
+# Baseline: Clash Party v5.4.20；权威产物为 OpenClash(mihomo).sh / OpenClash(mihomo-smart).sh（#2 国内 SDK/CDN 直连 + #6 junk 过滤关键词见两份 .sh heredoc / Ruby）
 # Historical FIXED v5.2.4-oc:
 #   FIX#1: CHINA_IP_ROUTE 0 → 避免 OpenClash Step3 注入裸 "geosite" 引用导致 parse error
 #   FIX#2: 添加 GEOSITE_CUSTOM_URL → 确保 geosite.dat 来源正确

--- a/OpenClash/OpenClash(mihomo).sh
+++ b/OpenClash/OpenClash(mihomo).sh
@@ -2,7 +2,7 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash Smart v5.4.19-oc-normal.1 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
+# Clash Smart v5.4.20-oc-normal.1 — OpenClash 覆写脚本（非 Smart 内核 / url-test 区域组）
 # Build: 2026-05-26
 # ============================================================================
 # 定位：与同目录 OpenClash(mihomo-smart).sh 规则 100% 等价的「非 Smart 内核」版本。
@@ -19,7 +19,7 @@
 #   • ~990 条 rules
 #   • DNS fake-ip + 嗅探（HTTP/TLS/QUIC）+ nameserver-policy 救援
 #   • Ruby 阶段做：节点过滤 / 区域分类 / url-test 组生成 / TLS 指纹注入
-# 基线：Clash Party v5.4.19（唯一主线；v5.3.1/v5.3.2 为桌面端 PROCESS-NAME 改动，路由器端不适用）── 任何规则/组/DNS 改动必须先改 Clash Party JS，
+# 基线：Clash Party v5.4.20（唯一主线；v5.3.1/v5.3.2 为桌面端 PROCESS-NAME 改动，路由器端不适用）── 任何规则/组/DNS 改动必须先改 Clash Party JS，
 #       再同步到此文件。参见仓库根目录 CLAUDE.md / AGENTS.md。
 # 变更历史：见 `OpenClash/CHANGELOG.md`（Normal 部分）。
 # ============================================================================
@@ -28,6 +28,7 @@
 
 VERSION_TAG="v5.4.19-oc-normal.1"
 VERSION_TAG="v5.4.17-oc-normal.2"
+VERSION_TAG="v5.4.20-oc-normal.1"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -4362,7 +4363,7 @@ cat > "$RUBY_SCRIPT" << 'RUBY_EOF'
 require 'yaml'
 require 'digest'
 
-VERSION = "v5.4.19-oc-normal.1"
+VERSION = "v5.4.20-oc-normal.1"
 
 STATUS_LOG = "/tmp/clash_normal_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }
@@ -4383,6 +4384,8 @@ INFO_PATTERNS = [
   /订阅/, /机场/, /客服/, /网址/, /邀请/, /注册/,
   /公告/, /通知/, /公众号/, /永久/, /套餐/, /续费/,
   /dns|DNS/, /IPLC|iplc/, /中转/,
+  # v5.4.20 #6 借鉴 Proxy-override：补充 junk 关键词（中文子串 + 英文 \b 词边界防误伤 Signal 等；/注册/ 已存在）
+  /免费/, /试用/, /应急/, /\bSign\b/i, /\bLogin\b/i, /\bRegister\b/i, /\bHelp\b/i, /\bFAQ\b/i,
   /^剩余|^到期|^流量|^官网/
 ]
 RESIDENTIAL_PATTERNS = [

--- a/OpenClash/OpenClash(mihomo-smart).sh
+++ b/OpenClash/OpenClash(mihomo-smart).sh
@@ -2,10 +2,10 @@
 . /usr/share/openclash/log.sh
 
 # ============================================================================
-# Clash Smart v5.4.19-oc-smart.1 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
+# Clash Smart v5.4.20-oc-smart.1 — OpenClash 覆写脚本（与 Clash Party 主线同等规则量）
 # Build: 2026-05-26
 # ============================================================================
-# 定位：对齐 Clash Party v5.4.19 JS 主线的 OpenClash 全量版本。v5.4.2: P0-FIX#41 小米白名单。
+# 定位：对齐 Clash Party v5.4.20 JS 主线的 OpenClash 全量版本。v5.4.2: P0-FIX#41 小米白名单。
 #       与同目录 OpenClash(mihomo).sh（Normal）互补：
 #         - Normal 面向稳定版 mihomo / 经典 url-test
 #         - full  面向 4GB+ 路由器 / 需要与 Clash Party 桌面端一致的细粒度分流
@@ -16,7 +16,7 @@
 #   • ~990 条 rules
 #   • DNS fake-ip + 嗅探（HTTP/TLS/QUIC）+ nameserver-policy 救援
 #   • Ruby 阶段做：节点过滤 / 区域分类 / Smart 组生成 / TLS 指纹注入
-# 基线：Clash Party v5.4.19（唯一主线；v5.3.1/v5.3.2 为桌面端 PROCESS-NAME 改动，路由器端不适用）── 任何规则/组/DNS 改动必须先改 Clash Party JS，
+# 基线：Clash Party v5.4.20（唯一主线；v5.3.1/v5.3.2 为桌面端 PROCESS-NAME 改动，路由器端不适用）── 任何规则/组/DNS 改动必须先改 Clash Party JS，
 #       再同步到此文件。参见仓库根目录 CLAUDE.md / AGENTS.md。
 # 变更历史：见 `OpenClash/CHANGELOG.md`（Full 部分）。
 # ============================================================================
@@ -25,6 +25,7 @@
 
 VERSION_TAG="v5.4.19-oc-smart.1"
 VERSION_TAG="v5.4.17-oc-smart.2"
+VERSION_TAG="v5.4.20-oc-smart.1"
 CONFIG_FILE="$1"
 LOG_FILE="/tmp/openclash.log"
 
@@ -4361,6 +4362,7 @@ require 'digest'
 
 VERSION = "v5.4.19-oc-smart.1"
 VERSION = "v5.4.17-oc-smart.2"
+VERSION = "v5.4.20-oc-smart.1"
 
 STATUS_LOG = "/tmp/clash_smart_status.log"
 File.open(STATUS_LOG, 'w') { |f| f.puts "[#{VERSION}] start" }
@@ -4381,6 +4383,8 @@ INFO_PATTERNS = [
   /订阅/, /机场/, /客服/, /网址/, /邀请/, /注册/,
   /公告/, /通知/, /公众号/, /永久/, /套餐/, /续费/,
   /dns|DNS/, /IPLC|iplc/, /中转/,
+  # v5.4.20 #6 借鉴 Proxy-override：补充 junk 关键词（中文子串 + 英文 \b 词边界防误伤 Signal 等；/注册/ 已存在）
+  /免费/, /试用/, /应急/, /\bSign\b/i, /\bLogin\b/i, /\bRegister\b/i, /\bHelp\b/i, /\bFAQ\b/i,
   /^剩余|^到期|^流量|^官网/
 ]
 RESIDENTIAL_PATTERNS = [

--- a/Passwall/CHANGELOG.md
+++ b/Passwall/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ---
 
+## v5.4.20-pw.1 (2026-05-30)
+
+- N/A#6 节点过滤关键词补充（批 B）：Passwall 无运行时节点分类 / junk 过滤器（静态 shunt_rules），#6 不适用；版本跟随 Clash Party v5.4.20 基线对齐。
+
 ## v5.4.19-pw.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A · #2 国内 SDK/CDN 直连前置（跟随 Clash Party v5.4.19；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/Passwall/Passwall(xray+sing-box)-apply.sh
+++ b/Passwall/Passwall(xray+sing-box)-apply.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 # ═══════════════════════════════════════════════════════════════════════════
 # Smart-Config-Kit for Passwall — UCI batch helper
-# Version: v5.4.19-pw.1 | Build 2026-05-30
+# Version: v5.4.20-pw.1 | Build 2026-05-30
 #
 # 用途：一次性在 Passwall（全功能版）中创建 32 条 shunt rule（含域名列表 + IP 列表），
 #       每条目标节点留空（NEED_CONFIG），用户之后到 LuCI 里手工选节点。
 #
+# 变更：v5.4.20-pw.1 — N/A#6 节点过滤关键词补充：Passwall 无运行时节点分类 / junk 过滤器，#6 不适用；版本跟随基线对齐
 # 变更：v5.4.19-pw.1 — 借鉴 Proxy-override #2：27-cn-site.list 增国内推送 SDK(jpush/umeng) + 前端 CDN(baomitu/bootcss/staticfile/upaiyun) 直连
 # 变更：v5.4.17-pw.1 — 跟随 Clash Party v5.4.17 记录 DNS split-bootstrap；Passwall shunt_rules 不承载 DNS
 # 变更：v5.4.16-pw.1 — Paddle 许可/支付链路加入金融支付；Passwall 不消费 anti-AD 远程源

--- a/Passwall/Passwall(xray+sing-box).conf
+++ b/Passwall/Passwall(xray+sing-box).conf
@@ -1,7 +1,7 @@
 # ════════════════════════════════════════════════════════════════════════════
 #  Smart-Config-Kit for Passwall — Shunt Rules Consolidated Reference
-#  Version: v5.4.19-pw.1 | Build: 2026-05-30
-#  Baseline: Clash Party v5.4.19（展平版；适用 Passwall 全功能版，
+#  Version: v5.4.20-pw.1 | Build: 2026-05-30
+#  Baseline: Clash Party v5.4.20（展平版；适用 Passwall 全功能版，
 #            Passwall / Passwall2 共用 shunt_rules.lua，同一份 .list 互通）
 # ────────────────────────────────────────────────────────────────────────────
 #  ⚠️ 注意：本 .conf 文件为手动配置参考；推荐使用同目录 .sh 脚本自动创建 32 条规则

--- a/Passwall/README.md
+++ b/Passwall/README.md
@@ -1,7 +1,7 @@
-# Passwall 使用教程（对齐 Clash Party v5.4.19 简化版）
+# Passwall 使用教程（对齐 Clash Party v5.4.20 简化版）
 
 > 配置参考：`Passwall/` 目录  
-> 版本：**v5.4.19-pw.1**（Build 2026-05-30；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连（27-cn-site.list）；DNS split-bootstrap 不适用于 Passwall shunt_rules，Paddle / Cloudflare R2 规则保持）
+> 版本：**v5.4.20-pw.1**（Build 2026-05-30；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连（27-cn-site.list）；DNS split-bootstrap 不适用于 Passwall shunt_rules，Paddle / Cloudflare R2 规则保持）
 > 目标：**[Passwall](https://github.com/Openwrt-Passwall/openwrt-passwall)**（全功能版）—— [`Openwrt-Passwall`](https://github.com/Openwrt-Passwall) 组织（原 `xiaorouji` 个人仓库已迁入）维护。与 [Passwall2](https://github.com/Openwrt-Passwall/openwrt-passwall2)（精简分流版）**并行维护**（非新旧关系），规则语法同源（共用 [shunt_rules.lua](https://github.com/Openwrt-Passwall/openwrt-passwall2/blob/main/luci-app-passwall2/luasrc/model/cbi/passwall2/client/shunt_rules.lua) 解析器），同一份 `.list` 两者通用。  
 > 架构：32 条 shunt rule（展平版，每条对应一个业务类别）+ xray/sing-box 原生域名匹配语法（纯字符串 / `regexp:` / `domain:` / `full:` / `geosite:` / `rule-set:remote|local:` / `geoip:` / CIDR）
 

--- a/Passwall2/CHANGELOG.md
+++ b/Passwall2/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ---
 
+## v5.4.20-pw2.1 (2026-05-30)
+
+- N/A#6 节点过滤关键词补充（批 B）：Passwall2 无运行时节点分类 / junk 过滤器（静态 shunt_rules），#6 不适用；版本跟随 Clash Party v5.4.20 基线对齐。
+
 ## v5.4.19-pw2.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A · #2 国内 SDK/CDN 直连前置（跟随 Clash Party v5.4.19；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/Passwall2/Passwall2(xray+sing-box)-apply.sh
+++ b/Passwall2/Passwall2(xray+sing-box)-apply.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 # ═══════════════════════════════════════════════════════════════════════════
 # Smart-Config-Kit for Passwall / Passwall2 — UCI batch helper
-# Version: v5.4.19-pw2.1 | Build 2026-05-30
+# Version: v5.4.20-pw2.1 | Build 2026-05-30
 #
 # 用途：一次性在 Passwall2 中创建 32 条 shunt rule（含域名列表 + IP 列表），
 #       每条目标节点留空（NEED_CONFIG），用户之后到 LuCI 里手工选节点。
 #
+# 变更：v5.4.20-pw2.1 — N/A#6 节点过滤关键词补充：Passwall2 无运行时节点分类 / junk 过滤器，#6 不适用；版本跟随基线对齐
 # 变更：v5.4.19-pw2.1 — 借鉴 Proxy-override #2：27-cn-site.list 增国内推送 SDK(jpush/umeng) + 前端 CDN(baomitu/bootcss/staticfile/upaiyun) 直连
 # 变更：v5.4.17-pw2.1 — 跟随 Clash Party v5.4.17 记录 DNS split-bootstrap；Passwall2 shunt_rules 不承载 DNS
 # 变更：v5.4.16-pw2.1 — Paddle 许可/支付链路加入金融支付；Passwall2 不消费 anti-AD 远程源

--- a/Passwall2/Passwall2(xray+sing-box).conf
+++ b/Passwall2/Passwall2(xray+sing-box).conf
@@ -1,7 +1,7 @@
 # ════════════════════════════════════════════════════════════════════════════
 #  Smart-Config-Kit for Passwall / Passwall2 — Shunt Rules Consolidated Reference
-#  Version: v5.4.19-pw2.1 | Build: 2026-05-30
-#  Baseline: Clash Party v5.4.19（展平版；适用 Passwall 全功能版 + Passwall2 精简版，
+#  Version: v5.4.20-pw2.1 | Build: 2026-05-30
+#  Baseline: Clash Party v5.4.20（展平版；适用 Passwall 全功能版 + Passwall2 精简版，
 #            两者共用 shunt_rules.lua，同一份 .list 互通）
 # ────────────────────────────────────────────────────────────────────────────
 #  ⚠️ 注意：本 .conf 文件为手动配置参考；推荐使用同目录 .sh 脚本自动创建 32 条规则

--- a/Passwall2/README.md
+++ b/Passwall2/README.md
@@ -1,7 +1,7 @@
-# Passwall / Passwall2 使用教程（对齐 Clash Party v5.4.19 简化版）
+# Passwall / Passwall2 使用教程（对齐 Clash Party v5.4.20 简化版）
 
 > 配置参考：`Passwall2/` 目录  
-> 版本：**v5.4.19-pw2.1**（Build 2026-05-30；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连（27-cn-site.list）；DNS split-bootstrap 不适用于 Passwall2 shunt_rules，Paddle / Cloudflare R2 规则保持）
+> 版本：**v5.4.20-pw2.1**（Build 2026-05-30；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连（27-cn-site.list）；DNS split-bootstrap 不适用于 Passwall2 shunt_rules，Paddle / Cloudflare R2 规则保持）
 > 目标：**[Passwall](https://github.com/Openwrt-Passwall/openwrt-passwall)**（全功能版）+ **[Passwall2](https://github.com/Openwrt-Passwall/openwrt-passwall2)**（精简分流版）—— [`Openwrt-Passwall`](https://github.com/Openwrt-Passwall) 组织（原 `xiaorouji` 个人仓库已迁入）并行维护的两款 OpenWrt 插件，**规则语法同源**（共用 [shunt_rules.lua](https://github.com/Openwrt-Passwall/openwrt-passwall2/blob/main/luci-app-passwall2/luasrc/model/cbi/passwall2/client/shunt_rules.lua) 解析器），同一份 `.list` 两者通用。  
 > 架构：32 条 shunt rule（展平版，每条对应一个业务类别）+ xray/sing-box 原生域名匹配语法（纯字符串 / `regexp:` / `domain:` / `full:` / `geosite:` / `rule-set:remote|local:` / `geoip:` / CIDR）
 

--- a/Quantumult X/CHANGELOG.md
+++ b/Quantumult X/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ---
 
+## v5.4.20-QX.1 (2026-05-30)
+
+- N/A#6 节点过滤关键词补充（批 B）：Quantumult X 不处理订阅去 junk（区域分类用 server-tag-regex，无 junk 排除器），#6 不适用；版本跟随 Clash Party v5.4.20 基线对齐。
+
 ## v5.4.19-QX.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A · #2 国内 SDK/CDN 直连前置（跟随 Clash Party v5.4.19；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/Quantumult X/QuantumultX.conf
+++ b/Quantumult X/QuantumultX.conf
@@ -1,9 +1,10 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Quantumult X Smart v5.4.19-QX.1 — Quantumult X 版（从 Clash Party v5.4.19 迁移）
+\#\ \ Quantumult\ X\ Smart\ v5\.4\.20-QX\.1 Quantumult X 版（从 Clash Party v5.4.19 迁移）
 REMOVED_DUP_LINE#  Quantumult X Smart v5.4.17-QX.2 — Quantumult X 版（从 Clash Party v5.4.17 迁移）
+#  Quantumult X Smart v5.4.20-QX.1 — Quantumult X 版（从 Clash Party v5.4.20 迁移）
 #  Build: 2026-05-30 | Target: Quantumult X iOS (App Store 付费正版)
 #  架构：22 区域 url-latency-benchmark（11 全部 + 11 家宽）+ 32 业务 static（含 14 流媒体平台组）+ 288 remote URL filters + 568 inline/local filters
-#  基线：Clash Party v5.4.19（唯一主线）
+#  基线：Clash Party v5.4.20（唯一主线）
 #  变更历史：见 `Quantumult X/CHANGELOG.md`
 # ══════════════════════════════════════════════════════════════════════════════
 

--- a/Quantumult X/README.md
+++ b/Quantumult X/README.md
@@ -1,7 +1,7 @@
-# Quantumult X 使用教程（对齐 Clash Party v5.4.19）
+# Quantumult X 使用教程（对齐 Clash Party v5.4.20）
 
 > 配置文件：`Quantumult X/QuantumultX.conf`
-> 版本：**v5.4.19-QX.1**（Build 2026-05-30，详见 `Quantumult X/CHANGELOG.md`；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连，jpush/umeng 前置于 jiguang/youmeng 拦截；DNS split-bootstrap 按 QX 原生字段映射，DoH 顺序 AliDNS 优先）
+> 版本：**v5.4.20-QX.1**（Build 2026-05-30，详见 `Quantumult X/CHANGELOG.md`；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连，jpush/umeng 前置于 jiguang/youmeng 拦截；DNS split-bootstrap 按 QX 原生字段映射，DoH 顺序 AliDNS 优先）
 > 目标：**Quantumult X iOS（App Store 付费正版）**
 > 架构：22 区域 `url-latency-benchmark` 组（11 全部 + 11 家宽）+ 32 业务 `static` 组 + ~290 filter_remote + 568 filter_local 规则
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ flowchart LR
 | 🐟 漏网之鱼 | 以 GEOSITE/GEOIP/FINAL 兜底为主（非单一固定 provider） | MetaCubeX（geo 规则） |
 | 🛑 广告拦截 | `anti-ad` `sukka-phishing` `hagezi-tif` `advertising` `privacy` `acc-unsupportvpn` | DustinWin / SukkaW / Hagezi / blackmatrix7 / Accademia |
 
-> v5.4.12 起持续修复误伤白名单（Paddle / Cloudflare R2 / STUN / RustDesk）+ Surge `DEST-PORT` 兼容 + [GEOSITE 覆盖台账](./docs/GEOSITE_COVERAGE_LEDGER.md)；DNS 自 v5.4.17 起采用 split-bootstrap 加固；v5.4.19 借鉴 Proxy-override 批 A（国内 SDK/CDN 直连前置 + fake-ip-filter 远控/游戏/P2P 补全 + `direct-nameserver-follow-policy`），详见下方 [DNS 净化](#-dns-净化科学上网的第一道防线)。
+> v5.4.12 起持续修复误伤白名单（Paddle / Cloudflare R2 / STUN / RustDesk）+ Surge `DEST-PORT` 兼容 + [GEOSITE 覆盖台账](./docs/GEOSITE_COVERAGE_LEDGER.md)；DNS 自 v5.4.17 起采用 split-bootstrap 加固；v5.4.19 借鉴 Proxy-override 批 A（国内 SDK/CDN 直连前置 + fake-ip-filter 远控/游戏/P2P 补全 + `direct-nameserver-follow-policy`）；v5.4.20 批 B（#6 节点过滤 junk 关键词补充 免费/试用/应急/Sign/Login/Register/Help/FAQ，6 mihomo 产物），详见下方 [DNS 净化](#-dns-净化科学上网的第一道防线)。
 
 ---
 

--- a/Shadowrocket/CHANGELOG.md
+++ b/Shadowrocket/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ---
 
+## v5.4.20-SR.1 (2026-05-30)
+
+- N/A#6 节点过滤关键词补充（批 B）：Shadowrocket 不处理订阅去 junk（无 isInfoNode / exclude-filter 等运行时 junk 过滤器），#6 不适用；版本跟随 Clash Party v5.4.20 基线对齐。
+
 ## v5.4.19-SR.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A · #2 国内 SDK/CDN 直连前置（跟随 Clash Party v5.4.19；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/Shadowrocket/README.md
+++ b/Shadowrocket/README.md
@@ -1,7 +1,7 @@
 # Shadowrocket（小火箭）使用教程
 
 > 配置文件：`Shadowrocket.conf`
-> 版本：**v5.4.19-SR.1**（Build 2026-05-30，跟随 Clash Party v5.4.19 基线；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连；DNS 普通/代理/fallback resolver 全部改为 DoH，QUIC 策略不变）
+> 版本：**v5.4.20-SR.1**（Build 2026-05-30，跟随 Clash Party v5.4.20 基线；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连；DNS 普通/代理/fallback resolver 全部改为 DoH，QUIC 策略不变）
 > 目标：**Shadowrocket iOS（App Store 正版）** / macOS 通用
 > 架构：22 区域组（11 全部 + 11 家宽，`url-test` + `policy-regex-filter` 按节点名自动分类）+ 32 业务策略组 + ~290 rule-set
 

--- a/Shadowrocket/Shadowrocket.conf
+++ b/Shadowrocket/Shadowrocket.conf
@@ -1,9 +1,10 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Shadowrocket Smart v5.4.19-SR.1 — 小火箭版（从 Clash Party v5.4.19 迁移重构）
+\#\ \ Shadowrocket\ Smart\ v5\.4\.20-SR\.1 小火箭版（从 Clash Party v5.4.19 迁移重构）
 REMOVED_DUP_LINE#  Shadowrocket Smart v5.4.17-SR.2 — 小火箭版（从 Clash Party v5.4.17 迁移重构）
+#  Shadowrocket Smart v5.4.20-SR.1 — 小火箭版（从 Clash Party v5.4.20 迁移重构）
 #  Build: 2026-05-30 | Target: Shadowrocket iOS (App Store 正版) | macOS 通用
 #  架构：22 区域 url-test 组（11 全部 + 11 家宽）+ 32 业务策略组（含 14 流媒体平台组）+ ~290 RULE-SET
-#  基线：Clash Party v5.4.19（唯一主线）
+#  基线：Clash Party v5.4.20（唯一主线）
 #  变更历史：见 `Shadowrocket/CHANGELOG.md`
 # ══════════════════════════════════════════════════════════════════════════════
 

--- a/SingBox/CHANGELOG.md
+++ b/SingBox/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ---
 
+## v5.4.20-sing.1 (2026-05-30)
+
+- N/A#6 节点过滤关键词补充（批 B）：sing-box 为静态 outbound 列表（用户自接入节点，无订阅 junk 过滤），#6 不适用。generator.js 版本/基线 bump 后重新生成，route.rules 不变（1077→725 转换）；版本跟随 Clash Party v5.4.20 基线对齐。
+
 ## v5.4.19-sing.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A · #2 国内 SDK/CDN 直连前置（由主线 Smart JS 规则自动派生后重新生成；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/SingBox/README.md
+++ b/SingBox/README.md
@@ -1,6 +1,6 @@
-# SingBox 使用教程（对齐 Clash Party v5.4.19 Full 语义）
+# SingBox 使用教程（对齐 Clash Party v5.4.20 Full 语义）
 
-> 配置文件：`SingBox/SingBox(sing-box)-full.json`（v5.4.19-sing.1）
+> 配置文件：`SingBox/SingBox(sing-box)-full.json`（v5.4.20-sing.1）
 > 生成脚本：`SingBox/SingBox(sing-box)-generator.js`
 > 目标：在 **sing-box** 上复刻 Clash Party 的「20 区域组（10 全部 + 10 家宽）+ 32 业务组」静态策略结构，并只使用 sing-box 官方可消费的 SRS 规则集，保持 sing-box 1.12/1.13/1.14 官方配置兼容。
 > 本目录只提供 Full 配置。

--- a/SingBox/SingBox(sing-box)-full.json
+++ b/SingBox/SingBox(sing-box)-full.json
@@ -5,9 +5,9 @@
   },
   "_meta": {
     "name": "SingBox Smart Full",
-    "version": "v5.4.19-sing.1",
+    "version": "v5.4.20-sing.1",
     "build": "2026-05-30",
-    "baseline": "Clash Party v5.4.19",
+    "baseline": "Clash Party v5.4.20",
     "changelog": "见 SingBox/CHANGELOG.md"
   },
   "experimental": {

--- a/SingBox/SingBox(sing-box)-generator.js
+++ b/SingBox/SingBox(sing-box)-generator.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const vm = require('vm');
 
-const VERSION = 'v5.4.19-sing.1';
+const VERSION = 'v5.4.20-sing.1';
 const BUILD = '2026-05-30';
-const BASELINE = 'Clash Party v5.4.19';
+const BASELINE = 'Clash Party v5.4.20';
 
 const SMART = {
   GLOBAL: '🌍 全球节点',

--- a/Surge/CHANGELOG.md
+++ b/Surge/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ---
 
+## v5.4.20-Surge.1 (2026-05-30)
+
+- N/A#6 节点过滤关键词补充（批 B）：Surge 不处理订阅去 junk（无运行时 junk 过滤器），#6 不适用；版本跟随 Clash Party v5.4.20 基线对齐。
+
 ## v5.4.19-Surge.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A · #2 国内 SDK/CDN 直连前置（跟随 Clash Party v5.4.19；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/Surge/README.md
+++ b/Surge/README.md
@@ -1,7 +1,7 @@
-# Surge 使用教程（对齐 Clash Party v5.4.19）
+# Surge 使用教程（对齐 Clash Party v5.4.20）
 
 > 配置文件：`Surge/Surge.conf`
-> 版本：**v5.4.19-Surge.1**（Build 2026-05-30，详见 `Surge/CHANGELOG.md`；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连；DNS split-bootstrap 按 Surge 原生字段映射，端口规则继续使用官方 `DEST-PORT`）
+> 版本：**v5.4.20-Surge.1**（Build 2026-05-30，详见 `Surge/CHANGELOG.md`；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连；DNS split-bootstrap 按 Surge 原生字段映射，端口规则继续使用官方 `DEST-PORT`）
 > 目标：**Surge 5 / Surge Mac**（付费正版；iOS + macOS 通用）
 > 架构：22 区域 url-test 组（11 全部 + 11 家宽，include-all-proxies + policy-regex-filter 自动按地区聚合）+ 32 业务策略组 + ~290 RULE-SET
 
@@ -240,7 +240,7 @@ Surge 的节点来源有两种方式，任选其一：
 
 ## 九、验证
 
-1. Surge → **首页** → **已启用的配置**：应显示 `Surge Smart v5.4.19-Surge.1`。
+1. Surge → **首页** → **已启用的配置**：应显示 `Surge Smart v5.4.20-Surge.1`。
 2. **策略组** 面板应出现 22 区域 + 32 业务共 54 组（不得少于 50 组）。
 3. 访问以下网站做功能验证：
    - `https://chat.openai.com` → 命中「🤖 AI 服务」

--- a/Surge/Surge.conf
+++ b/Surge/Surge.conf
@@ -1,9 +1,10 @@
 # ══════════════════════════════════════════════════════════════════════════════
-#  Surge Smart v5.4.19-Surge.1 — Surge 版（从 Clash Party v5.4.19 迁移）
+\#\ \ Surge\ Smart\ v5\.4\.20-Surge\.1 Surge 版（从 Clash Party v5.4.19 迁移）
 REMOVED_DUP_LINE#  Surge Smart v5.4.17-Surge.2 — Surge 版（从 Clash Party v5.4.17 迁移）
+#  Surge Smart v5.4.20-Surge.1 — Surge 版（从 Clash Party v5.4.20 迁移）
 #  Build: 2026-05-30 | Target: Surge 5 / Surge Mac (付费正版) | iOS + macOS
 #  架构：22 区域 url-test 组（11 全部 + 11 家宽）+ 32 业务 select 组（含 14 流媒体平台组）+ ~290 RULE-SET
-#  基线：Clash Party v5.4.19（唯一主线）
+#  基线：Clash Party v5.4.20（唯一主线）
 #  变更历史：见 `Surge/CHANGELOG.md`
 # ══════════════════════════════════════════════════════════════════════════════
 

--- a/tools/test-info-node-filter.js
+++ b/tools/test-info-node-filter.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+'use strict';
+// ============================================================================
+// #6 借鉴 Proxy-override：节点过滤(junk)关键词补充 —— 6 个 mihomo 产物跨端一致性回归
+// ----------------------------------------------------------------------------
+// 背景：#6 给 junk 节点过滤器补充关键词 `免费/试用/应急`（中文子串）+
+//       `Sign/Login/Register/Help/FAQ`（英文，必须 \b 词边界，否则 RE2/Ruby 子串
+//       引擎会把 "Signal" 当 "Sign" 误伤——参见 CLAUDE.md §3.5.3 正则语义差异）。
+// 分工：
+//   - 行为回归（junk 真被过滤 + "Signal" 不被误伤）：tools/validate-js-overwrites.js
+//     的 fixture 已含正例(免费/试用/应急/Sign Up/Login/Register/Help/FAQ)与
+//     负例("Signal 香港 IEPL x1")，对 3 个 JS 产物实跑 main() 断言。
+//   - 本测试：静态源码一致性——确保全部 6 个 mihomo 产物（含 validator 不执行的
+//     CMFA YAML / OpenClash Ruby）都补齐了关键词，且英文采用 \b 词边界形态。
+// 用法：node tools/test-info-node-filter.js
+// ============================================================================
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO = path.resolve(__dirname, '..');
+
+const CN = ['免费', '试用', '应急'];                       // 中文：子串匹配即可（无词边界问题）
+const EN = ['Sign', 'Login', 'Register', 'Help', 'FAQ'];   // 英文：必须 \b 词边界
+
+// junk 过滤器所在的 6 个 mihomo 产物（其余产物不处理订阅去 junk，#6 不适用）
+const PRODUCTS = [
+  'Clash Party/ClashParty(mihomo-smart).js',
+  'Clash Party/ClashParty(mihomo).js',
+  'FlClash/FlClash(mihomo).js',
+  'Clash Meta For Android/CMFA(mihomo).yaml',
+  'OpenClash/OpenClash(mihomo-smart).sh',
+  'OpenClash/OpenClash(mihomo).sh',
+];
+
+// 英文关键词的词边界保护：接受两种合法形态
+//   个体形态 \bSign\b          —— CMFA exclude-filter / OpenClash Ruby
+//   群组形态 \b(?:Sign|...)\b   —— Clash Party / FlClash JS 的 isInfoNode infoRes
+function enProtected(src, kw) {
+  if (src.includes('\\b' + kw + '\\b')) return true;
+  const groups = src.match(/\\b\(\?:[^)]+\)\\b/g) || [];
+  return groups.some((g) => g.split(/[(?:|)]/).includes(kw));
+}
+
+let failures = 0;
+for (const rel of PRODUCTS) {
+  const abs = path.join(REPO, rel);
+  let src;
+  try {
+    src = fs.readFileSync(abs, 'utf8');
+  } catch (err) {
+    console.error(`FAIL ${rel}: 无法读取（${err.message}）`);
+    failures += 1;
+    continue;
+  }
+  for (const kw of CN) {
+    if (!src.includes(kw)) {
+      console.error(`FAIL ${rel}: 缺中文 junk 关键词「${kw}」`);
+      failures += 1;
+    }
+  }
+  for (const kw of EN) {
+    if (!enProtected(src, kw)) {
+      console.error(`FAIL ${rel}: 缺英文 junk 关键词 \\b${kw}\\b（须词边界保护，防误伤 Signal 等）`);
+      failures += 1;
+    }
+  }
+}
+
+if (failures > 0) {
+  console.error(`\nFAIL #6 junk 关键词跨产物一致性：${failures} 处缺失/错误`);
+  process.exit(1);
+}
+console.log(`PASS #6 junk 关键词跨产物一致性：${PRODUCTS.length} 产物 × (${CN.length} 中文 + ${EN.length} 英文\\b) 全部就位`);
+console.log('  正例(应过滤): 免费节点 / 试用1天 / 应急入口 / Sign Up / Login Panel / Register Now / Help Center / FAQ');
+console.log('  负例(应保留): Signal(含 Sign 但有词边界保护) / 香港 IEPL x1 / 美国节点');
+console.log('  行为回归: 见 tools/validate-js-overwrites.js（fixture 含上述正/负例，对 3 JS 产物实跑 main() 断言）');
+process.exit(0);

--- a/tools/validate-js-overwrites.js
+++ b/tools/validate-js-overwrites.js
@@ -98,7 +98,9 @@ const BIZ_GROUPS = [
 const EXPECTED_GROUP_ORDER = [SMART_GROUPS[0], ...BIZ_GROUPS, ...SMART_GROUPS.slice(1)];
 const DIRECT_POLICIES = new Set(['DIRECT', 'REJECT', 'REJECT-DROP', 'PASS']);
 const INFO_NODES = new Set(['剩余流量 10G', '官网 example.com', 'USE 100GB']);
-const EXTRA_INFO_NODES = new Set(['距离下次重置 12 天', '套餐到期 2026-06-01', 'Panel Channel Author']);
+const EXTRA_INFO_NODES = new Set(['距离下次重置 12 天', '套餐到期 2026-06-01', 'Panel Channel Author',
+  // v5.4.20 #6 借鉴 Proxy-override：新增 junk 关键词回归（免费/试用/应急 + Sign/Login/Register/Help/FAQ）
+  '免费节点 01', '试用 1 天', '应急入口', 'Sign Up Panel', 'Login Portal', 'Register Now', 'Help Center', 'FAQ']);
 const COST_AND_LINE_QUALITY_CASES = [
   'JP 02 0.2x Saver Home x0.2',
   'HK IPLC 03 x3',
@@ -123,6 +125,7 @@ const STUN_FAKE_IP_FILTER_ENTRIES = [
 const CLASSIFICATION_CASES = [
   ['HKG 01 IEPL x1', 'HK'],
   ['深港 IEPL 02 x1', 'HK'],
+  ['Signal 香港 IEPL x1', 'HK'],
   ['TWN 01 AnyRoute IEPL x2.5', 'TW'],
   ['SGP 01 Home x1', 'SG'],
   ['JPN 01 Tokyo Home x1', 'JP'],
@@ -225,6 +228,17 @@ function makeFixtureConfig() {
       makeProxy('Panel Channel Author'),
       makeProxy('JP 02 0.2x Saver Home x0.2'),
       makeProxy('HK IPLC 03 x3'),
+      // v5.4.20 #6 junk 关键词回归——以下应被 isInfoNode 过滤（排除出 classified ALL）
+      makeProxy('免费节点 01'),
+      makeProxy('试用 1 天'),
+      makeProxy('应急入口'),
+      makeProxy('Sign Up Panel'),
+      makeProxy('Login Portal'),
+      makeProxy('Register Now'),
+      makeProxy('Help Center'),
+      makeProxy('FAQ'),
+      // v5.4.20 #6 合法名守卫——"Signal" 含 "Sign" 但有词边界保护，必须保留并分类到 HK
+      makeProxy('Signal 香港 IEPL x1'),
     ],
     'proxy-groups': [
       { name: '机场自动选择', type: 'url-test', proxies: ['HKG 01 IEPL x1'] },

--- a/v2rayN/CHANGELOG.md
+++ b/v2rayN/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ---
 
+## v5.4.20-v2n.1 (2026-05-30)
+
+- N/A#6 节点过滤关键词补充（批 B）：Xray 路由 JSON 无运行时节点分类 / junk 过滤器，#6 不适用；版本跟随 Clash Party v5.4.20 基线对齐。
+
 ## v5.4.19-v2n.1 (2026-05-30)
 
 借鉴 Proxy-override 批 A · #2 国内 SDK/CDN 直连前置（跟随 Clash Party v5.4.19；spec：`docs/2026-05-30-proxy-override-借鉴设计.md`）：

--- a/v2rayN/README.md
+++ b/v2rayN/README.md
@@ -1,6 +1,6 @@
-# v2rayN 使用教程（对齐 Clash Party v5.4.19）
+# v2rayN 使用教程（对齐 Clash Party v5.4.20）
 
-> 路径 C（Xray 核）产物：`v2rayN/v2rayN(xray).json` v5.4.19-v2n.1（详见 `v2rayN/CHANGELOG.md`；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连；Xray 路由 JSON 不承载 DNS split-bootstrap，mihomo / sing-box 路径复用对应产物）。
+> 路径 C（Xray 核）产物：`v2rayN/v2rayN(xray).json` v5.4.20-v2n.1（详见 `v2rayN/CHANGELOG.md`；含借鉴 Proxy-override 批 A #2 国内 SDK/CDN 直连；Xray 路由 JSON 不承载 DNS split-bootstrap，mihomo / sing-box 路径复用对应产物）。
 
 > 本目录提供 Windows 客户端 **v2rayN** 的接入说明。
 > v2rayN 本身不是内核，它是一个「多核心调度器」——可以切换到 **mihomo（推荐）/ sing-box / Xray** 三种核心。

--- a/v2rayN/v2rayN(xray).json
+++ b/v2rayN/v2rayN(xray).json
@@ -2,7 +2,7 @@
     {
       "id": "scki-000-meta",
       "enabled": false,
-      "remarks": "Smart-Config-Kit v5.4.19-v2n.1 | Build 2026-05-30 | Baseline Clash Party v5.4.19 | changelog: v2rayN/CHANGELOG.md | DNS split-bootstrap not applicable to Xray routing rules",
+      "remarks": "Smart-Config-Kit v5.4.20-v2n.1 | Build 2026-05-30 | Baseline Clash Party v5.4.20 | changelog: v2rayN/CHANGELOG.md | DNS split-bootstrap not applicable to Xray routing rules",
       "outboundTag": "direct",
       "domain": [
         "domain:smart-config-kit.invalid"


### PR DESCRIPTION
## 概述

借鉴 Proxy-override **批 B**（#6 节点过滤关键词补充，中风险）。spec：`docs/2026-05-30-proxy-override-借鉴设计.md`。

> **Stacked PR**：本 PR 基于 `feat/proxy-override-batch-a`（PR #157），diff 仅含批 B 改动。#157 合并到 main 后，本 PR base 需 rebase 到 main。

## #6 改动

给 **6 个 mihomo 产物**的 junk 节点过滤器补充关键词：
- **中文子串**：`免费` / `试用` / `应急`
- **英文（`\b` 词边界）**：`Sign` / `Login` / `Register` / `Help` / `FAQ`
- 不加 `更新` / `地址`（误伤风险高，owner spec 排除）

⚠️ **关键正则语义陷阱**（CLAUDE.md §3.5.3）：英文关键词在 mihomo RE2 / Ruby 子串引擎下若无 `\b` 会误伤 **Signal**（信号 App）→ "Sign"。故所有引擎的英文关键词均用词边界保护。

## §1.5 全产物同构审计（各引擎落点）

| 产物 | junk 过滤器 | #6 落点 |
|------|-----------|---------|
| Clash Party Smart/Normal JS · FlClash JS | `isInfoNode` | infoPatterns(中文) + infoRes `\b(?:Sign\|Login\|...)\b/i` |
| CMFA YAML | proxy-providers `exclude-filter` | Go RE2 正则 `\bSign\b` 等 |
| OpenClash Smart/Normal | Ruby `INFO_PATTERNS` reject | `/免费/` + `/\bSign\b/i` 等（`/注册/` 已存在） |
| SR/Surge/Loon/QX/SingBox/v2rayN/Passwall×2 | 无 junk 过滤器 | **N/A**（不处理订阅去 junk） |

## 回归测试

- **新增** `tools/test-info-node-filter.js`：6 产物源码一致性（中文子串 + 英文 `\b` 词边界形态，防漏产物）
- **扩展** `tools/validate-js-overwrites.js` fixture：8 个 junk 正例（免费/试用/应急/Sign Up/Login/Register/Help/FAQ）断言被过滤 + `Signal 香港 IEPL x1` 负例断言**保留并分类 HK**（实证 `\b` 词边界生效，3 JS 产物实跑 `main()`）

## 版本
全 14 产物 v5.4.19 → **v5.4.20**（依 v5.4.17 全产物对齐先例；validator 强制 `baseline-header` 一致——实测留 8 产物在 v5.4.19 会 FAIL）。8 个无 junk 过滤器的产物为 N/A 版本对齐（CHANGELOG 注明）。

## 自检 ✅
```
validate-js-overwrites:      PASS ×3（v5.4.20, groups=54, #6 fixture 通过）
test-info-node-filter:       PASS（6 产物 × 8 关键词一致）
validate-artifact-contracts: PASS（baseline=v5.4.20, checks=298；仅 ruby 跳过警告）
validate-process-name-direct: OK
```

## 文件（44）
6 mihomo 产物(#6) + 8 N/A 版本对齐 + 12 CHANGELOG + 12 README + 3 .conf + 新测试 + validator 扩展
