### PR TITLE
fix: node in generate-fused-fallback-artifacts.js

### DIFF
--- a/tools/generate-fused-fallback-artifacts.js
+++ b/tools/generate-fused-fallback-artifacts.js
@@ -15,6 +15,8 @@ const V2RAYN_FILE = path.join(REPO_ROOT, 'v2rayN/v2rayN(xray).json');
 const PASSWALL_SHUNT_DIR = path.join(REPO_ROOT, 'Passwall/shunt-rules');
 const PASSWALL2_SHUNT_DIR = path.join(REPO_ROOT, 'Passwall2/shunt-rules');
 
+const MAX_FILE_BYTES = 50 * 1024 * 1024; // 50 MB – guard against resource exhaustion
+
 const BUILD_DATE = '2026-07-19';
 const V2RAYN_VERSION = 'v6.0.9-v2n.1';
 const PASSWALL_VERSION = 'v6.0.9-pw.1';
@@ -86,6 +88,8 @@ function ensureRepoPath(file) {
 }
 
 function readJson(file) {
+  const { size } = fs.statSync(file);
+  if (size > MAX_FILE_BYTES) throw new Error(`File too large (${size} bytes): ${file}`);
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
@@ -128,6 +132,8 @@ function xrayProcessesFromSingBoxRule(rule) {
 }
 
 function parseMihomoFusedRules() {
+  const { size } = fs.statSync(CLASH_SMART_FILE);
+  if (size > MAX_FILE_BYTES) throw new Error(`File too large (${size} bytes): ${relPath(CLASH_SMART_FILE)}`);
   const source = fs.readFileSync(CLASH_SMART_FILE, 'utf8');
   const marker = 'const MIHOMO_FUSED_RULES = ';
   const start = source.indexOf(marker);


### PR DESCRIPTION
## Summary
Fix high severity security issue in `tools/generate-fused-fallback-artifacts.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `tools/generate-fused-fallback-artifacts.js:1` |
| **Assessment** | Likely exploitable |

**Description**: Node.js build tools synchronously load entire large ruleset files (e.g., 270k+ lines) into memory using `fs.readFileSync()` without any size validation, memory limits, or streaming processing. This design flaw allows resource exhaustion.

## Evidence

**Exploitation scenario**: An attacker with access to execute the Node.js tools (e.g., via CI/CD pipeline or developer environment) can trigger processing of the existing massive ruleset files.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Changes
- `tools/generate-fused-fallback-artifacts.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
