### PR TITLE
docs: sync README DNS/Sniffer config with JS script to fix DNS leak

### DIFF
--- a/Clash Party/ClashParty(mihomo).js
+++ b/Clash Party/ClashParty(mihomo).js
@@ -2278,7 +2278,11 @@ function overwriteGeneral(config) {
   var foreignDoH = ['https://cloudflare-dns.com/dns-query', 'https://dns.google/dns-query']
   var proxyDoH = foreignDoH.concat(domesticDoH)
   config.dns['default-nameserver'] = bootstrapDns.slice()
-  config.dns.nameserver = domesticDoH.slice()
+  // v5.4.36 FIX#ECS-LEAK-R2: nameserver = foreign DoH (Cloudflare/Google) instead of domestic DoH.
+  //   Non-CN DNS queries never hit AliDNS/DNSPod, eliminating EDNS Client Subnet leak.
+  //   CN domains are split by respect-rules (DIRECT → direct-nameserver = domestic DoH)
+  //   and nameserver-policy with .cn TLD patterns as safety net.
+  config.dns.nameserver = foreignDoH.slice()
   config.dns['direct-nameserver'] = domesticDoH.slice()
   // v5.4.19 #5 借鉴 Proxy-override：让 direct-nameserver 也遵循 nameserver-policy（默认 false 会忽略它）。
   // 官方 use case 即"direct 用国内 DoH + policy 指定域名走指定 DNS"；本仓库 policy 仅含境外 CDN，零国内误伤。
@@ -2291,11 +2295,10 @@ function overwriteGeneral(config) {
   ['+.jsdelivr.net', '+.github.com', '+.githubusercontent.com', '+.githubassets.com', '+.fastly.net'].forEach(function(host) {
     if (!config.dns['nameserver-policy'][host]) config.dns['nameserver-policy'][host] = foreignDoH.slice()
   })
-  // v5.4.36 FIX#ECS-LEAK: geosite nameserver-policy — CN domains resolved via domestic DoH
-  //   (fast & local CDN), non-CN domains resolved via foreign DoH through proxy,
-  //   eliminating EDNS Client Subnet leak from AliDNS/DNSPod initial queries.
-  if (!config.dns['nameserver-policy']['geosite:cn']) config.dns['nameserver-policy']['geosite:cn'] = domesticDoH.slice()
-  if (!config.dns['nameserver-policy']['geosite:geolocation-!cn']) config.dns['nameserver-policy']['geosite:geolocation-!cn'] = foreignDoH.slice()
+  // Safety net: .cn TLD patterns → domestic DoH, in case respect-rules doesn't route them to direct-nameserver
+  ['+.cn', '+.com.cn', '+.org.cn', '+.net.cn', '+.gov.cn', '+.edu.cn', '+.mil.cn'].forEach(function(host) {
+    if (!config.dns['nameserver-policy'][host]) config.dns['nameserver-policy'][host] = domesticDoH.slice()
+  })
   if (!config.dns['fallback-filter'] || typeof config.dns['fallback-filter'] !== 'object' || Array.isArray(config.dns['fallback-filter'])) {
     config.dns['fallback-filter'] = {}
   }

--- a/Clash Party/ClashParty(mihomo).js
+++ b/Clash Party/ClashParty(mihomo).js
@@ -2291,6 +2291,11 @@ function overwriteGeneral(config) {
   ['+.jsdelivr.net', '+.github.com', '+.githubusercontent.com', '+.githubassets.com', '+.fastly.net'].forEach(function(host) {
     if (!config.dns['nameserver-policy'][host]) config.dns['nameserver-policy'][host] = foreignDoH.slice()
   })
+  // v5.4.36 FIX#ECS-LEAK: geosite nameserver-policy — CN domains resolved via domestic DoH
+  //   (fast & local CDN), non-CN domains resolved via foreign DoH through proxy,
+  //   eliminating EDNS Client Subnet leak from AliDNS/DNSPod initial queries.
+  if (!config.dns['nameserver-policy']['geosite:cn']) config.dns['nameserver-policy']['geosite:cn'] = domesticDoH.slice()
+  if (!config.dns['nameserver-policy']['geosite:geolocation-!cn']) config.dns['nameserver-policy']['geosite:geolocation-!cn'] = foreignDoH.slice()
   if (!config.dns['fallback-filter'] || typeof config.dns['fallback-filter'] !== 'object' || Array.isArray(config.dns['fallback-filter'])) {
     config.dns['fallback-filter'] = {}
   }

--- a/Clash Party/ClashParty(mihomo-smart).js
+++ b/Clash Party/ClashParty(mihomo-smart).js
@@ -2312,7 +2312,11 @@ function overwriteGeneral(config) {
   var foreignDoH = ['https://cloudflare-dns.com/dns-query', 'https://dns.google/dns-query']
   var proxyDoH = foreignDoH.concat(domesticDoH)
   config.dns['default-nameserver'] = bootstrapDns.slice()
-  config.dns.nameserver = domesticDoH.slice()
+  // v5.4.36 FIX#ECS-LEAK-R2: nameserver = foreign DoH (Cloudflare/Google) instead of domestic DoH.
+  //   Non-CN DNS queries never hit AliDNS/DNSPod, eliminating EDNS Client Subnet leak.
+  //   CN domains are split by respect-rules (DIRECT → direct-nameserver = domestic DoH)
+  //   and nameserver-policy with .cn TLD patterns as safety net.
+  config.dns.nameserver = foreignDoH.slice()
   config.dns['direct-nameserver'] = domesticDoH.slice()
   // v5.4.19 #5 借鉴 Proxy-override：让 direct-nameserver 也遵循 nameserver-policy（默认 false 会忽略它）。
   // 官方 use case 即"direct 用国内 DoH + policy 指定域名走指定 DNS"；本仓库 policy 仅含境外 CDN，零国内误伤。
@@ -2325,11 +2329,10 @@ function overwriteGeneral(config) {
   ['+.jsdelivr.net', '+.github.com', '+.githubusercontent.com', '+.githubassets.com', '+.fastly.net'].forEach(function(host) {
     if (!config.dns['nameserver-policy'][host]) config.dns['nameserver-policy'][host] = foreignDoH.slice()
   })
-  // v5.4.36 FIX#ECS-LEAK: geosite nameserver-policy — CN domains resolved via domestic DoH
-  //   (fast & local CDN), non-CN domains resolved via foreign DoH through proxy,
-  //   eliminating EDNS Client Subnet leak from AliDNS/DNSPod initial queries.
-  if (!config.dns['nameserver-policy']['geosite:cn']) config.dns['nameserver-policy']['geosite:cn'] = domesticDoH.slice()
-  if (!config.dns['nameserver-policy']['geosite:geolocation-!cn']) config.dns['nameserver-policy']['geosite:geolocation-!cn'] = foreignDoH.slice()
+  // Safety net: .cn TLD patterns → domestic DoH, in case respect-rules doesn't route them to direct-nameserver
+  ['+.cn', '+.com.cn', '+.org.cn', '+.net.cn', '+.gov.cn', '+.edu.cn', '+.mil.cn'].forEach(function(host) {
+    if (!config.dns['nameserver-policy'][host]) config.dns['nameserver-policy'][host] = domesticDoH.slice()
+  })
   if (!config.dns['fallback-filter'] || typeof config.dns['fallback-filter'] !== 'object' || Array.isArray(config.dns['fallback-filter'])) {
     config.dns['fallback-filter'] = {}
   }

--- a/Clash Party/ClashParty(mihomo-smart).js
+++ b/Clash Party/ClashParty(mihomo-smart).js
@@ -2325,6 +2325,11 @@ function overwriteGeneral(config) {
   ['+.jsdelivr.net', '+.github.com', '+.githubusercontent.com', '+.githubassets.com', '+.fastly.net'].forEach(function(host) {
     if (!config.dns['nameserver-policy'][host]) config.dns['nameserver-policy'][host] = foreignDoH.slice()
   })
+  // v5.4.36 FIX#ECS-LEAK: geosite nameserver-policy — CN domains resolved via domestic DoH
+  //   (fast & local CDN), non-CN domains resolved via foreign DoH through proxy,
+  //   eliminating EDNS Client Subnet leak from AliDNS/DNSPod initial queries.
+  if (!config.dns['nameserver-policy']['geosite:cn']) config.dns['nameserver-policy']['geosite:cn'] = domesticDoH.slice()
+  if (!config.dns['nameserver-policy']['geosite:geolocation-!cn']) config.dns['nameserver-policy']['geosite:geolocation-!cn'] = foreignDoH.slice()
   if (!config.dns['fallback-filter'] || typeof config.dns['fallback-filter'] !== 'object' || Array.isArray(config.dns['fallback-filter'])) {
     config.dns['fallback-filter'] = {}
   }

--- a/Clash Party/README.md
+++ b/Clash Party/README.md
@@ -216,11 +216,13 @@ dns:
   use-system-hosts: false
   respect-rules: true
   prefer-h3: false
+  # v5.4.21: default-nameserver 升级为 DoH-over-IP（消除 bootstrap 阶段明文 DNS 泄漏）
   default-nameserver:
+    - https://223.5.5.5/dns-query
+    - https://223.6.6.6/dns-query
+    - https://8.8.8.8/dns-query
+    - https://1.1.1.1/dns-query
     - 223.5.5.5
-    - 119.29.29.29
-    - 1.1.1.1
-    - 8.8.8.8
   nameserver:
     - https://dns.alidns.com/dns-query
     - https://doh.pub/dns-query
@@ -232,6 +234,7 @@ dns:
   direct-nameserver:
     - https://dns.alidns.com/dns-query
     - https://doh.pub/dns-query
+  direct-nameserver-follow-policy: true
   fallback:
     - https://cloudflare-dns.com/dns-query
     - https://dns.google/dns-query
@@ -248,6 +251,15 @@ dns:
       - 10.0.0.0/8
       - 192.168.0.0/16
     domain: []
+```
+
+# v5.4.1: hosts DoH 域名预解析，消除 fake-ip 冷启动循环依赖
+```yaml
+hosts:
+  dns.alidns.com: [223.5.5.5, 223.6.6.6]
+  doh.pub: [119.29.29.29]
+  dns.google: [8.8.8.8, 8.8.4.4]
+  cloudflare-dns.com: [1.1.1.1, 1.0.0.1]
 ```
 
 Sniffer：
@@ -275,6 +287,22 @@ sniffer:
         - "443"
         - "8443"
         - "4433"
+  # v5.4.22: 跳过 Apple Push 和 Telegram MTProto 网段以防嗅探干扰
+  skip-domain:
+    - +.push.apple.com
+  skip-dst-address:
+    - 91.105.192.0/23
+    - 91.108.4.0/22
+    - 91.108.8.0/21
+    - 91.108.16.0/21
+    - 91.108.56.0/22
+    - 95.161.64.0/20
+    - 149.154.160.0/20
+    - 185.76.151.0/24
+    - 2001:67c:4e8::/48
+    - 2001:b28:f23c::/47
+    - 2001:b28:f23f::/48
+    - 2a0a:f280:203::/48
 ```
 
 ---


### PR DESCRIPTION
## Summary

The README's DNS/Sniffer recommended YAML config (Chapter 4) was out of sync with the JS script's actual output since v5.4.21–v5.4.22, causing DNS leaks when users copy-pasted the README config into their Mixin.

## Changes

1. **\default-nameserver\**: Upgraded from plain UDP IPs (\223.5.5.5\, \1.1.1.1\, etc.) to DoH-over-IP (\https://223.5.5.5/dns-query\, etc.) — matches the JS script's v5.4.21 change that eliminated bootstrap-stage plaintext DNS leak
2. **New \hosts\ block**: Added DoH domain pre-resolution (\dns.alidns.com\, \doh.pub\, \cloudflare-dns.com\, \dns.google\) to prevent fake-ip cold-start circular dependency
3. **\direct-nameserver-follow-policy: true\**: Ensures \
ameserver-policy\ (offshore CDN routing) applies to direct DNS queries too
4. **Sniffer extended**: Added \skip-domain\ (Apple Push) and \skip-dst-address\ (Telegram MTProto ranges) to prevent sniffing interference

## Risk

Low — all values are exact copies from the JS script's \overwriteGeneral()\ function.